### PR TITLE
Write the regulatingTerminal of a generator only if its not the local terminal

### DIFF
--- a/src/iidm/converter/xml/GeneratorXml.cpp
+++ b/src/iidm/converter/xml/GeneratorXml.cpp
@@ -89,8 +89,7 @@ void GeneratorXml::writeRootElementAttributes(const Generator& generator, const 
 }
 
 void GeneratorXml::writeSubElements(const Generator& generator, const VoltageLevel& /*voltageLevel*/, NetworkXmlWriterContext& context) const {
-    if (generator.getRegulatingTerminal()
-        && generator.getRegulatingTerminal().get().getBusBreakerView().getConnectableBus() != generator.getTerminal().getBusBreakerView().getConnectableBus()) {
+    if (!stdcxx::areSame(generator.getTerminal(), generator.getRegulatingTerminal().get())) {
         TerminalRefXml::writeTerminalRef(generator.getRegulatingTerminal(), context, REGULATING_TERMINAL);
     }
     ReactiveLimitsXml::getInstance().write(generator, context);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#24 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The regulating terminal of a generator is exported if it exists and is not connected to a different bus than the local terminal


**What is the new behavior (if this is a feature change)?**
The regulating terminal of a generator is exported if it's not the local terminal even they are connected to the same bus


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
