### PR TITLE
Fix the test to defined the BOOST_ARGS_SEPARATOR variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ enable_testing()
 
 # Since Boost 1.60, program arguments and boost test arguments are separated by --
 # https://github.com/boostorg/test/commit/d63379a9b3ad33d263d55c119681047c1d28547c
-if (${Boost_VERSION_MACRO} GREATER 106000)
+if ((DEFINED Boost_VERSION_MACRO AND ${Boost_VERSION_MACRO} GREATER 106000) OR (${Boost_VERSION} GREATER 106000))
     set(BOOST_ARGS_SEPARATOR "--")
 endif()
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The minimal version of CMake is v3.12 but before CMake 3.15, the `Boost_VERSION_MACRO` variable is not defined. In that case, depending on the version of boost you use, the BOOST_ARGS_SEPARATOR could have wrong value.


**What is the new behavior (if this is a feature change)?**
We change the test to support both modern and old FindBoost script.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
