### PR TITLE
Network.hpp should include Anonymizer.hpp

### DIFF
--- a/include/powsybl/iidm/Network.hpp
+++ b/include/powsybl/iidm/Network.hpp
@@ -14,6 +14,7 @@
 #include <powsybl/iidm/SubstationAdder.hpp>
 #include <powsybl/iidm/VariantManager.hpp>
 #include <powsybl/iidm/VariantManagerHolder.hpp>
+#include <powsybl/iidm/converter/Anonymizer.hpp>
 #include <powsybl/stdcxx/DateTime.hpp>
 #include <powsybl/stdcxx/range.hpp>
 
@@ -46,7 +47,6 @@ class VscConverterStation;
 
 namespace converter {
 
-class Anonymizer;
 class ExportOptions;
 class ImportOptions;
 

--- a/src/test/converter/RoundTrip.cpp
+++ b/src/test/converter/RoundTrip.cpp
@@ -9,8 +9,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <powsybl/iidm/converter/Anonymizer.hpp>
-
 namespace powsybl {
 
 namespace test {

--- a/tools/benchmark/Benchmark.cpp
+++ b/tools/benchmark/Benchmark.cpp
@@ -10,9 +10,7 @@
 #include <boost/program_options.hpp>
 
 #include <powsybl/iidm/Network.hpp>
-#include <powsybl/iidm/converter/Anonymizer.hpp>
 #include <powsybl/logging/ConsoleLogger.hpp>
-#include <powsybl/logging/Logger.hpp>
 #include <powsybl/logging/LoggerFactory.hpp>
 #include <powsybl/logging/MessageFormat.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix?


**What is the current behavior?** *(You can also link to an open issue here)*
If you use `Network::writeXml` you have to include Anonymizer.hpp because this method returns a `std::unique_ptr<Anonymizer>`. The forward declaration in Network.hpp is not sufficient here, we have to include the header.


**What is the new behavior (if this is a feature change)?**
Include the header of Anonymizer is not needed anymore. Network.hpp is auto sufficient.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
