### PR TITLE
Fix the TODO in VoltageLevelXml for Bus/Branch topology

### DIFF
--- a/src/iidm/converter/xml/VoltageLevelXml.cpp
+++ b/src/iidm/converter/xml/VoltageLevelXml.cpp
@@ -120,10 +120,9 @@ void VoltageLevelXml::writeBatteries(const VoltageLevel& voltageLevel, NetworkXm
 void VoltageLevelXml::writeBusBranchTopology(const VoltageLevel& voltageLevel, NetworkXmlWriterContext& context) const {
     context.getWriter().writeStartElement(IIDM_URI, BUS_BREAKER_TOPOLOGY);
     for (const Bus& bus : voltageLevel.getBusView().getBuses()) {
-        // TODO(sebalaig) consider filtering
-//        if (!context.getFilter().test(bus)) {
-//            continue;
-//        }
+        if (!context.getFilter().test(bus)) {
+            continue;
+        }
         BusXml::getInstance().write(bus, voltageLevel, context);
     }
     context.getWriter().writeEndElement();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR activates the filtering of buses for the Bus/Branch topology in VL exporter.


**What is the current behavior?** *(You can also link to an open issue here)*
Unchanged


**What is the new behavior (if this is a feature change)?**
The behavior is unchanged because the connected and synchronous component are not implemented yet.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
