### PR TITLE
Implement phaseAngleClock extension for 2 and 3 windings transformers

### DIFF
--- a/extensions/iidm/CMakeLists.txt
+++ b/extensions/iidm/CMakeLists.txt
@@ -13,12 +13,18 @@ set(EXT_SOURCES
     src/CoordinatedReactiveControl.cpp
     src/CoordinatedReactiveControlXmlSerializer.cpp
     src/Iidm.cpp
+    src/ThreeWindingsTransformerPhaseAngleClock.cpp
+    src/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.cpp
+    src/TwoWindingsTransformerPhaseAngleClock.cpp
+    src/TwoWindingsTransformerPhaseAngleClockXmlSerializer.cpp
 )
 
 set(UNIT_TEST_SOURCES
     test/ActivePowerControlTest.cpp
     test/CoordinatedReactiveControlTest.cpp
     test/iidm.cpp
+    test/ThreeWindingsTransformerPhaseAngleClockTest.cpp
+    test/TwoWindingsTransformerPhaseAngleClockTest.cpp
 )
 
 # Shared library

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef POWSYBL_IIDM_EXTENSIONS_IIDM_THREEWINDINGSTRANSFORMERPHASEANGLECLOCK_HPP
+#define POWSYBL_IIDM_EXTENSIONS_IIDM_THREEWINDINGSTRANSFORMERPHASEANGLECLOCK_HPP
+
+#include <powsybl/iidm/Extension.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+class ThreeWindingsTransformer;
+
+namespace extensions {
+
+namespace iidm {
+
+class ThreeWindingsTransformerPhaseAngleClock : public Extension {
+public:  // Extension
+    const std::string& getName() const override;
+
+    const std::type_index& getType() const override;
+
+public:
+    ThreeWindingsTransformerPhaseAngleClock(ThreeWindingsTransformer& battery, unsigned long phaseAngleClockLeg2, unsigned long phaseAngleClockLeg3);
+
+    unsigned long getPhaseAngleClockLeg2() const;
+
+    unsigned long getPhaseAngleClockLeg3() const;
+
+    ThreeWindingsTransformerPhaseAngleClock& setPhaseAngleClockLeg2(unsigned long phaseAngleClockLeg2);
+
+    ThreeWindingsTransformerPhaseAngleClock& setPhaseAngleClockLeg3(unsigned long phaseAngleClockLeg3);
+
+private:  // Extension
+    void assertExtendable(const stdcxx::Reference<Extendable>& extendable) const override;
+
+    unsigned long checkPhaseAngleClock(unsigned long phaseAngleClock) const;
+
+private:
+    unsigned long m_phaseAngleClockLeg2;
+
+    unsigned long m_phaseAngleClockLeg3;
+};
+
+}  // namespace iidm
+
+}  // namespace extensions
+
+}  // namespace iidm
+
+}  // namespace powsybl
+
+#endif  // POWSYBL_IIDM_EXTENSIONS_IIDM_THREEWINDINGSTRANSFORMERPHASEANGLECLOCK_HPP

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp
@@ -27,7 +27,7 @@ public:  // Extension
     const std::type_index& getType() const override;
 
 public:
-    ThreeWindingsTransformerPhaseAngleClock(ThreeWindingsTransformer& battery, unsigned long phaseAngleClockLeg2, unsigned long phaseAngleClockLeg3);
+    ThreeWindingsTransformerPhaseAngleClock(ThreeWindingsTransformer& transformer, unsigned long phaseAngleClockLeg2, unsigned long phaseAngleClockLeg3);
 
     unsigned long getPhaseAngleClockLeg2() const;
 

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.hpp
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef POWSYBL_IIDM_EXTENSIONS_IIDM_THREEWINDINGSTRANSFORMERPHASEANGLECLOCKXMLSERIALIZER_HPP
+#define POWSYBL_IIDM_EXTENSIONS_IIDM_THREEWINDINGSTRANSFORMERPHASEANGLECLOCKXMLSERIALIZER_HPP
+
+#include <powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+namespace extensions {
+
+namespace iidm {
+
+class ThreeWindingsTransformerPhaseAngleClockXmlSerializer : public converter::xml::ExtensionXmlSerializer {
+public:  // ExtensionXmlSerializer
+    std::unique_ptr<Extension> read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+
+    void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
+
+public:
+    ThreeWindingsTransformerPhaseAngleClockXmlSerializer();
+
+    ~ThreeWindingsTransformerPhaseAngleClockXmlSerializer() noexcept override = default;
+};
+
+}  // namespace iidm
+
+}  // namespace extensions
+
+}  // namespace iidm
+
+}  // namespace powsybl
+
+#endif  // POWSYBL_IIDM_EXTENSIONS_IIDM_THREEWINDINGSTRANSFORMERPHASEANGLECLOCKXMLSERIALIZER_HPP

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef POWSYBL_IIDM_EXTENSIONS_IIDM_TWOWINDINGSTRANSFORMERPHASEANGLECLOCK_HPP
+#define POWSYBL_IIDM_EXTENSIONS_IIDM_TWOWINDINGSTRANSFORMERPHASEANGLECLOCK_HPP
+
+#include <powsybl/iidm/Extension.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+class TwoWindingsTransformer;
+
+namespace extensions {
+
+namespace iidm {
+
+class TwoWindingsTransformerPhaseAngleClock : public Extension {
+public:  // Extension
+    const std::string& getName() const override;
+
+    const std::type_index& getType() const override;
+
+public:
+    TwoWindingsTransformerPhaseAngleClock(TwoWindingsTransformer& battery, unsigned long phaseAngleClock);
+
+    unsigned long getPhaseAngleClock() const;
+
+    TwoWindingsTransformerPhaseAngleClock& setPhaseAngleClock(unsigned long phaseAngleClock);
+
+private:  // Extension
+    void assertExtendable(const stdcxx::Reference<Extendable>& extendable) const override;
+
+    unsigned long checkPhaseAngleClock(unsigned long phaseAngleClock) const;
+
+private:
+    unsigned long m_phaseAngleClock;
+
+};
+
+}  // namespace iidm
+
+}  // namespace extensions
+
+}  // namespace iidm
+
+}  // namespace powsybl
+
+#endif  // POWSYBL_IIDM_EXTENSIONS_IIDM_TWOWINDINGSTRANSFORMERPHASEANGLECLOCK_HPP

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp
@@ -27,7 +27,7 @@ public:  // Extension
     const std::type_index& getType() const override;
 
 public:
-    TwoWindingsTransformerPhaseAngleClock(TwoWindingsTransformer& battery, unsigned long phaseAngleClock);
+    TwoWindingsTransformerPhaseAngleClock(TwoWindingsTransformer& transformer, unsigned long phaseAngleClock);
 
     unsigned long getPhaseAngleClock() const;
 

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClockXmlSerializer.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClockXmlSerializer.hpp
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef POWSYBL_IIDM_EXTENSIONS_IIDM_TWOWINDINGSTRANSFORMERPHASEANGLECLOCKXMLSERIALIZER_HPP
+#define POWSYBL_IIDM_EXTENSIONS_IIDM_TWOWINDINGSTRANSFORMERPHASEANGLECLOCKXMLSERIALIZER_HPP
+
+#include <powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+namespace extensions {
+
+namespace iidm {
+
+class TwoWindingsTransformerPhaseAngleClockXmlSerializer : public converter::xml::ExtensionXmlSerializer {
+public:  // ExtensionXmlSerializer
+    std::unique_ptr<Extension> read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+
+    void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
+
+public:
+    TwoWindingsTransformerPhaseAngleClockXmlSerializer();
+
+    ~TwoWindingsTransformerPhaseAngleClockXmlSerializer() noexcept override = default;
+};
+
+}  // namespace iidm
+
+}  // namespace extensions
+
+}  // namespace iidm
+
+}  // namespace powsybl
+
+#endif  // POWSYBL_IIDM_EXTENSIONS_IIDM_TWOWINDINGSTRANSFORMERPHASEANGLECLOCKXMLSERIALIZER_HPP

--- a/extensions/iidm/resources/threeWindingsTransformerPhaseAngleClock.xml
+++ b/extensions/iidm/resources/threeWindingsTransformerPhaseAngleClock.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" xmlns:threewtpac="http://www.powsybl.org/schema/iidm/ext/three_windings_transformer_phase_angle_clock/1_0" id="three-windings-transformer" caseDate="2018-03-05T13:30:30.486000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="SUBSTATION" country="FR">
+        <iidm:voltageLevel id="VL_132" nominalV="132" lowVoltageLimit="118.8" highVoltageLimit="145.19999999999999" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS_132" v="133.584" angle="-9.6199999999999992"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN_132" energySource="OTHER" minP="0" maxP="140" voltageRegulatorOn="true" targetP="7.2000000000000002" targetV="135" bus="BUS_132" connectableBus="BUS_132">
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VL_33" nominalV="33" lowVoltageLimit="29.699999999999999" highVoltageLimit="36.299999999999997" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS_33" v="34.881" angle="-15.24"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD_33" loadType="UNDEFINED" p0="11.199999999999999" q0="7.5" bus="BUS_33" connectableBus="BUS_33" p="11.199999999999999" q="7.5"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VL_11" nominalV="11" lowVoltageLimit="9.9000000000000004" highVoltageLimit="12.1" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS_11" v="11.781000000000001" angle="-15.24"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD_11" loadType="UNDEFINED" p0="0" q0="-10.6" bus="BUS_11" connectableBus="BUS_11" p="0" q="-10.6"/>
+        </iidm:voltageLevel>
+        <iidm:threeWindingsTransformer id="3WT" r1="17.423999999999999" x1="1.7423999999999999" g1="0.0057392102846648297" b1="0.00057392102846648299" ratedU1="132" r2="1.089" x2="0.1089" ratedU2="33" r3="0.121" x3="0.0121" ratedU3="11" bus1="BUS_132" connectableBus1="BUS_132" voltageLevelId1="VL_132" bus2="BUS_33" connectableBus2="BUS_33" voltageLevelId2="VL_33" bus3="BUS_11" connectableBus3="BUS_11" voltageLevelId3="VL_11">
+            <iidm:ratioTapChanger2 lowTapPosition="0" tapPosition="2" targetDeadband="0" loadTapChangingCapabilities="true" regulating="true" targetV="33">
+                <iidm:terminalRef id="LOAD_33"/>
+                <iidm:step r="0.98009999999999997" x="0.09801" g="0.082644628099173556" b="0.0082644628099173556" rho="0.90000000000000002"/>
+                <iidm:step r="1.089" x="0.1089" g="0.091827364554637275" b="0.0091827364554637279" rho="1"/>
+                <iidm:step r="1.1979" x="0.11978999999999999" g="0.10101010101010101" b="0.0101010101010101" rho="1.1000000000000001"/>
+            </iidm:ratioTapChanger2>
+            <iidm:ratioTapChanger3 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="false" targetV="11">
+                <iidm:terminalRef id="LOAD_11"/>
+                <iidm:step r="0.1089" x="0.01089" g="0.82644628099173556" b="0.082644628099173556" rho="0.90000000000000002"/>
+                <iidm:step r="0.121" x="0.0121" g="0.82644628099173556" b="0.082644628099173556" rho="1"/>
+                <iidm:step r="0.1331" x="0.013310000000000001" g="0.90909090909090917" b="0.090909090909090925" rho="1.1000000000000001"/>
+            </iidm:ratioTapChanger3>
+        </iidm:threeWindingsTransformer>
+    </iidm:substation>
+    <iidm:extension id="3WT">
+        <threewtpac:threeWindingsTransformerPhaseAngleClock phaseAngleClockLeg2="3" phaseAngleClockLeg3="1"/>
+    </iidm:extension>
+</iidm:network>

--- a/extensions/iidm/resources/twoWindingsTransformerPhaseAngleClock.xml
+++ b/extensions/iidm/resources/twoWindingsTransformerPhaseAngleClock.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" xmlns:twowtpac="http://www.powsybl.org/schema/iidm/ext/two_windings_transformer_phase_angle_clock/1_0" id="sim1" caseDate="2019-05-27T12:17:02.504000+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.9899999999998" maxP="9999.9899999999998" voltageRegulatorOn="true" targetP="607" targetV="24.5" targetQ="301" bus="NGEN" connectableBus="NGEN">
+                <iidm:minMaxReactiveLimits minQ="-9999.9899999999998" maxQ="9999.9899999999998"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0" b="0" ratedU1="24" ratedU2="400" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600" q0="200" bus="NLOAD" connectableBus="NLOAD"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.047249999999999993" x="4.0497243656204551" g="0" b="0" ratedU1="400" ratedU2="158" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.85056666666666658"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0006666666666666"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1507666666666665"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3" x="33" g1="0" b1="0.000193" g2="0" b2="0.000193" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_2" r="3" x="33" g1="0" b1="0.000193" g2="0" b2="0.000193" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:extension id="NHV2_NLOAD">
+        <twowtpac:twoWindingsTransformerPhaseAngleClock phaseAngleClock="3"/>
+    </iidm:extension>
+</iidm:network>

--- a/extensions/iidm/src/Iidm.cpp
+++ b/extensions/iidm/src/Iidm.cpp
@@ -12,6 +12,8 @@
 
 #include <powsybl/iidm/extensions/iidm/ActivePowerControlXmlSerializer.hpp>
 #include <powsybl/iidm/extensions/iidm/CoordinatedReactiveControlXmlSerializer.hpp>
+#include <powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.hpp>
+#include <powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClockXmlSerializer.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 
 namespace powsybl {
@@ -26,6 +28,8 @@ std::vector<std::unique_ptr<ExtensionProvider>> create() {
     std::vector<std::unique_ptr<ExtensionProvider>> serializers;
     serializers.emplace_back(stdcxx::make_unique<ActivePowerControlXmlSerializer>());
     serializers.emplace_back(stdcxx::make_unique<CoordinatedReactiveControlXmlSerializer>());
+    serializers.emplace_back(stdcxx::make_unique<ThreeWindingsTransformerPhaseAngleClockXmlSerializer>());
+    serializers.emplace_back(stdcxx::make_unique<TwoWindingsTransformerPhaseAngleClockXmlSerializer>());
 
     return serializers;
 }

--- a/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClock.cpp
+++ b/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClock.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp>
+
+#include <powsybl/AssertionError.hpp>
+#include <powsybl/PowsyblException.hpp>
+#include <powsybl/iidm/ThreeWindingsTransformer.hpp>
+#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/instanceof.hpp>
+#include <powsybl/stdcxx/reference_wrapper.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+namespace extensions {
+
+namespace iidm {
+
+ThreeWindingsTransformerPhaseAngleClock::ThreeWindingsTransformerPhaseAngleClock(ThreeWindingsTransformer& transformer, unsigned long phaseAngleClockLeg2, unsigned long phaseAngleClockLeg3) :
+    Extension(transformer),
+    m_phaseAngleClockLeg2(checkPhaseAngleClock(phaseAngleClockLeg2)),
+    m_phaseAngleClockLeg3(checkPhaseAngleClock(phaseAngleClockLeg3)){
+}
+
+void ThreeWindingsTransformerPhaseAngleClock::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
+    if (extendable && !stdcxx::isInstanceOf<ThreeWindingsTransformer>(extendable.get())) {
+        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<ThreeWindingsTransformer>()));
+    }
+}
+
+unsigned long ThreeWindingsTransformerPhaseAngleClock::checkPhaseAngleClock(unsigned long phaseAngleClock) const {
+    if (phaseAngleClock > 11) {
+        throw PowsyblException(logging::format("Unexpected value for phaseAngleClock: %1%1", phaseAngleClock));
+    }
+    return phaseAngleClock;
+}
+
+const std::string& ThreeWindingsTransformerPhaseAngleClock::getName() const {
+    static std::string s_name = "threeWindingsTransformerPhaseAngleClock";
+    return s_name;
+}
+
+unsigned long ThreeWindingsTransformerPhaseAngleClock::getPhaseAngleClockLeg2() const {
+    return m_phaseAngleClockLeg2;
+}
+
+unsigned long ThreeWindingsTransformerPhaseAngleClock::getPhaseAngleClockLeg3() const {
+    return m_phaseAngleClockLeg3;
+}
+
+const std::type_index& ThreeWindingsTransformerPhaseAngleClock::getType() const {
+    static std::type_index s_type = typeid(ThreeWindingsTransformerPhaseAngleClock);
+    return s_type;
+}
+
+ThreeWindingsTransformerPhaseAngleClock& ThreeWindingsTransformerPhaseAngleClock::setPhaseAngleClockLeg2(unsigned long phaseAngleClockLeg2) {
+    m_phaseAngleClockLeg2 = checkPhaseAngleClock(phaseAngleClockLeg2);
+    return *this;
+}
+
+ThreeWindingsTransformerPhaseAngleClock& ThreeWindingsTransformerPhaseAngleClock::setPhaseAngleClockLeg3(unsigned long phaseAngleClockLeg3) {
+    m_phaseAngleClockLeg3 = checkPhaseAngleClock(phaseAngleClockLeg3);
+    return *this;
+}
+
+}  // namespace iidm
+
+}  // namespace extensions
+
+}  // namespace iidm
+
+}  // namespace powsybl

--- a/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.cpp
+++ b/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.cpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.hpp>
+
+#include <powsybl/iidm/ThreeWindingsTransformer.hpp>
+
+#include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
+#include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
+
+#include <powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp>
+
+#include <powsybl/stdcxx/make_unique.hpp>
+
+#include <powsybl/xml/XmlStreamReader.hpp>
+#include <powsybl/xml/XmlStreamWriter.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+namespace extensions {
+
+namespace iidm {
+
+ThreeWindingsTransformerPhaseAngleClockXmlSerializer::ThreeWindingsTransformerPhaseAngleClockXmlSerializer() :
+    ExtensionXmlSerializer("threeWindingsTransformerPhaseAngleClock", "network", "http://www.powsybl.org/schema/iidm/ext/three_windings_transformer_phase_angle_clock/1_0", "threewtpac") {
+}
+
+std::unique_ptr<Extension> ThreeWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+    if (!stdcxx::isInstanceOf<ThreeWindingsTransformer>(extendable)) {
+        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<ThreeWindingsTransformer>()));
+    }
+    auto& transformer = dynamic_cast<ThreeWindingsTransformer&>(extendable);
+
+    const auto& phaseAngleClockLeg2 = context.getReader().getOptionalAttributeValue("phaseAngleClockLeg2", 0UL);
+    const auto& phaseAngleClockLeg3 = context.getReader().getOptionalAttributeValue("phaseAngleClockLeg3", 0UL);
+
+    return stdcxx::make_unique<Extension, ThreeWindingsTransformerPhaseAngleClock>(transformer, phaseAngleClockLeg2, phaseAngleClockLeg3);
+}
+
+void ThreeWindingsTransformerPhaseAngleClockXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {
+    const auto& ext = safeCast<ThreeWindingsTransformerPhaseAngleClock>(extension);
+
+    context.getExtensionsWriter().writeOptionalAttribute("phaseAngleClockLeg2", ext.getPhaseAngleClockLeg2(), 0UL);
+    context.getExtensionsWriter().writeOptionalAttribute("phaseAngleClockLeg3", ext.getPhaseAngleClockLeg3(), 0UL);
+}
+
+}  // namespace iidm
+
+}  // namespace extensions
+
+}  // namespace iidm
+
+}  // namespace powsybl

--- a/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClock.cpp
+++ b/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClock.cpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp>
+
+#include <powsybl/AssertionError.hpp>
+#include <powsybl/PowsyblException.hpp>
+#include <powsybl/iidm/TwoWindingsTransformer.hpp>
+#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/instanceof.hpp>
+#include <powsybl/stdcxx/reference_wrapper.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+namespace extensions {
+
+namespace iidm {
+
+TwoWindingsTransformerPhaseAngleClock::TwoWindingsTransformerPhaseAngleClock(TwoWindingsTransformer& transformer, unsigned long phaseAngleClock) :
+    Extension(transformer),
+    m_phaseAngleClock(checkPhaseAngleClock(phaseAngleClock)) {
+}
+
+void TwoWindingsTransformerPhaseAngleClock::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
+    if (extendable && !stdcxx::isInstanceOf<TwoWindingsTransformer>(extendable.get())) {
+        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<TwoWindingsTransformer>()));
+    }
+}
+
+unsigned long TwoWindingsTransformerPhaseAngleClock::checkPhaseAngleClock(unsigned long phaseAngleClock) const {
+    if (phaseAngleClock > 11) {
+        throw PowsyblException(logging::format("Unexpected value for phaseAngleClock: %1%1", phaseAngleClock));
+    }
+    return phaseAngleClock;
+}
+
+const std::string& TwoWindingsTransformerPhaseAngleClock::getName() const {
+    static std::string s_name = "twoWindingsTransformerPhaseAngleClock";
+    return s_name;
+}
+
+unsigned long TwoWindingsTransformerPhaseAngleClock::getPhaseAngleClock() const {
+    return m_phaseAngleClock;
+}
+
+const std::type_index& TwoWindingsTransformerPhaseAngleClock::getType() const {
+    static std::type_index s_type = typeid(TwoWindingsTransformerPhaseAngleClock);
+    return s_type;
+}
+
+TwoWindingsTransformerPhaseAngleClock& TwoWindingsTransformerPhaseAngleClock::setPhaseAngleClock(unsigned long phaseAngleClock) {
+    m_phaseAngleClock = checkPhaseAngleClock(phaseAngleClock);
+    return *this;
+}
+
+}  // namespace iidm
+
+}  // namespace extensions
+
+}  // namespace iidm
+
+}  // namespace powsybl

--- a/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClockXmlSerializer.cpp
+++ b/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClockXmlSerializer.cpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClockXmlSerializer.hpp>
+
+#include <powsybl/iidm/TwoWindingsTransformer.hpp>
+
+#include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
+#include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
+
+#include <powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp>
+
+#include <powsybl/stdcxx/make_unique.hpp>
+
+#include <powsybl/xml/XmlStreamReader.hpp>
+#include <powsybl/xml/XmlStreamWriter.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+namespace extensions {
+
+namespace iidm {
+
+TwoWindingsTransformerPhaseAngleClockXmlSerializer::TwoWindingsTransformerPhaseAngleClockXmlSerializer() :
+    ExtensionXmlSerializer("twoWindingsTransformerPhaseAngleClock", "network", "http://www.powsybl.org/schema/iidm/ext/two_windings_transformer_phase_angle_clock/1_0", "twowtpac") {
+}
+
+std::unique_ptr<Extension> TwoWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+    if (!stdcxx::isInstanceOf<TwoWindingsTransformer>(extendable)) {
+        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<TwoWindingsTransformer>()));
+    }
+    auto& transformer = dynamic_cast<TwoWindingsTransformer&>(extendable);
+
+    const auto& phaseAngleClock = context.getReader().getOptionalAttributeValue("phaseAngleClock", 0UL);
+
+    return stdcxx::make_unique<Extension, TwoWindingsTransformerPhaseAngleClock>(transformer, phaseAngleClock);
+}
+
+void TwoWindingsTransformerPhaseAngleClockXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {
+    const auto& ext = safeCast<TwoWindingsTransformerPhaseAngleClock>(extension);
+
+    context.getExtensionsWriter().writeOptionalAttribute("phaseAngleClock", ext.getPhaseAngleClock(), 0UL);
+}
+
+}  // namespace iidm
+
+}  // namespace extensions
+
+}  // namespace iidm
+
+}  // namespace powsybl

--- a/extensions/iidm/test/ThreeWindingsTransformerPhaseAngleClockTest.cpp
+++ b/extensions/iidm/test/ThreeWindingsTransformerPhaseAngleClockTest.cpp
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <powsybl/iidm/Network.hpp>
+#include <powsybl/iidm/ThreeWindingsTransformer.hpp>
+#include <powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp>
+#include <powsybl/network/ThreeWindingsTransformerNetworkFactory.hpp>
+
+#include <powsybl/test/ResourceFixture.hpp>
+#include <powsybl/test/converter/RoundTrip.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+namespace extensions {
+
+namespace iidm {
+
+BOOST_AUTO_TEST_SUITE(ThreeWindingsTransformerPhaseAngleClockTestSuite)
+
+BOOST_FIXTURE_TEST_CASE(ThreeWindingsTransformerPhaseAngleClockXmlSerializerTest, test::ResourceFixture) {
+    Network network = powsybl::network::ThreeWindingsTransformerNetworkFactory::create();
+    network.setCaseDate(stdcxx::DateTime::parse("2018-03-05T13:30:30.486+01:00"));
+
+    ThreeWindingsTransformer& transformer = network.getThreeWindingsTransformer("3WT");
+    transformer.addExtension(Extension::create<ThreeWindingsTransformerPhaseAngleClock>(transformer, 3, 1));
+
+    const std::string& networkStr = ResourceFixture::getResource("threeWindingsTransformerPhaseAngleClock.xml");
+
+    test::converter::RoundTrip::runXml(network, networkStr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace iidm
+
+}  // namespace extensions
+
+}  // namespace iidm
+
+}  // namespace powsybl

--- a/extensions/iidm/test/TwoWindingsTransformerPhaseAngleClockTest.cpp
+++ b/extensions/iidm/test/TwoWindingsTransformerPhaseAngleClockTest.cpp
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <powsybl/iidm/Network.hpp>
+#include <powsybl/iidm/TwoWindingsTransformer.hpp>
+#include <powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp>
+#include <powsybl/network/EurostagFactory.hpp>
+
+#include <powsybl/test/ResourceFixture.hpp>
+#include <powsybl/test/converter/RoundTrip.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+namespace extensions {
+
+namespace iidm {
+
+BOOST_AUTO_TEST_SUITE(TwoWindingsTransformerPhaseAngleClockTestSuite)
+
+BOOST_FIXTURE_TEST_CASE(TwoWindingsTransformerPhaseAngleClockXmlSerializerTest, test::ResourceFixture) {
+    Network network = powsybl::network::EurostagFactory::createTutorial1Network();
+    network.setCaseDate(stdcxx::DateTime::parse("2019-05-27T12:17:02.504+02:00"));
+
+    TwoWindingsTransformer& transformer = network.getTwoWindingsTransformer("NHV2_NLOAD");
+    transformer.addExtension(Extension::create<TwoWindingsTransformerPhaseAngleClock>(transformer, 3));
+
+    const std::string& networkStr = ResourceFixture::getResource("twoWindingsTransformerPhaseAngleClock.xml");
+
+    test::converter::RoundTrip::runXml(network, networkStr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace iidm
+
+}  // namespace extensions
+
+}  // namespace iidm
+
+}  // namespace powsybl

--- a/include/powsybl/network/ThreeWindingsTransformerNetworkFactory.hpp
+++ b/include/powsybl/network/ThreeWindingsTransformerNetworkFactory.hpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef POWSYBL_IIDM_NETWORK_THREEWINDINGSTRANSFORMERNETWORKFACTORY_HPP
+#define POWSYBL_IIDM_NETWORK_THREEWINDINGSTRANSFORMERNETWORKFACTORY_HPP
+
+#include <powsybl/iidm/Network.hpp>
+
+namespace powsybl {
+
+namespace network {
+
+class ThreeWindingsTransformerNetworkFactory {
+public:
+    static iidm::Network create();
+
+    static iidm::Network createWithCurrentLimits();
+
+public:
+    ThreeWindingsTransformerNetworkFactory() = delete;
+};
+
+}  // namespace network
+
+}  // namespace powsybl
+
+#endif  // POWSYBL_IIDM_NETWORK_THREEWINDINGSTRANSFORMERNETWORKFACTORY_HPP

--- a/include/powsybl/xml/XmlStreamWriter.hpp
+++ b/include/powsybl/xml/XmlStreamWriter.hpp
@@ -59,6 +59,8 @@ public:
 
     void writeOptionalAttribute(const std::string& attributeName, int attributeValue, int absentValue);
 
+    void writeOptionalAttribute(const std::string& attributeName, unsigned long attributeValue, unsigned long absentValue);
+
     void writeOptionalAttribute(const std::string& attributeName, const std::string& attributeValue,
                                 const std::string& absentValue);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,6 +156,7 @@ set(IIDM_SOURCES
 
     network/BatteryNetworkFactory.cpp
     network/EurostagFactory.cpp
+    network/ThreeWindingsTransformerNetworkFactory.cpp
 
     stdcxx/DateTime.cpp
     stdcxx/demangle.cpp

--- a/src/iidm/converter/xml/CurrentLimitsXml.cpp
+++ b/src/iidm/converter/xml/CurrentLimitsXml.cpp
@@ -22,10 +22,12 @@ void CurrentLimitsXml::writeCurrentLimits(const CurrentLimits& limits, powsybl::
         writer.writeStartElement(nsPrefix, toString(CURRENT_LIMITS, index));
         writer.writeAttribute(PERMANENT_LIMIT, limits.getPermanentLimit());
 
+        constexpr unsigned long undefinedAcceptableDuration = std::numeric_limits<int>::max();
+
         for (const auto& tl : limits.getTemporaryLimits()) {
             writer.writeStartElement(nsPrefix, TEMPORARY_LIMIT);
             writer.writeAttribute(NAME, tl.get().getName());
-            writer.writeOptionalAttribute(ACCEPTABLE_DURATION, tl.get().getAcceptableDuration(), std::numeric_limits<int>::max());
+            writer.writeOptionalAttribute(ACCEPTABLE_DURATION, tl.get().getAcceptableDuration(), undefinedAcceptableDuration);
             writer.writeOptionalAttribute(VALUE, tl.get().getValue(), std::numeric_limits<double>::max());
             writer.writeOptionalAttribute(FICTITIOUS, tl.get().isFictitious(), false);
             writer.writeEndElement();

--- a/src/network/ThreeWindingsTransformerNetworkFactory.cpp
+++ b/src/network/ThreeWindingsTransformerNetworkFactory.cpp
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <powsybl/network/ThreeWindingsTransformerNetworkFactory.hpp>
+
+#include <powsybl/iidm/Bus.hpp>
+#include <powsybl/iidm/Country.hpp>
+#include <powsybl/iidm/GeneratorAdder.hpp>
+#include <powsybl/iidm/Load.hpp>
+#include <powsybl/iidm/LoadAdder.hpp>
+#include <powsybl/iidm/RatioTapChanger.hpp>
+#include <powsybl/iidm/RatioTapChangerAdder.hpp>
+#include <powsybl/iidm/Substation.hpp>
+#include <powsybl/iidm/SubstationAdder.hpp>
+#include <powsybl/iidm/ThreeWindingsTransformer.hpp>
+#include <powsybl/iidm/ThreeWindingsTransformerAdder.hpp>
+#include <powsybl/iidm/TopologyKind.hpp>
+#include <powsybl/iidm/VoltageLevel.hpp>
+#include <powsybl/iidm/VoltageLevelAdder.hpp>
+#include <powsybl/stdcxx/DateTime.hpp>
+
+
+namespace powsybl {
+
+namespace network {
+
+iidm::Network ThreeWindingsTransformerNetworkFactory::create() {
+    iidm::Network network("three-windings-transformer", "test");
+    network.setCaseDate(stdcxx::DateTime::parse("2018-03-05T13:30:30.486+01:00"));
+
+    iidm::Substation& substation = network.newSubstation()
+        .setId("SUBSTATION")
+        .setCountry(iidm::Country::FR)
+        .add();
+    iidm::VoltageLevel& vl1 = substation.newVoltageLevel()
+        .setId("VL_132")
+        .setNominalVoltage(132.0)
+        .setLowVoltageLimit(118.8)
+        .setHighVoltageLimit(145.2)
+        .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
+        .add();
+    iidm::Bus& bus132 = vl1.getBusBreakerView().newBus()
+        .setId("BUS_132")
+        .add();
+    bus132.setV(133.584).setAngle(-9.62);
+    vl1.newGenerator()
+        .setId("GEN_132")
+        .setBus("BUS_132")
+        .setMinP(0.0)
+        .setMaxP(140)
+        .setTargetP(7.2)
+        .setTargetV(135)
+        .setVoltageRegulatorOn(true)
+        .add();
+
+    iidm::VoltageLevel& vl2 = substation.newVoltageLevel()
+        .setId("VL_33")
+        .setNominalVoltage(33.0)
+        .setLowVoltageLimit(29.7)
+        .setHighVoltageLimit(36.3)
+        .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
+        .add();
+    iidm::Bus& bus33 = vl2.getBusBreakerView().newBus()
+        .setId("BUS_33")
+        .add();
+    bus33.setV(34.881).setAngle(-15.24);
+    iidm::Load& load33 = vl2.newLoad()
+        .setId("LOAD_33")
+        .setBus("BUS_33")
+        .setP0(11.2)
+        .setQ0(7.5)
+        .add();
+    load33.getTerminal()
+        .setP(11.2)
+        .setQ(7.5);
+
+    iidm::VoltageLevel& vl3 = substation.newVoltageLevel()
+        .setId("VL_11")
+        .setNominalVoltage(11.0)
+        .setLowVoltageLimit(9.9)
+        .setHighVoltageLimit(12.1)
+        .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
+        .add();
+    iidm::Bus& bus11 = vl3.getBusBreakerView().newBus()
+        .setId("BUS_11")
+        .add();
+    bus11.setV(11.781).setAngle(-15.24);
+    iidm::Load& load11 = vl3.newLoad()
+        .setId("LOAD_11")
+        .setBus("BUS_11")
+        .setP0(0.0)
+        .setQ0(-10.6)
+        .add();
+    load11.getTerminal()
+        .setP(0.0)
+        .setQ(-10.6);
+
+    iidm::ThreeWindingsTransformer& twt = substation.newThreeWindingsTransformer()
+        .setId("3WT")
+        // TODO(mathbagu) .setRatedU0(132.0)
+        .newLeg1()
+            .setR(17.424)
+            .setX(1.7424)
+            .setG(0.00573921028466483)
+            .setB(0.000573921028466483)
+            .setRatedU(132.0)
+            .setVoltageLevel(vl1.getId())
+            .setBus(bus132.getId())
+        .add()
+        .newLeg2()
+            .setR(1.089)
+            .setX(0.1089)
+            // TODO(mathbagu) .setG(0.0)
+            // TODO(mathbagu) .setB(0.0)
+            .setRatedU(33.0)
+            .setVoltageLevel(vl2.getId())
+            .setBus(bus33.getId())
+        .add()
+        .newLeg3()
+            .setR(0.121)
+            .setX(0.0121)
+            // TODO(mathbagu) .setG(0.0)
+            // TODO(mathbagu) .setB(0.0)
+            .setRatedU(11.0)
+            .setVoltageLevel(vl3.getId())
+            .setBus(bus11.getId())
+        .add()
+        .add();
+
+    twt.getLeg2().newRatioTapChanger()
+        .beginStep()
+            .setRho(0.9)
+            .setR(0.9801)
+            .setX(0.09801)
+            .setG(0.08264462809917356)
+            .setB(0.008264462809917356)
+        .endStep()
+        .beginStep()
+            .setRho(1.0)
+            .setR(1.089)
+            .setX(0.1089)
+            .setG(0.09182736455463728)
+            .setB(0.009182736455463728)
+        .endStep()
+        .beginStep()
+            .setRho(1.1)
+            .setR(1.1979)
+            .setX(0.11979)
+            .setG(0.10101010101010101)
+            .setB(0.010101010101010101)
+        .endStep()
+        .setTapPosition(2)
+        .setLoadTapChangingCapabilities(true)
+        .setRegulating(true)
+        .setTargetV(33.0)
+        .setTargetDeadband(0)
+        .setRegulationTerminal(stdcxx::ref(load33.getTerminal()))
+        .add();
+
+    twt.getLeg3().newRatioTapChanger()
+        .beginStep()
+            .setRho(0.9)
+            .setR(0.1089)
+            .setX(0.01089)
+            .setG(0.8264462809917356)
+            .setB(0.08264462809917356)
+        .endStep()
+        .beginStep()
+            .setRho(1.0)
+            .setR(0.121)
+            .setX(0.0121)
+            .setG(0.8264462809917356)
+            .setB(0.08264462809917356)
+        .endStep()
+        .beginStep()
+            .setRho(1.1)
+            .setR(0.1331)
+            .setX(0.01331)
+            .setG(0.9090909090909092)
+            .setB(0.09090909090909092)
+        .endStep()
+        .setTapPosition(0)
+        .setLoadTapChangingCapabilities(true)
+        .setRegulating(false)
+        .setTargetV(11.0)
+        .setRegulationTerminal(stdcxx::ref(load11.getTerminal()))
+        .add();
+
+    return network;
+}
+
+iidm::Network ThreeWindingsTransformerNetworkFactory::createWithCurrentLimits() {
+    iidm::Network network = create();
+
+    network.getThreeWindingsTransformer("3WT").getLeg1().newCurrentLimits()
+        .setPermanentLimit(1000.0)
+        .beginTemporaryLimit()
+            .setName("20'")
+            .setValue(1200.0)
+            .setAcceptableDuration(20 * 60)
+        .endTemporaryLimit()
+        .beginTemporaryLimit()
+            .setName("10'")
+            .setValue(1400.0)
+            .setAcceptableDuration(10 * 60)
+        .endTemporaryLimit()
+        .add();
+
+    network.getThreeWindingsTransformer("3WT").getLeg2().newCurrentLimits()
+        .setPermanentLimit(100.0)
+        .beginTemporaryLimit()
+            .setName("20'")
+            .setValue(120.0)
+            .setAcceptableDuration(20 * 60)
+        .endTemporaryLimit()
+        .beginTemporaryLimit()
+            .setName("10'")
+            .setValue(140.0)
+            .setAcceptableDuration(10 * 60)
+        .endTemporaryLimit()
+        .add();
+
+    network.getThreeWindingsTransformer("3WT").getLeg3().newCurrentLimits()
+        .setPermanentLimit(10.0)
+        .beginTemporaryLimit()
+            .setName("20'")
+            .setValue(12.0)
+            .setAcceptableDuration(20 * 60)
+        .endTemporaryLimit()
+        .beginTemporaryLimit()
+            .setName("10'")
+            .setValue(14.0)
+            .setAcceptableDuration(10 * 60)
+        .endTemporaryLimit()
+        .add();
+
+    return network;
+}
+
+}  // namespace network
+
+}  // namespace powsybl

--- a/src/xml/XmlStreamWriter.cpp
+++ b/src/xml/XmlStreamWriter.cpp
@@ -123,6 +123,12 @@ void XmlStreamWriter::writeOptionalAttribute(const std::string& attributeName, i
     }
 }
 
+void XmlStreamWriter::writeOptionalAttribute(const std::string& attributeName, unsigned long attributeValue, unsigned long absentValue) {
+    if (attributeValue != absentValue) {
+        writeAttribute(attributeName, std::to_string(attributeValue));
+    }
+}
+
 void XmlStreamWriter::writeOptionalAttribute(const std::string& attributeName, const std::string& attributeValue,
                                              const std::string& absentValue) {
     if (attributeValue != absentValue) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#18 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The phaseAngleClock extension doesn't exist


**What is the new behavior (if this is a feature change)?**
The phaseAngleClock extension is available for both 2 and 3 windings transformer.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
This PR doesn't fix the second part of the issue #18 that I will implement in another PR. The second part is not directly bounded to this evolution and is quiet hard to port in C++ due to the usage of raw types in Java (TapChanger). I don't know yet how to implement it.

(if any of the questions/checkboxes don't apply, please delete them entirely)
