### PR TITLE
Change CMAKE minimum version and update documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 project(powsybl-iidm4cpp)
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ To install these requirements, the simplest way is to use the package manager:
 
 ### Alpine
 ```
-$> apk add boost-dev clang cmake g++ make
+$> apk add boost-dev clang cmake git g++ libxml2-dev make
 ```
 
 ### CentOS
 ```
-$> yum -y install boost-devel clang cmake gcc-c++ make
+$> yum -y install boost-devel clang cmake gcc-c++ git libxml2-devel make
 ```
 
 ### Ubuntu
 ```
-$> apt-get -y install clang cmake g++ libboost-all-dev make
+$> apt-get -y install clang cmake g++ git libboost-all-dev libxml2-dev make
 ```
 
 **Note**: On Ubuntu 18.04, default cmake package is too old (3.10), so you have to install it manually:

--- a/README.md
+++ b/README.md
@@ -10,26 +10,33 @@
 
 To build powsybl-iidm4cpp, you need:
 - A C++ compiler that supports C++11 ([clang](https://clang.llvm.org) 3.3 or higher, [g++](https://gcc.gnu.org) 5.0 or higher)
-- [CMake](https://cmake.org) (2.6 or higher)
+- [CMake](https://cmake.org) (3.12 or higher)
 - [Make](https://www.gnu.org/software/make/)
 - [Boost](https://www.boost.org) development packages (1.56 or higher)
 - [LibXML2](http://www.xmlsoft.org/) development packages
 
 To install these requirements, the simplest way is to use the package manager:
 
-**Alpine**
+### Alpine
 ```
 $> apk add boost-dev clang cmake g++ make
 ```
 
-**CentOS**
+### CentOS
 ```
 $> yum -y install boost-devel clang cmake gcc-c++ make
 ```
 
-**Ubuntu**
+### Ubuntu
 ```
-$> apt-get -y install clang cmake g++ libboost-all-dev make
+$> apt-get -y install clang g++ libboost-all-dev make
+```
+
+**Note**: On Ubuntu 18.04, default cmake package is too old (3.10), so you have to install it manually:
+```
+$> wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.tar.gz
+$> tar xzf cmake-3.12.0-Linux-x86_64.tar.gz
+$> export PATH=$PWD/cmake-3.12.0-Linux-x86_64/bin:$PATH
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $> yum -y install boost-devel clang cmake gcc-c++ make
 
 ### Ubuntu
 ```
-$> apt-get -y install clang g++ libboost-all-dev make
+$> apt-get -y install clang cmake g++ libboost-all-dev make
 ```
 
 **Note**: On Ubuntu 18.04, default cmake package is too old (3.10), so you have to install it manually:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,5 +16,4 @@ sonar.tests=test,extensions/entsoe/test,extensions/iidm/test
 
 sonar.cfamily.build-wrapper-output=build/output
 sonar.coverageReportPaths=build/coverage/coverage.xml
-# sonar.cfamily.gcov.reportsPath=build/coverage/reports
 sonar.cfamily.threads=2


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Docs


**What is the current behavior?** *(You can also link to an open issue here)*
The project doesn't compile on Ubuntu 18.04 with the default cmake package, because the target `LibXml2::LibXml2` is not created

**What is the new behavior (if this is a feature change)?**
We change the minimum version to 3.12 in the main CMakeLists.txt, and adapt the documentation.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
