### PR TITLE
Fix move constructor implementation

### DIFF
--- a/include/powsybl/iidm/Battery.hpp
+++ b/include/powsybl/iidm/Battery.hpp
@@ -49,8 +49,6 @@ private: // Identifiable
     const std::string& getTypeDescription() const override;
 
 private:
-    stdcxx::Reference<VariantManagerHolder> m_network;
-
     std::vector<double> m_p0;
 
     std::vector<double> m_q0;

--- a/include/powsybl/iidm/BatteryAdder.hpp
+++ b/include/powsybl/iidm/BatteryAdder.hpp
@@ -33,9 +33,6 @@ public:
 
     BatteryAdder& setQ0(double q0);
 
-protected: // IdentifiableAdder
-    Network& getNetwork() override;
-
 private: // IdentifiableAdder
     const std::string& getTypeDescription() const override;
 
@@ -45,8 +42,6 @@ private:
     friend class VoltageLevel;
 
 private:
-    VoltageLevel& m_voltageLevel;
-
     double m_p0 = stdcxx::nan();
 
     double m_q0 = stdcxx::nan();

--- a/include/powsybl/iidm/BranchAdder.hpp
+++ b/include/powsybl/iidm/BranchAdder.hpp
@@ -44,10 +44,9 @@ public:
     Adder& setVoltageLevel2(const std::string& voltageLevelId2);
 
 protected:
+    std::unique_ptr<Terminal> checkAndGetTerminal1(VoltageLevel& voltageLevel);
 
-    std::unique_ptr<Terminal> checkAndGetTerminal1();
-
-    std::unique_ptr<Terminal> checkAndGetTerminal2();
+    std::unique_ptr<Terminal> checkAndGetTerminal2(VoltageLevel& voltageLevel);
 
     VoltageLevel& checkAndGetVoltageLevel1();
 

--- a/include/powsybl/iidm/BranchAdder.hxx
+++ b/include/powsybl/iidm/BranchAdder.hxx
@@ -19,8 +19,8 @@ namespace powsybl {
 namespace iidm {
 
 template <typename Adder>
-std::unique_ptr<Terminal> BranchAdder<Adder>::checkAndGetTerminal1() {
-    return TerminalBuilder(this->getNetwork(), *this)
+std::unique_ptr<Terminal> BranchAdder<Adder>::checkAndGetTerminal1(VoltageLevel& voltageLevel) {
+    return TerminalBuilder(voltageLevel, *this)
                .setNode(m_node1)
                .setBus(m_bus1)
                .setConnectableBus(m_connectableBus1)
@@ -28,8 +28,8 @@ std::unique_ptr<Terminal> BranchAdder<Adder>::checkAndGetTerminal1() {
 }
 
 template <typename Adder>
-std::unique_ptr<Terminal> BranchAdder<Adder>::checkAndGetTerminal2() {
-    return TerminalBuilder(this->getNetwork(), *this)
+std::unique_ptr<Terminal> BranchAdder<Adder>::checkAndGetTerminal2(VoltageLevel& voltageLevel) {
+    return TerminalBuilder(voltageLevel, *this)
                .setNode(m_node2)
                .setBus(m_bus2)
                .setConnectableBus(m_connectableBus2)

--- a/include/powsybl/iidm/BusbarSection.hpp
+++ b/include/powsybl/iidm/BusbarSection.hpp
@@ -9,8 +9,6 @@
 #define POWSYBL_IIDM_BUSBARSECTION_HPP
 
 #include <powsybl/iidm/Injection.hpp>
-#include <powsybl/iidm/VariantManagerHolder.hpp>
-#include <powsybl/stdcxx/reference_wrapper.hpp>
 
 namespace powsybl {
 
@@ -18,7 +16,7 @@ namespace iidm {
 
 class BusbarSection : public Injection {
 public:
-    BusbarSection(VariantManagerHolder& network, const std::string& id, const std::string& name);
+    BusbarSection(const std::string& id, const std::string& name);
 
     ~BusbarSection() noexcept override = default;
 
@@ -28,9 +26,6 @@ public:
 
 private: // Identifiable
     const std::string& getTypeDescription() const override;
-
-private:
-    stdcxx::Reference<VariantManagerHolder> m_network;
 };
 
 }  // namespace iidm

--- a/include/powsybl/iidm/Container.hpp
+++ b/include/powsybl/iidm/Container.hpp
@@ -23,14 +23,20 @@ public:
     };
 
 public:
+    Container(const Container&) = delete;
+
+    Container(Container&& container) noexcept;
+
     ~Container() noexcept override = default;
+
+    Container& operator=(const Container&) = delete;
+
+    Container& operator=(Container&&) = delete;
 
     const Type& getContainerType() const;
 
 protected:
     Container(const std::string& id, const std::string& name, const Container::Type& type);
-
-    Container(Container&&) = default;
 
 private:
     Container::Type m_type;

--- a/include/powsybl/iidm/DanglingLine.hpp
+++ b/include/powsybl/iidm/DanglingLine.hpp
@@ -15,8 +15,6 @@ namespace powsybl {
 
 namespace iidm {
 
-class VariantManagerHolder;
-
 class DanglingLine : public Injection {
 public:
     DanglingLine(VariantManagerHolder& network, const std::string& id, const std::string& name,
@@ -73,8 +71,6 @@ private:
     friend class CurrentLimitsAdder<std::nullptr_t, DanglingLine>;
 
 private:
-    stdcxx::Reference<VariantManagerHolder> m_network;
-
     double m_b;
 
     double m_g;

--- a/include/powsybl/iidm/DanglingLineAdder.hpp
+++ b/include/powsybl/iidm/DanglingLineAdder.hpp
@@ -39,9 +39,6 @@ public:
 
     DanglingLineAdder& setX(double x);
 
-protected: // IdentifiableAdder
-    Network& getNetwork() override;
-
 private: // IdentifiableAdder
     const std::string& getTypeDescription() const override;
 
@@ -51,8 +48,6 @@ private:
     friend class VoltageLevel;
 
 private:
-    VoltageLevel& m_voltageLevel;
-
     double m_r = stdcxx::nan();
 
     double m_x = stdcxx::nan();

--- a/include/powsybl/iidm/Extendable.hpp
+++ b/include/powsybl/iidm/Extendable.hpp
@@ -25,9 +25,15 @@ class Extendable {
 public:
     Extendable() = default;
 
+    Extendable(const Extendable&) = delete;
+
     Extendable(Extendable&& extendable) noexcept;
 
     virtual ~Extendable() noexcept = default;
+
+    Extendable& operator=(const Extendable&) = delete;
+
+    Extendable& operator=(Extendable&&) noexcept = delete;
 
     void addExtension(std::unique_ptr<Extension>&& extension);
 

--- a/include/powsybl/iidm/Generator.hpp
+++ b/include/powsybl/iidm/Generator.hpp
@@ -87,8 +87,6 @@ private: // Identifiable
     const std::string& getTypeDescription() const override;
 
 private:
-    stdcxx::Reference<VariantManagerHolder> m_network;
-
     EnergySource m_energySource;
 
     double m_minP;

--- a/include/powsybl/iidm/GeneratorAdder.hpp
+++ b/include/powsybl/iidm/GeneratorAdder.hpp
@@ -52,9 +52,6 @@ public:
 
     GeneratorAdder& setVoltageSetpoint(double voltageSetpoint);
 
-protected: // IdentifiableAdder
-    Network& getNetwork() override;
-
 private: // IdentifiableAdder
     const std::string& getTypeDescription() const override;
 
@@ -64,8 +61,6 @@ private:
     friend class VoltageLevel;
 
 private:
-    VoltageLevel& m_voltageLevel;
-
     EnergySource m_energySource = EnergySource::OTHER;
 
     double m_minP = stdcxx::nan();

--- a/include/powsybl/iidm/HvdcConverterStationAdder.hpp
+++ b/include/powsybl/iidm/HvdcConverterStationAdder.hpp
@@ -25,21 +25,14 @@ public:
 
     Adder& setLossFactor(double lossFactor);
 
-protected: // IdentifiableAdder
-    Network& getNetwork() override;
-
 protected:
     explicit HvdcConverterStationAdder(VoltageLevel& voltageLevel);
 
     double getLossFactor() const;
 
-    VoltageLevel& getVoltageLevel() const;
-
     virtual void validate() const;
 
 private:
-    VoltageLevel& m_voltageLevel;
-
     double m_lossFactor = stdcxx::nan();
 };
 

--- a/include/powsybl/iidm/HvdcConverterStationAdder.hxx
+++ b/include/powsybl/iidm/HvdcConverterStationAdder.hxx
@@ -20,22 +20,12 @@ double checkLossFactor(const Validable& validable, double lossFactor);
 
 template<typename Adder>
 HvdcConverterStationAdder<Adder>::HvdcConverterStationAdder(VoltageLevel& voltageLevel) :
-    m_voltageLevel(voltageLevel) {
+    InjectionAdder<Adder>(voltageLevel) {
 }
 
 template<typename Adder>
 double HvdcConverterStationAdder<Adder>::getLossFactor() const {
     return m_lossFactor;
-}
-
-template<typename Adder>
-Network& HvdcConverterStationAdder<Adder>::getNetwork() {
-    return m_voltageLevel.getNetwork();
-}
-
-template<typename Adder>
-VoltageLevel& HvdcConverterStationAdder<Adder>::getVoltageLevel() const {
-    return m_voltageLevel;
 }
 
 template<typename Adder>

--- a/include/powsybl/iidm/HvdcLine.hpp
+++ b/include/powsybl/iidm/HvdcLine.hpp
@@ -94,8 +94,6 @@ private:
     HvdcConverterStation& attach(HvdcConverterStation& converterStation);
 
 private:
-    stdcxx::Reference<Network> m_network;
-
     stdcxx::Reference<HvdcConverterStation> m_converterStation1;
 
     stdcxx::Reference<HvdcConverterStation> m_converterStation2;

--- a/include/powsybl/iidm/Identifiable.hpp
+++ b/include/powsybl/iidm/Identifiable.hpp
@@ -25,11 +25,15 @@ public: // Validable
     std::string getMessageHeader() const override;
 
 public:
-    Identifiable(const Identifiable& identifiable) = delete;
+    Identifiable(const Identifiable&) = delete;
+
+    Identifiable(Identifiable&& identifiable) noexcept;
 
     ~Identifiable() noexcept override = default;
 
-    Identifiable& operator=(const Identifiable& identifiable) = delete;
+    Identifiable& operator=(const Identifiable&) = delete;
+
+    Identifiable& operator=(Identifiable&&) noexcept = delete;
 
     const std::string& getId() const;
 
@@ -48,8 +52,6 @@ public:
     stdcxx::optional<std::string> setProperty(const std::string& key, const std::string& value);
 
 protected:
-    Identifiable(Identifiable&&) = default;
-
     Identifiable(const std::string& id, const std::string& name);
 
 private:

--- a/include/powsybl/iidm/InjectionAdder.hpp
+++ b/include/powsybl/iidm/InjectionAdder.hpp
@@ -18,6 +18,7 @@ namespace powsybl {
 namespace iidm {
 
 class Terminal;
+class VoltageLevel;
 
 template <typename Adder>
 class InjectionAdder : public IdentifiableAdder<Adder> {
@@ -30,12 +31,19 @@ public:
 
     Adder& setNode(unsigned long node);
 
+protected:  // IdentifiableAdder
+    Network& getNetwork() override;
+
 protected:
-    InjectionAdder() = default;
+    InjectionAdder(VoltageLevel& voltageLevel);
 
     std::unique_ptr<Terminal> checkAndGetTerminal();
 
+    VoltageLevel& getVoltageLevel();
+
 private:
+    VoltageLevel& m_voltageLevel;
+
     stdcxx::optional<unsigned long> m_node;
 
     std::string m_bus;

--- a/include/powsybl/iidm/InjectionAdder.hxx
+++ b/include/powsybl/iidm/InjectionAdder.hxx
@@ -11,6 +11,7 @@
 #include <powsybl/iidm/InjectionAdder.hpp>
 
 #include <powsybl/iidm/Network.hpp>
+#include <powsybl/iidm/VoltageLevel.hpp>
 #include <powsybl/iidm/TerminalBuilder.hpp>
 #include <powsybl/iidm/ValidationException.hpp>
 
@@ -19,12 +20,27 @@ namespace powsybl {
 namespace iidm {
 
 template <typename Adder>
+InjectionAdder<Adder>::InjectionAdder(VoltageLevel& voltageLevel) :
+    m_voltageLevel(voltageLevel) {
+}
+
+template <typename Adder>
 std::unique_ptr<Terminal> InjectionAdder<Adder>::checkAndGetTerminal() {
-    return TerminalBuilder(this->getNetwork(), *this)
+    return TerminalBuilder(m_voltageLevel, *this)
                .setNode(m_node)
                .setBus(m_bus)
                .setConnectableBus(m_connectableBus)
                .build();
+}
+
+template <typename Adder>
+Network& InjectionAdder<Adder>::getNetwork() {
+    return m_voltageLevel.getNetwork();
+}
+
+template <typename Adder>
+VoltageLevel& InjectionAdder<Adder>::getVoltageLevel() {
+    return m_voltageLevel;
 }
 
 template <typename Adder>

--- a/include/powsybl/iidm/Load.hpp
+++ b/include/powsybl/iidm/Load.hpp
@@ -12,8 +12,6 @@
 
 #include <powsybl/iidm/Injection.hpp>
 #include <powsybl/iidm/LoadType.hpp>
-#include <powsybl/iidm/VariantManagerHolder.hpp>
-#include <powsybl/stdcxx/reference_wrapper.hpp>
 
 namespace powsybl {
 
@@ -49,8 +47,6 @@ private: // Identifiable
     const std::string& getTypeDescription() const override;
 
 private:
-    stdcxx::Reference<VariantManagerHolder> m_network;
-
     LoadType m_loadType;
 
     std::vector<double> m_p0;

--- a/include/powsybl/iidm/LoadAdder.hpp
+++ b/include/powsybl/iidm/LoadAdder.hpp
@@ -32,9 +32,6 @@ public:
 
     LoadAdder& setQ0(double q0);
 
-protected: // IdentifiableAdder
-    Network& getNetwork() override;
-
 private: // IdentifiableAdder
     const std::string& getTypeDescription() const override;
 
@@ -44,8 +41,6 @@ private:
     friend class VoltageLevel;
 
 private:
-    VoltageLevel& m_voltageLevel;
-
     LoadType m_loadType = LoadType::UNDEFINED;
 
     double m_p0 = stdcxx::nan();

--- a/include/powsybl/iidm/Network.hpp
+++ b/include/powsybl/iidm/Network.hpp
@@ -79,9 +79,15 @@ public: // VariantManagerHolder
 public:
     Network(const std::string& id, const std::string& sourceFormat);
 
-    Network(Network&&) = default;
+    Network(const Network&) = delete;
+
+    Network(Network&&) noexcept;
 
     ~Network() noexcept override = default;
+
+    Network& operator=(const Network&) = delete;
+
+    Network& operator=(Network&&) noexcept = delete;
 
     template <typename T>
     T& checkAndAdd(std::unique_ptr<T>&& identifiable);

--- a/include/powsybl/iidm/NetworkIndex.hpp
+++ b/include/powsybl/iidm/NetworkIndex.hpp
@@ -20,17 +20,23 @@ namespace powsybl {
 
 namespace iidm {
 
+class Network;
+
 class NetworkIndex {
 public:
     NetworkIndex() = default;
 
-    NetworkIndex(const NetworkIndex& networkIndex) = delete;
+    NetworkIndex(const NetworkIndex&) = delete;
 
-    NetworkIndex(NetworkIndex&& networkIndex) noexcept;
+    NetworkIndex(NetworkIndex&&) noexcept = delete;
+
+    NetworkIndex(Network& network, NetworkIndex&& networkIndex) noexcept;
 
     ~NetworkIndex() noexcept = default;
 
-    NetworkIndex& operator=(const NetworkIndex& networkIndex) = delete;
+    NetworkIndex& operator=(const NetworkIndex&) = delete;
+
+    NetworkIndex& operator=(NetworkIndex&&) noexcept = delete;
 
     template <typename T>
     T& checkAndAdd(std::unique_ptr<T>&& identifiable);

--- a/include/powsybl/iidm/NetworkRef.hpp
+++ b/include/powsybl/iidm/NetworkRef.hpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef POWSYBL_IIDM_NETWORKREF_HPP
+#define POWSYBL_IIDM_NETWORKREF_HPP
+
+namespace powsybl {
+
+namespace iidm {
+
+class Network;
+
+/**
+ * A {@link NetworkRef} instance holds a reference to a network.
+ * It uses to maintain the back reference between an {@link Identifiable} and the network it belongs to.
+ */
+class NetworkRef {
+public:
+    /**
+     * Create a reference to a {@link Network} object.
+     * @param network the network pointed by this reference.
+     */
+    explicit NetworkRef(Network& network);
+
+    /**
+     * Copy constructor
+     */
+    NetworkRef(const NetworkRef&) = delete;
+
+    /**
+     * Move constructor
+     */
+     NetworkRef(NetworkRef&&) noexcept = delete;
+
+    /**
+     * Destructor
+     */
+    ~NetworkRef() = default;
+
+    /**
+     * Copy assignment operator
+     */
+    NetworkRef& operator=(const NetworkRef&) = delete;
+
+    /**
+     * Move assignment operator
+     */
+    NetworkRef& operator=(NetworkRef&&) noexcept = delete;
+
+    /**
+     * Get the {@link Network} object pointed by this reference.
+     * @return a network object
+     */
+    const Network& get() const;
+
+    /**
+     * Get the {@link Network} object pointed by this reference.
+     * @return a network object
+     */
+    Network& get();
+
+    /**
+     * Set the {@link Network} object pointed by this reference.
+     */
+    void set(Network& network);
+
+private:
+    Network* m_pointer;
+};
+
+}  // namespace iidm
+
+}  // namespace powsybl
+
+#endif  // POWSYBL_IIDM_NETWORKREF_HPP

--- a/include/powsybl/iidm/Properties.hpp
+++ b/include/powsybl/iidm/Properties.hpp
@@ -27,7 +27,15 @@ public:
 public:
     Properties() = default;
 
+    Properties(const Properties&) = default;
+
+    Properties(Properties&&) noexcept = default;
+
     ~Properties() = default;
+
+    Properties& operator=(const Properties&) = default;
+
+    Properties& operator=(Properties&&) noexcept = default;
 
     const_iterator begin() const;
 

--- a/include/powsybl/iidm/ShuntCompensator.hpp
+++ b/include/powsybl/iidm/ShuntCompensator.hpp
@@ -48,8 +48,6 @@ private: // Identifiable
     const std::string& getTypeDescription() const override;
 
 private:
-    stdcxx::Reference<VariantManagerHolder> m_network;
-
     double m_bPerSection;
 
     unsigned long m_maximumSectionCount;

--- a/include/powsybl/iidm/ShuntCompensatorAdder.hpp
+++ b/include/powsybl/iidm/ShuntCompensatorAdder.hpp
@@ -31,9 +31,6 @@ public:
 
     ShuntCompensatorAdder& setMaximumSectionCount(unsigned long maximumSectionCount);
 
-protected: // IdentifiableAdder
-    Network& getNetwork() override;
-
 private: // IdentifiableAdder
     const std::string& getTypeDescription() const override;
 
@@ -43,8 +40,6 @@ private:
     friend class VoltageLevel;
 
 private:
-    VoltageLevel& m_voltageLevel;
-
     double m_bPerSection = stdcxx::nan();
 
     unsigned long m_currentSectionCount = 0;

--- a/include/powsybl/iidm/StaticVarCompensator.hpp
+++ b/include/powsybl/iidm/StaticVarCompensator.hpp
@@ -59,8 +59,6 @@ private: // Identifiable
     const std::string& getTypeDescription() const override;
 
 private:
-    stdcxx::Reference<VariantManagerHolder> m_network;
-
     double m_bMin;
 
     double m_bMax;

--- a/include/powsybl/iidm/StaticVarCompensatorAdder.hpp
+++ b/include/powsybl/iidm/StaticVarCompensatorAdder.hpp
@@ -32,9 +32,6 @@ public:
 
     StaticVarCompensatorAdder& setVoltageSetpoint(double voltageSetpoint);
 
-protected: // IdentifiableAdder
-    Network& getNetwork() override;
-
 private: // IdentifiableAdder
     const std::string& getTypeDescription() const override;
 
@@ -44,8 +41,6 @@ private:
     friend class VoltageLevel;
 
 private:
-    VoltageLevel& m_voltageLevel;
-
     double m_bMin = stdcxx::nan();
 
     double m_bMax = stdcxx::nan();

--- a/include/powsybl/iidm/Substation.hpp
+++ b/include/powsybl/iidm/Substation.hpp
@@ -15,7 +15,7 @@
 
 #include <powsybl/iidm/Container.hpp>
 #include <powsybl/iidm/Country.hpp>
-#include <powsybl/iidm/Network.hpp>
+#include <powsybl/iidm/NetworkRef.hpp>
 #include <powsybl/iidm/VoltageLevelAdder.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
 
@@ -23,6 +23,7 @@ namespace powsybl {
 
 namespace iidm {
 
+class Network;
 class ThreeWindingsTransformer;
 class ThreeWindingsTransformerAdder;
 class TwoWindingsTransformer;
@@ -81,7 +82,7 @@ private:
     friend class VoltageLevelAdder;
 
 private:
-    stdcxx::Reference<Network> m_network;
+    NetworkRef m_network;
 
     stdcxx::optional<Country> m_country;
 

--- a/include/powsybl/iidm/Substation.hpp
+++ b/include/powsybl/iidm/Substation.hpp
@@ -24,6 +24,7 @@ namespace powsybl {
 namespace iidm {
 
 class Network;
+class NetworkIndex;
 class ThreeWindingsTransformer;
 class ThreeWindingsTransformerAdder;
 class TwoWindingsTransformer;
@@ -79,7 +80,11 @@ private: // Identifiable
 private:
     void addVoltageLevel(VoltageLevel& voltageLevel);
 
+    void setNetworkRef(Network& network);
+
     friend class VoltageLevelAdder;
+
+    friend class NetworkIndex;
 
 private:
     NetworkRef m_network;

--- a/include/powsybl/iidm/TapChanger.hpp
+++ b/include/powsybl/iidm/TapChanger.hpp
@@ -87,8 +87,6 @@ protected:
     H& getParent();
 
 private:
-    stdcxx::Reference<VariantManagerHolder> m_network;
-
     H& m_parent;
 
     long m_lowTapPosition;

--- a/include/powsybl/iidm/TapChanger.hxx
+++ b/include/powsybl/iidm/TapChanger.hxx
@@ -25,7 +25,6 @@ double checkTargetDeadband(const Validable& validable, double targetDeadband);
 template<typename H, typename C, typename S>
 TapChanger<H, C, S>::TapChanger(VariantManagerHolder& network, H& parent, long lowTapPosition, const std::vector<S>& steps, const stdcxx::Reference<Terminal>& regulationTerminal,
                                 long tapPosition, bool regulating, double targetDeadband) :
-   m_network(network),
    m_parent(parent),
    m_lowTapPosition(lowTapPosition),
    m_steps(steps),
@@ -125,17 +124,17 @@ unsigned int TapChanger<H, C, S>::getStepCount() const {
 
 template<typename H, typename C, typename S>
 long TapChanger<H, C, S>::getTapPosition() const {
-    return m_tapPosition.at(m_network.get().getVariantIndex());
+    return m_tapPosition.at(getNetwork().getVariantIndex());
 }
 
 template<typename H, typename C, typename S>
 double TapChanger<H, C, S>::getTargetDeadband() const {
-    return m_targetDeadband.at(m_network.get().getVariantIndex());
+    return m_targetDeadband.at(getNetwork().getVariantIndex());
 }
 
 template<typename H, typename C, typename S>
 bool TapChanger<H, C, S>::isRegulating() const {
-    return m_regulating.at(m_network.get().getVariantIndex());
+    return m_regulating.at(getNetwork().getVariantIndex());
 }
 
 template<typename H, typename C, typename S>
@@ -149,14 +148,14 @@ template<typename H, typename C, typename S>
 C& TapChanger<H, C, S>::setLowTapPosition(long lowTapPosition) {
     long oldValue = m_lowTapPosition;
     m_lowTapPosition = lowTapPosition;
-    m_tapPosition[m_network.get().getVariantIndex()] = getTapPosition() + m_lowTapPosition - oldValue;
+    m_tapPosition[getNetwork().getVariantIndex()] = getTapPosition() + m_lowTapPosition - oldValue;
 
     return static_cast<C&>(*this);
 }
 
 template<typename H, typename C, typename S>
 C& TapChanger<H, C, S>::setRegulating(bool regulating) {
-    m_regulating[m_network.get().getVariantIndex()] = regulating;
+    m_regulating[getNetwork().getVariantIndex()] = regulating;
 
     return static_cast<C&>(*this);
 }
@@ -173,14 +172,14 @@ C& TapChanger<H, C, S>::setRegulationTerminal(const stdcxx::Reference<Terminal>&
 
 template<typename H, typename C, typename S>
 C& TapChanger<H, C, S>::setTapPosition(long tapPosition) {
-    m_tapPosition[m_network.get().getVariantIndex()] = checkTapPosition(m_parent, tapPosition, m_lowTapPosition, getHighTapPosition());
+    m_tapPosition[getNetwork().getVariantIndex()] = checkTapPosition(m_parent, tapPosition, m_lowTapPosition, getHighTapPosition());
 
     return static_cast<C&>(*this);
 }
 
 template<typename H, typename C, typename S>
 C& TapChanger<H, C, S>::setTargetDeadband(double targetDeadband) {
-    m_targetDeadband[m_network.get().getVariantIndex()] = checkTargetDeadband(m_parent, targetDeadband);
+    m_targetDeadband[getNetwork().getVariantIndex()] = checkTargetDeadband(m_parent, targetDeadband);
 
     return static_cast<C&>(*this);
 }

--- a/include/powsybl/iidm/Terminal.hpp
+++ b/include/powsybl/iidm/Terminal.hpp
@@ -83,8 +83,6 @@ public:
 
     Terminal& setQ(double q);
 
-    Terminal& setVoltageLevel(const stdcxx::Reference<VoltageLevel>& voltageLevel);
-
 protected: // MultiVariantObject
     void allocateVariantArrayElement(const std::set<unsigned long>& indexes, unsigned long sourceIndex) override;
 
@@ -97,25 +95,25 @@ protected: // MultiVariantObject
     friend class Connectable;
 
 protected:
-    explicit Terminal(VariantManagerHolder& network);
+    explicit Terminal(VoltageLevel& voltageLevel);
 
-    const VariantManagerHolder& getNetwork() const;
+    const Network& getNetwork() const;
+
+    Network& getNetwork();
 
 private:
-    stdcxx::Reference<VariantManagerHolder> m_network;
+    VoltageLevel& m_voltageLevel;
 
     stdcxx::Reference<Connectable> m_connectable;
-
-    stdcxx::Reference<VoltageLevel> m_voltageLevel;
 
     std::vector<double> m_p;
 
     std::vector<double> m_q;
 };
 
-std::unique_ptr<Terminal> createBusTerminal(Network& network, const std::string& connectableBusId, bool connected);
+std::unique_ptr<Terminal> createBusTerminal(VoltageLevel& network, const std::string& connectableBusId, bool connected);
 
-std::unique_ptr<Terminal> createNodeTerminal(Network& network, unsigned long node);
+std::unique_ptr<Terminal> createNodeTerminal(VoltageLevel& network, unsigned long node);
 
 }  // namespace iidm
 

--- a/include/powsybl/iidm/TerminalBuilder.hpp
+++ b/include/powsybl/iidm/TerminalBuilder.hpp
@@ -17,13 +17,13 @@ namespace powsybl {
 
 namespace iidm {
 
-class Network;
 class Terminal;
 class Validable;
+class VoltageLevel;
 
 class TerminalBuilder {
 public:
-    TerminalBuilder(Network& network, Validable& validable);
+    TerminalBuilder(VoltageLevel& voltageLevel, Validable& validable);
 
     ~TerminalBuilder() noexcept = default;
 
@@ -39,7 +39,7 @@ private:
     const std::string& getConnectionBus() const;
 
 private:
-    Network& m_network;
+    VoltageLevel& m_voltageLevel;
 
     Validable& m_validable;
 

--- a/include/powsybl/iidm/ThreeWindingsTransformerAdder.hpp
+++ b/include/powsybl/iidm/ThreeWindingsTransformerAdder.hpp
@@ -54,7 +54,7 @@ public:
 
         std::unique_ptr<ThreeWindingsTransformer::Leg> checkAndGetLeg() const;
 
-        std::unique_ptr<Terminal> checkAndGetTerminal();
+        std::unique_ptr<Terminal> checkAndGetTerminal(VoltageLevel& voltageLevel);
 
         VoltageLevel& checkAndGetVoltageLevel();
 

--- a/include/powsybl/iidm/Validable.hpp
+++ b/include/powsybl/iidm/Validable.hpp
@@ -16,7 +16,17 @@ namespace iidm {
 
 class Validable {
 public:
+    Validable() = default;
+
+    Validable(const Validable&) = default;
+
+    Validable(Validable&&) noexcept = default;
+
     virtual ~Validable() noexcept = default;
+
+    Validable& operator=(const Validable&) = default;
+
+    Validable& operator=(Validable&&) noexcept = default;
 
     virtual std::string getMessageHeader() const = 0;
 };

--- a/include/powsybl/iidm/VariantManager.hpp
+++ b/include/powsybl/iidm/VariantManager.hpp
@@ -30,13 +30,17 @@ public:
 public:
     explicit VariantManager(Network& network);
 
-    VariantManager(const VariantManager& variantManager) = delete;
+    VariantManager(const VariantManager&) = delete;
 
-    VariantManager(VariantManager&& variantManager) noexcept;
+    VariantManager(VariantManager&& variantManager) noexcept = delete;
+
+    VariantManager(Network& network, VariantManager&& variantManager) noexcept;
 
     ~VariantManager() noexcept = default;
 
-    VariantManager& operator=(const VariantManager& variantManager) = delete;
+    VariantManager& operator=(const VariantManager&) = delete;
+
+    VariantManager& operator=(VariantManager&&) noexcept = delete;
 
     void cloneVariant(const std::string& sourceVariantId, const std::string& targetVariantId);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ set(IIDM_SOURCES
     iidm/MultipleVariantContext.cpp
     iidm/Network.cpp
     iidm/NetworkIndex.cpp
+    iidm/NetworkRef.cpp
     iidm/NetworkViews.cpp
     iidm/NodeBreakerVoltageLevel.cpp
     iidm/NodeBreakerVoltageLevelBusCache.cpp

--- a/src/iidm/Battery.cpp
+++ b/src/iidm/Battery.cpp
@@ -16,7 +16,6 @@ namespace iidm {
 Battery::Battery(VariantManagerHolder& network, const std::string& id, const std::string& name,
     double p0, double q0, double minP, double maxP) :
     Injection(id, name, ConnectableType::BATTERY),
-    m_network(network),
     m_p0(network.getVariantManager().getVariantArraySize(), checkP0(*this, p0)),
     m_q0(network.getVariantManager().getVariantArraySize(), checkQ0(*this, q0)),
     m_minP(checkMinP(*this, minP)),
@@ -49,11 +48,11 @@ double Battery::getMinP() const {
 }
 
 double Battery::getP0() const {
-    return m_p0.at(m_network.get().getVariantIndex());
+    return m_p0.at(getNetwork().getVariantIndex());
 }
 
 double Battery::getQ0() const {
-    return m_q0.at(m_network.get().getVariantIndex());
+    return m_q0.at(getNetwork().getVariantIndex());
 }
 
 const std::string& Battery::getTypeDescription() const {
@@ -88,13 +87,13 @@ Battery& Battery::setMinP(double minP) {
 Battery& Battery::setP0(double p0) {
     checkP0(*this, p0);
     checkActivePowerLimits(*this, m_minP, m_maxP, p0);
-    m_p0[m_network.get().getVariantIndex()] = p0;
+    m_p0[getNetwork().getVariantIndex()] = p0;
 
     return *this;
 }
 
 Battery& Battery::setQ0(double q0) {
-    m_q0[m_network.get().getVariantIndex()] = checkQ0(*this, q0);
+    m_q0[getNetwork().getVariantIndex()] = checkQ0(*this, q0);
 
     return *this;
 }

--- a/src/iidm/BatteryAdder.cpp
+++ b/src/iidm/BatteryAdder.cpp
@@ -19,7 +19,7 @@ namespace powsybl {
 namespace iidm {
 
 BatteryAdder::BatteryAdder(VoltageLevel& voltageLevel) :
-    m_voltageLevel(voltageLevel) {
+    InjectionAdder(voltageLevel) {
 }
 
 Battery& BatteryAdder::add() {
@@ -33,13 +33,9 @@ Battery& BatteryAdder::add() {
     auto& battery = getNetwork().checkAndAdd<Battery>(std::move(ptrBattery));
 
     Terminal& terminal = battery.addTerminal(checkAndGetTerminal());
-    m_voltageLevel.attach(terminal, false);
+    getVoltageLevel().attach(terminal, false);
 
     return battery;
-}
-
-Network& BatteryAdder::getNetwork() {
-    return m_voltageLevel.getNetwork();
 }
 
 const std::string& BatteryAdder::getTypeDescription() const {

--- a/src/iidm/BusBreakerVoltageLevel.cpp
+++ b/src/iidm/BusBreakerVoltageLevel.cpp
@@ -57,9 +57,6 @@ void BusBreakerVoltageLevel::allocateVariantArrayElement(const std::set<unsigned
 void BusBreakerVoltageLevel::attach(Terminal& terminal, bool test) {
     checkTerminal(terminal);
     if (!test) {
-        // create the link terminal -> voltage level
-        terminal.setVoltageLevel(stdcxx::ref<VoltageLevel>(*this));
-
         auto& busTerminal = dynamic_cast<BusTerminal&>(terminal);
         const auto& connectableBus = getConfiguredBus(busTerminal.getConnectableBusId(), true);
 
@@ -120,8 +117,6 @@ void BusBreakerVoltageLevel::detach(Terminal& terminal) {
 
         invalidateCache();
     });
-
-    terminal.setVoltageLevel(stdcxx::ref<VoltageLevel>());
 }
 
 bool BusBreakerVoltageLevel::disconnect(Terminal& terminal) {

--- a/src/iidm/BusBreakerVoltageLevel.cpp
+++ b/src/iidm/BusBreakerVoltageLevel.cpp
@@ -24,7 +24,7 @@ namespace iidm {
 BusBreakerVoltageLevel::BusBreakerVoltageLevel(const std::string& id, const std::string& name, Substation& substation,
                                                double nominalVoltage, double lowVoltageLimit, double highVoltagelimit) :
     VoltageLevel(id, name, substation, nominalVoltage, lowVoltageLimit, highVoltagelimit),
-    m_variants(substation.getNetwork(), [this]() { return stdcxx::make_unique<bus_breaker_voltage_level::VariantImpl>(*this); }),
+    m_variants(*this, [this]() { return stdcxx::make_unique<bus_breaker_voltage_level::VariantImpl>(*this); }),
     m_busBreakerView(*this),
     m_busView(*this) {
 }

--- a/src/iidm/BusTerminal.cpp
+++ b/src/iidm/BusTerminal.cpp
@@ -18,10 +18,10 @@ namespace powsybl {
 
 namespace iidm {
 
-BusTerminal::BusTerminal(VariantManagerHolder& network, const std::string& connectableBusId, bool connected) :
-    Terminal(network),
-    m_connected(network.getVariantManager().getVariantArraySize(), connected),
-    m_connectableBusId(network.getVariantManager().getVariantArraySize(), checkNotEmpty(connectableBusId, "ConnectableBusId is required")),
+BusTerminal::BusTerminal(VoltageLevel& voltageLevel, const std::string& connectableBusId, bool connected) :
+    Terminal(voltageLevel),
+    m_connected(voltageLevel.getNetwork().getVariantManager().getVariantArraySize(), connected),
+    m_connectableBusId(voltageLevel.getNetwork().getVariantManager().getVariantArraySize(), checkNotEmpty(connectableBusId, "ConnectableBusId is required")),
     m_busBreakerView(*this),
     m_busView(*this) {
 }

--- a/src/iidm/BusTerminal.hpp
+++ b/src/iidm/BusTerminal.hpp
@@ -48,7 +48,7 @@ public: // Terminal
     bool isConnected() const override;
 
 public:
-    BusTerminal(VariantManagerHolder& network, const std::string& connectableBusId, bool connected);
+    BusTerminal(VoltageLevel& voltageLevel, const std::string& connectableBusId, bool connected);
 
     BusTerminal(const BusTerminal& nodeTerminal) = delete;
 

--- a/src/iidm/BusbarSection.cpp
+++ b/src/iidm/BusbarSection.cpp
@@ -13,10 +13,8 @@ namespace powsybl {
 
 namespace iidm {
 
-BusbarSection::BusbarSection(VariantManagerHolder& network, const std::string& id, const std::string& name) :
-    Injection(id, name, ConnectableType::BUSBAR_SECTION),
-    m_network(network) {
-
+BusbarSection::BusbarSection(const std::string& id, const std::string& name) :
+    Injection(id, name, ConnectableType::BUSBAR_SECTION) {
 }
 
 double BusbarSection::getAngle() const {

--- a/src/iidm/BusbarSectionAdder.cpp
+++ b/src/iidm/BusbarSectionAdder.cpp
@@ -28,7 +28,7 @@ BusbarSection& BusbarSectionAdder::add() {
     std::unique_ptr<BusbarSection> ptrBusbarSection = stdcxx::make_unique<BusbarSection>(getId(), getName());
     BusbarSection& busbarSection = getNetwork().checkAndAdd(std::move(ptrBusbarSection));
 
-    Terminal& terminal = busbarSection.addTerminal(createNodeTerminal(getNetwork(), *m_node));
+    Terminal& terminal = busbarSection.addTerminal(createNodeTerminal(m_voltageLevel, *m_node));
     m_voltageLevel.attach(terminal, false);
 
     return busbarSection;

--- a/src/iidm/BusbarSectionAdder.cpp
+++ b/src/iidm/BusbarSectionAdder.cpp
@@ -25,7 +25,7 @@ BusbarSectionAdder::BusbarSectionAdder(NodeBreakerVoltageLevel& voltageLevel) :
 BusbarSection& BusbarSectionAdder::add() {
     checkOptional(*this, m_node, "Node is not set");
 
-    std::unique_ptr<BusbarSection> ptrBusbarSection = stdcxx::make_unique<BusbarSection>(getNetwork(), getId(), getName());
+    std::unique_ptr<BusbarSection> ptrBusbarSection = stdcxx::make_unique<BusbarSection>(getId(), getName());
     BusbarSection& busbarSection = getNetwork().checkAndAdd(std::move(ptrBusbarSection));
 
     Terminal& terminal = busbarSection.addTerminal(createNodeTerminal(getNetwork(), *m_node));

--- a/src/iidm/ConfiguredBus.cpp
+++ b/src/iidm/ConfiguredBus.cpp
@@ -25,15 +25,14 @@ namespace iidm {
 ConfiguredBus::ConfiguredBus(const std::string& id, const std::string& name, BusBreakerVoltageLevel& voltageLevel) :
     Bus(id, name),
     m_voltageLevel(voltageLevel),
-    m_network(voltageLevel.getNetwork()),
-    m_terminals(m_network.get().getVariantManager().getVariantArraySize()),
-    m_v(m_network.get().getVariantManager().getVariantArraySize(), stdcxx::nan()),
-    m_angle(m_network.get().getVariantManager().getVariantArraySize(), stdcxx::nan()) {
+    m_terminals(voltageLevel.getNetwork().getVariantManager().getVariantArraySize()),
+    m_v(voltageLevel.getNetwork().getVariantManager().getVariantArraySize(), stdcxx::nan()),
+    m_angle(voltageLevel.getNetwork().getVariantManager().getVariantArraySize(), stdcxx::nan()) {
 
 }
 
 void ConfiguredBus::addTerminal(BusTerminal& terminal) {
-    m_terminals[m_network.get().getVariantIndex()].push_back(std::ref(terminal));
+    m_terminals[getNetwork().getVariantIndex()].push_back(std::ref(terminal));
 }
 
 void ConfiguredBus::allocateVariantArrayElement(const std::set<unsigned long>& indexes, unsigned long sourceIndex) {
@@ -55,13 +54,13 @@ void ConfiguredBus::extendVariantArraySize(unsigned long /*initVariantArraySize*
 }
 
 double ConfiguredBus::getAngle() const {
-    return m_angle[m_network.get().getVariantIndex()];
+    return m_angle[getNetwork().getVariantIndex()];
 }
 
 unsigned long ConfiguredBus::getConnectedTerminalCount() const {
     unsigned long count = 0;
 
-    const std::list<std::reference_wrapper<BusTerminal> >& terminals = m_terminals[m_network.get().getVariantIndex()];
+    const std::list<std::reference_wrapper<BusTerminal> >& terminals = m_terminals[getNetwork().getVariantIndex()];
     for (const auto& terminal : terminals) {
         if (terminal.get().isConnected()) {
             ++count;
@@ -72,7 +71,7 @@ unsigned long ConfiguredBus::getConnectedTerminalCount() const {
 }
 
 stdcxx::const_range<Terminal> ConfiguredBus::getConnectedTerminals() const {
-    const auto& busTerminals = m_terminals[m_network.get().getVariantIndex()];
+    const auto& busTerminals = m_terminals[getNetwork().getVariantIndex()];
 
     const auto& filter = [](const Terminal& terminal) {
         return terminal.isConnected();
@@ -84,7 +83,7 @@ stdcxx::const_range<Terminal> ConfiguredBus::getConnectedTerminals() const {
 }
 
 stdcxx::range<Terminal> ConfiguredBus::getConnectedTerminals() {
-    const auto& busTerminals = m_terminals[m_network.get().getVariantIndex()];
+    const auto& busTerminals = m_terminals[getNetwork().getVariantIndex()];
 
     const auto& filter = [](const Terminal& terminal) {
         return terminal.isConnected();
@@ -95,12 +94,20 @@ stdcxx::range<Terminal> ConfiguredBus::getConnectedTerminals() {
     return busTerminals | boost::adaptors::transformed(mapper) | boost::adaptors::filtered(filter);
 }
 
+const Network& ConfiguredBus::getNetwork() const {
+    return m_voltageLevel.get().getNetwork();
+}
+
+Network& ConfiguredBus::getNetwork() {
+    return m_voltageLevel.get().getNetwork();
+}
+
 unsigned long ConfiguredBus::getTerminalCount() const {
-    return m_terminals[m_network.get().getVariantIndex()].size();
+    return m_terminals[getNetwork().getVariantIndex()].size();
 }
 
 stdcxx::const_range<BusTerminal> ConfiguredBus::getTerminals() const {
-    const auto& terminals = m_terminals[m_network.get().getVariantIndex()];
+    const auto& terminals = m_terminals[getNetwork().getVariantIndex()];
 
     const auto& mapper = stdcxx::map<std::reference_wrapper<BusTerminal>, BusTerminal>;
 
@@ -108,7 +115,7 @@ stdcxx::const_range<BusTerminal> ConfiguredBus::getTerminals() const {
 }
 
 stdcxx::range<BusTerminal> ConfiguredBus::getTerminals() {
-    const auto& terminals = m_terminals[m_network.get().getVariantIndex()];
+    const auto& terminals = m_terminals[getNetwork().getVariantIndex()];
 
     const auto& mapper = stdcxx::map<std::reference_wrapper<BusTerminal>, BusTerminal>;
 
@@ -116,7 +123,7 @@ stdcxx::range<BusTerminal> ConfiguredBus::getTerminals() {
 }
 
 double ConfiguredBus::getV() const {
-    return m_v[m_network.get().getVariantIndex()];
+    return m_v[getNetwork().getVariantIndex()];
 }
 
 VoltageLevel& ConfiguredBus::getVoltageLevel() const {
@@ -130,7 +137,7 @@ void ConfiguredBus::reduceVariantArraySize(unsigned long number) {
 }
 
 void ConfiguredBus::removeTerminal(BusTerminal& terminal) {
-    auto& terminals = m_terminals[m_network.get().getVariantIndex()];
+    auto& terminals = m_terminals[getNetwork().getVariantIndex()];
     const auto& it = std::find_if(terminals.begin(), terminals.end(), [&terminal](const std::reference_wrapper<BusTerminal>& item) {
         return stdcxx::areSame(terminal, item.get());
     });
@@ -143,7 +150,7 @@ void ConfiguredBus::removeTerminal(BusTerminal& terminal) {
 }
 
 Bus& ConfiguredBus::setAngle(double angle) {
-    m_angle[m_network.get().getVariantIndex()] = angle;
+    m_angle[getNetwork().getVariantIndex()] = angle;
 
     return *this;
 }
@@ -151,7 +158,7 @@ Bus& ConfiguredBus::setAngle(double angle) {
 Bus& ConfiguredBus::setV(double v) {
     checkVoltage(*this, v);
 
-    m_v[m_network.get().getVariantIndex()] = v;
+    m_v[getNetwork().getVariantIndex()] = v;
 
     return *this;
 }

--- a/src/iidm/ConfiguredBus.hpp
+++ b/src/iidm/ConfiguredBus.hpp
@@ -14,7 +14,6 @@
 #include <powsybl/iidm/Bus.hpp>
 #include <powsybl/iidm/BusAdder.hpp>
 #include <powsybl/iidm/MultiVariantObject.hpp>
-#include <powsybl/iidm/VariantManagerHolder.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
 
 namespace powsybl {
@@ -23,6 +22,7 @@ namespace iidm {
 
 class BusBreakerVoltageLevel;
 class BusTerminal;
+class Network;
 class Terminal;
 
 class ConfiguredBus : public Bus, public MultiVariantObject {
@@ -50,6 +50,10 @@ public:
 
     void addTerminal(BusTerminal& terminal);
 
+    const Network& getNetwork() const;
+
+    Network& getNetwork();
+
     unsigned long getTerminalCount() const;
 
     stdcxx::const_range<BusTerminal> getTerminals() const;
@@ -69,8 +73,6 @@ protected: // MultiVariantObject
 
 private:
     stdcxx::Reference<BusBreakerVoltageLevel> m_voltageLevel;
-
-    stdcxx::Reference<VariantManagerHolder> m_network;
 
     std::vector<std::list<std::reference_wrapper<BusTerminal> > > m_terminals;
 

--- a/src/iidm/Container.cpp
+++ b/src/iidm/Container.cpp
@@ -16,6 +16,11 @@ Container::Container(const std::string& id, const std::string& name, const Conta
     m_type(type) {
 }
 
+Container::Container(Container&& container) noexcept :
+    Identifiable(std::move(container)),
+    m_type(container.m_type) {
+}
+
 const Container::Type& Container::getContainerType() const {
     return m_type;
 }

--- a/src/iidm/DanglingLine.cpp
+++ b/src/iidm/DanglingLine.cpp
@@ -17,7 +17,6 @@ namespace iidm {
 DanglingLine::DanglingLine(VariantManagerHolder& network, const std::string& id, const std::string& name,
                            double p0, double q0, double r, double x, double g, double b, const std::string& ucteXnodeCode) :
     Injection(id, name, ConnectableType::DANGLING_LINE),
-    m_network(network),
     m_b(checkB(*this, b)),
     m_g(checkG(*this, g)),
     m_r(checkR(*this, r)),
@@ -60,11 +59,11 @@ double DanglingLine::getG() const {
 }
 
 double DanglingLine::getP0() const {
-    return m_p0.at(m_network.get().getVariantIndex());
+    return m_p0.at(getNetwork().getVariantIndex());
 }
 
 double DanglingLine::getQ0() const {
-    return m_q0.at(m_network.get().getVariantIndex());
+    return m_q0.at(getNetwork().getVariantIndex());
 }
 
 double DanglingLine::getR() const {
@@ -113,13 +112,13 @@ DanglingLine& DanglingLine::setG(double g) {
 }
 
 DanglingLine& DanglingLine::setP0(double p0) {
-    m_p0[m_network.get().getVariantIndex()] = checkP0(*this, p0);
+    m_p0[getNetwork().getVariantIndex()] = checkP0(*this, p0);
 
     return *this;
 }
 
 DanglingLine& DanglingLine::setQ0(double q0) {
-    m_q0[m_network.get().getVariantIndex()] = checkQ0(*this, q0);
+    m_q0[getNetwork().getVariantIndex()] = checkQ0(*this, q0);
 
     return *this;
 }

--- a/src/iidm/DanglingLineAdder.cpp
+++ b/src/iidm/DanglingLineAdder.cpp
@@ -19,7 +19,7 @@ namespace powsybl {
 namespace iidm {
 
 DanglingLineAdder::DanglingLineAdder(VoltageLevel& voltageLevel) :
-    m_voltageLevel(voltageLevel) {
+    InjectionAdder(voltageLevel) {
 }
 
 DanglingLine& DanglingLineAdder::add() {
@@ -34,13 +34,9 @@ DanglingLine& DanglingLineAdder::add() {
     auto& danglingLine = getNetwork().checkAndAdd<DanglingLine>(std::move(ptrDanglingLine));
 
     Terminal& terminal = danglingLine.addTerminal(checkAndGetTerminal());
-    m_voltageLevel.attach(terminal, false);
+    getVoltageLevel().attach(terminal, false);
 
     return danglingLine;
-}
-
-Network& DanglingLineAdder::getNetwork() {
-    return m_voltageLevel.getNetwork();
 }
 
 const std::string& DanglingLineAdder::getTypeDescription() const {

--- a/src/iidm/Generator.cpp
+++ b/src/iidm/Generator.cpp
@@ -20,7 +20,6 @@ Generator::Generator(powsybl::iidm::VariantManagerHolder& network, const std::st
                      const stdcxx::Reference<powsybl::iidm::Terminal>& regulatingTerminal, double activePowerSetpoint,
                      double reactivePowerSetpoint, double voltageSetpoint, double ratedS) :
     Injection(id, name, ConnectableType::GENERATOR),
-    m_network(network),
     m_energySource(energySource),
     m_minP(checkMinP(*this, minP)),
     m_maxP(checkMaxP(*this, maxP)),
@@ -55,7 +54,7 @@ void Generator::extendVariantArraySize(unsigned long initVariantArraySize, unsig
 }
 
 double Generator::getActivePowerSetpoint() const {
-    return m_activePowerSetpoint.at(m_network.get().getVariantIndex());
+    return m_activePowerSetpoint.at(getNetwork().getVariantIndex());
 }
 
 const EnergySource& Generator::getEnergySource() const {
@@ -75,7 +74,7 @@ double Generator::getRatedS() const {
 }
 
 double Generator::getReactivePowerSetpoint() const {
-    return m_reactivePowerSetpoint.at(m_network.get().getVariantIndex());
+    return m_reactivePowerSetpoint.at(getNetwork().getVariantIndex());
 }
 
 stdcxx::CReference<Terminal> Generator::getRegulatingTerminal() const {
@@ -105,11 +104,11 @@ const std::string& Generator::getTypeDescription() const {
 }
 
 double Generator::getVoltageSetpoint() const {
-    return m_voltageSetpoint.at(m_network.get().getVariantIndex());
+    return m_voltageSetpoint.at(getNetwork().getVariantIndex());
 }
 
 bool Generator::isVoltageRegulatorOn() const {
-    return m_voltageRegulatorOn.at(m_network.get().getVariantIndex());
+    return m_voltageRegulatorOn.at(getNetwork().getVariantIndex());
 }
 
 void Generator::reduceVariantArraySize(unsigned long number) {
@@ -122,7 +121,7 @@ void Generator::reduceVariantArraySize(unsigned long number) {
 }
 
 Generator& Generator::setActivePowerSetpoint(double activePowerSetpoint) {
-    m_activePowerSetpoint[m_network.get().getVariantIndex()] = checkActivePowerSetpoint(*this, activePowerSetpoint);
+    m_activePowerSetpoint[getNetwork().getVariantIndex()] = checkActivePowerSetpoint(*this, activePowerSetpoint);
     return *this;
 }
 
@@ -152,7 +151,7 @@ Generator& Generator::setRatedS(double ratedS) {
 
 Generator& Generator::setReactivePowerSetpoint(double reactivePowerSetpoint) {
     checkVoltageControl(*this, isVoltageRegulatorOn(), getVoltageSetpoint(), reactivePowerSetpoint);
-    m_reactivePowerSetpoint[m_network.get().getVariantIndex()] = reactivePowerSetpoint;
+    m_reactivePowerSetpoint[getNetwork().getVariantIndex()] = reactivePowerSetpoint;
     return *this;
 }
 
@@ -180,13 +179,13 @@ Generator& Generator::setTargetV(double voltageSetpoint) {
 
 Generator& Generator::setVoltageRegulatorOn(bool voltageRegulatorOn) {
     checkVoltageControl(*this, voltageRegulatorOn, getTargetV(), getTargetQ());
-    m_voltageRegulatorOn[m_network.get().getVariantIndex()] = voltageRegulatorOn;
+    m_voltageRegulatorOn[getNetwork().getVariantIndex()] = voltageRegulatorOn;
     return *this;
 }
 
 Generator& Generator::setVoltageSetpoint(double voltageSetpoint) {
     checkVoltageControl(*this, isVoltageRegulatorOn(), voltageSetpoint, getReactivePowerSetpoint());
-    m_voltageSetpoint[m_network.get().getVariantIndex()] = voltageSetpoint;
+    m_voltageSetpoint[getNetwork().getVariantIndex()] = voltageSetpoint;
     return *this;
 }
 

--- a/src/iidm/GeneratorAdder.cpp
+++ b/src/iidm/GeneratorAdder.cpp
@@ -19,7 +19,7 @@ namespace powsybl {
 namespace iidm {
 
 GeneratorAdder::GeneratorAdder(powsybl::iidm::VoltageLevel& voltageLevel) :
-    m_voltageLevel(voltageLevel) {
+    InjectionAdder(voltageLevel) {
 }
 
 Generator& GeneratorAdder::add() {
@@ -40,13 +40,9 @@ Generator& GeneratorAdder::add() {
     auto& generator = getNetwork().checkAndAdd(std::move(ptrGenerator));
 
     Terminal& terminal = generator.addTerminal(std::move(terminalPtr));
-    m_voltageLevel.attach(terminal, false);
+    getVoltageLevel().attach(terminal, false);
 
     return generator;
-}
-
-Network& GeneratorAdder::getNetwork() {
-    return m_voltageLevel.getNetwork();
 }
 
 const std::string& GeneratorAdder::getTypeDescription() const {

--- a/src/iidm/Identifiable.cpp
+++ b/src/iidm/Identifiable.cpp
@@ -28,6 +28,14 @@ Identifiable::Identifiable(const std::string& id, const std::string& name) :
     m_name(name) {
 }
 
+Identifiable::Identifiable(Identifiable&& identifiable) noexcept :
+    Validable(std::move(identifiable)),
+    Extendable(std::move(identifiable)),
+    m_id(std::move(identifiable.m_id)),
+    m_name(std::move(identifiable.m_name)),
+    m_properties(std::move(identifiable.m_properties)) {
+}
+
 const std::string& Identifiable::getId() const {
     return m_id;
 }

--- a/src/iidm/LineAdder.cpp
+++ b/src/iidm/LineAdder.cpp
@@ -27,8 +27,8 @@ LineAdder::LineAdder(Network& network) :
 Line& LineAdder::add() {
     VoltageLevel& voltageLevel1 = checkAndGetVoltageLevel1();
     VoltageLevel& voltageLevel2 = checkAndGetVoltageLevel2();
-    std::unique_ptr<Terminal> ptrTerminal1 = checkAndGetTerminal1();
-    std::unique_ptr<Terminal> ptrTerminal2 = checkAndGetTerminal2();
+    std::unique_ptr<Terminal> ptrTerminal1 = checkAndGetTerminal1(voltageLevel1);
+    std::unique_ptr<Terminal> ptrTerminal2 = checkAndGetTerminal2(voltageLevel2);
 
     checkB1(*this, m_b1);
     checkB2(*this, m_b2);

--- a/src/iidm/Load.cpp
+++ b/src/iidm/Load.cpp
@@ -18,7 +18,6 @@ namespace iidm {
 Load::Load(VariantManagerHolder& network, const std::string& id, const std::string& name, const LoadType& loadType,
            double p0, double q0) :
     Injection(id, name, ConnectableType::LOAD),
-    m_network(network),
     m_loadType(checkLoadType(*this, loadType)),
     m_p0(network.getVariantManager().getVariantArraySize(), checkP0(*this, p0)),
     m_q0(network.getVariantManager().getVariantArraySize(), checkQ0(*this, q0)) {
@@ -46,11 +45,11 @@ const LoadType& Load::getLoadType() const {
 }
 
 double Load::getP0() const {
-    return m_p0.at(m_network.get().getVariantIndex());
+    return m_p0.at(getNetwork().getVariantIndex());
 }
 
 double Load::getQ0() const {
-    return m_q0[m_network.get().getVariantIndex()];
+    return m_q0[getNetwork().getVariantIndex()];
 }
 
 const std::string& Load::getTypeDescription() const {
@@ -73,13 +72,13 @@ Load& Load::setLoadType(const LoadType& loadType) {
 }
 
 Load& Load::setP0(double p0) {
-    m_p0[m_network.get().getVariantIndex()] = checkP0(*this, p0);
+    m_p0[getNetwork().getVariantIndex()] = checkP0(*this, p0);
 
     return *this;
 }
 
 Load& Load::setQ0(double q0) {
-    m_q0[m_network.get().getVariantIndex()] = checkQ0(*this, q0);
+    m_q0[getNetwork().getVariantIndex()] = checkQ0(*this, q0);
 
     return *this;
 }

--- a/src/iidm/LoadAdder.cpp
+++ b/src/iidm/LoadAdder.cpp
@@ -19,7 +19,7 @@ namespace powsybl {
 namespace iidm {
 
 LoadAdder::LoadAdder(VoltageLevel& voltageLevel) :
-    m_voltageLevel(voltageLevel) {
+    InjectionAdder(voltageLevel) {
 }
 
 Load& LoadAdder::add() {
@@ -31,13 +31,9 @@ Load& LoadAdder::add() {
     auto& load = getNetwork().checkAndAdd<Load>(std::move(ptrLoad));
 
     Terminal& terminal = load.addTerminal(checkAndGetTerminal());
-    m_voltageLevel.attach(terminal, false);
+    getVoltageLevel().attach(terminal, false);
 
     return load;
-}
-
-Network& LoadAdder::getNetwork() {
-    return m_voltageLevel.getNetwork();
 }
 
 const std::string& LoadAdder::getTypeDescription() const {

--- a/src/iidm/Network.cpp
+++ b/src/iidm/Network.cpp
@@ -73,6 +73,18 @@ Network::Network(const std::string& id, const std::string& sourceFormat) :
     m_busView(*this) {
 }
 
+Network::Network(Network&& network) noexcept :
+    Container(std::move(network)),
+    VariantManagerHolder(std::move(network)),
+    m_caseDate(std::move(network.m_caseDate)),
+    m_forecastDistance(network.m_forecastDistance),
+    m_sourceFormat(std::move(network.m_sourceFormat)),
+    m_networkIndex(*this, std::move(network.m_networkIndex)),
+    m_variantManager(*this, std::move(network.m_variantManager)),
+    m_busBreakerView(*this),
+    m_busView(*this) {
+}
+
 const Battery& Network::getBattery(const std::string& id) const {
     return get<Battery>(id);
 }

--- a/src/iidm/NetworkIndex.cpp
+++ b/src/iidm/NetworkIndex.cpp
@@ -12,6 +12,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
+#include <powsybl/iidm/Substation.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 
 #include "ValidationUtils.hpp"
@@ -20,9 +21,13 @@ namespace powsybl {
 
 namespace iidm {
 
-NetworkIndex::NetworkIndex(NetworkIndex&& networkIndex) noexcept :
+NetworkIndex::NetworkIndex(Network& network, NetworkIndex&& networkIndex) noexcept :
     m_objectsById(std::move(networkIndex.m_objectsById)),
     m_objectsByType(std::move(networkIndex.m_objectsByType)) {
+
+    for (Substation& substation : getAll<Substation>()) {
+        substation.setNetworkRef(network);
+    }
 }
 
 void NetworkIndex::checkId(const std::string& id) {

--- a/src/iidm/NetworkRef.cpp
+++ b/src/iidm/NetworkRef.cpp
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <powsybl/iidm/NetworkRef.hpp>
+
+#include <powsybl/AssertionError.hpp>
+#include <powsybl/iidm/Network.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+NetworkRef::NetworkRef(Network& network) :
+    m_pointer(&network) {
+}
+
+const Network& NetworkRef::get() const {
+    if (m_pointer == nullptr) {
+        throw AssertionError("m_pointer is null");
+    }
+    return *m_pointer;
+}
+
+Network& NetworkRef::get() {
+    if (m_pointer == nullptr) {
+        throw AssertionError("m_pointer is null");
+    }
+    return *m_pointer;
+}
+
+void NetworkRef::set(Network& network) {
+    m_pointer = &network;
+}
+
+}  // namespace iidm
+
+}  // namespace powsybl

--- a/src/iidm/NodeBreakerVoltageLevel.cpp
+++ b/src/iidm/NodeBreakerVoltageLevel.cpp
@@ -60,9 +60,6 @@ void NodeBreakerVoltageLevel::attach(Terminal& terminal, bool test) {
                                 tmp.get().getConnectable().get().getId(), node, getId()));
         }
 
-        // create the link terminal <-> voltage level
-        terminal.setVoltageLevel(stdcxx::ref<VoltageLevel>(*this));
-
         // create the link terminal <-> graph vertex
         m_graph.setVertexObject(node, stdcxx::ref(nodeTerminal));
     }
@@ -123,9 +120,6 @@ void NodeBreakerVoltageLevel::detach(Terminal& terminal) {
 
     // remove the link terminal <-> graph vertex
     m_graph.setVertexObject(node, stdcxx::ref<NodeTerminal>());
-
-    // remove the link terminal <-> voltage level
-    nodeTerminal.setVoltageLevel(stdcxx::ref<VoltageLevel>());
 }
 
 bool NodeBreakerVoltageLevel::disconnect(Terminal& terminal) {

--- a/src/iidm/NodeBreakerVoltageLevel.cpp
+++ b/src/iidm/NodeBreakerVoltageLevel.cpp
@@ -23,7 +23,7 @@ NodeBreakerVoltageLevel::NodeBreakerVoltageLevel(const std::string& id, const st
                                                  double nominalVoltage, double lowVoltageLimit, double highVoltagelimit) :
     VoltageLevel(id, name, substation, nominalVoltage, lowVoltageLimit, highVoltagelimit),
     m_busNamingStrategy(*this),
-    m_variants(substation.getNetwork(), [this]() { return stdcxx::make_unique<node_breaker_voltage_level::VariantImpl>(*this); }),
+    m_variants(*this, [this]() { return stdcxx::make_unique<node_breaker_voltage_level::VariantImpl>(*this); }),
     m_nodeBreakerView(*this),
     m_busBreakerView(*this),
     m_busView(*this) {

--- a/src/iidm/NodeTerminal.cpp
+++ b/src/iidm/NodeTerminal.cpp
@@ -18,11 +18,11 @@ namespace powsybl {
 
 namespace iidm {
 
-NodeTerminal::NodeTerminal(VariantManagerHolder& network, unsigned long node) :
-    Terminal(network),
+NodeTerminal::NodeTerminal(VoltageLevel& voltageLevel, unsigned long node) :
+    Terminal(voltageLevel),
     m_node(node),
-    m_v(network.getVariantManager().getVariantArraySize(), stdcxx::nan()),
-    m_angle(network.getVariantManager().getVariantArraySize(), stdcxx::nan()),
+    m_v(voltageLevel.getNetwork().getVariantManager().getVariantArraySize(), stdcxx::nan()),
+    m_angle(voltageLevel.getNetwork().getVariantManager().getVariantArraySize(), stdcxx::nan()),
     m_nodeBreakerView(*this),
     m_busBreakerView(*this),
     m_busView(*this) {

--- a/src/iidm/NodeTerminal.hpp
+++ b/src/iidm/NodeTerminal.hpp
@@ -44,7 +44,7 @@ public: // Terminal
     bool isConnected() const override;
 
 public:
-    NodeTerminal(VariantManagerHolder& network, unsigned long node);
+    NodeTerminal(VoltageLevel& voltageLevel, unsigned long node);
 
     NodeTerminal(const NodeTerminal& nodeTerminal) = delete;
 

--- a/src/iidm/ShuntCompensator.cpp
+++ b/src/iidm/ShuntCompensator.cpp
@@ -17,7 +17,6 @@ namespace iidm {
 ShuntCompensator::ShuntCompensator(VariantManagerHolder& network, const std::string& id, const std::string& name,
     double bPerSection, unsigned long maximumSectionCount, unsigned long currentSectionCount) :
     Injection(id, name, ConnectableType::SHUNT_COMPENSATOR),
-    m_network(network),
     m_bPerSection(checkbPerSection(*this, bPerSection)),
     m_maximumSectionCount(maximumSectionCount),
     m_currentSectionCount(network.getVariantManager().getVariantArraySize(), currentSectionCount) {
@@ -47,7 +46,7 @@ double ShuntCompensator::getCurrentB() const {
 }
 
 unsigned long ShuntCompensator::getCurrentSectionCount() const {
-    return m_currentSectionCount.at(m_network.get().getVariantIndex());
+    return m_currentSectionCount.at(getNetwork().getVariantIndex());
 }
 
 double ShuntCompensator::getMaximumB() const {
@@ -78,7 +77,7 @@ ShuntCompensator& ShuntCompensator::setbPerSection(double bPerSection) {
 
 ShuntCompensator& ShuntCompensator::setCurrentSectionCount(unsigned long currentSectionCount) {
     checkSections(*this, currentSectionCount, m_maximumSectionCount);
-    m_currentSectionCount[m_network.get().getVariantIndex()] = currentSectionCount;
+    m_currentSectionCount[getNetwork().getVariantIndex()] = currentSectionCount;
 
     return *this;
 }

--- a/src/iidm/ShuntCompensatorAdder.cpp
+++ b/src/iidm/ShuntCompensatorAdder.cpp
@@ -18,7 +18,7 @@ namespace powsybl {
 namespace iidm {
 
 ShuntCompensatorAdder::ShuntCompensatorAdder(VoltageLevel& voltageLevel) :
-    m_voltageLevel(voltageLevel) {
+    InjectionAdder(voltageLevel) {
 }
 
 ShuntCompensator& ShuntCompensatorAdder::add() {
@@ -29,13 +29,9 @@ ShuntCompensator& ShuntCompensatorAdder::add() {
     auto& shunt = getNetwork().checkAndAdd<ShuntCompensator>(std::move(ptrShunt));
 
     Terminal& terminal = shunt.addTerminal(checkAndGetTerminal());
-    m_voltageLevel.attach(terminal, false);
+    getVoltageLevel().attach(terminal, false);
 
     return shunt;
-}
-
-Network& ShuntCompensatorAdder::getNetwork() {
-    return m_voltageLevel.getNetwork();
 }
 
 const std::string& ShuntCompensatorAdder::getTypeDescription() const {

--- a/src/iidm/StaticVarCompensator.cpp
+++ b/src/iidm/StaticVarCompensator.cpp
@@ -20,7 +20,6 @@ namespace iidm {
 StaticVarCompensator::StaticVarCompensator(VariantManagerHolder& network, const std::string& id, const std::string& name,
         double bMin, double bMax, double voltageSetpoint, double reactivePowerSetpoint, const RegulationMode& regulationMode) :
     Injection(id, name, ConnectableType::STATIC_VAR_COMPENSATOR),
-    m_network(network),
     m_bMin(checkBmin(*this, bMin)),
     m_bMax(checkBmax(*this, bMax)),
     m_voltageSetpoint(network.getVariantManager().getVariantArraySize(), voltageSetpoint),
@@ -56,11 +55,11 @@ double StaticVarCompensator::getBmin() const {
 }
 
 double StaticVarCompensator::getReactivePowerSetpoint() const {
-    return m_reactivePowerSetpoint.at(m_network.get().getVariantIndex());
+    return m_reactivePowerSetpoint.at(getNetwork().getVariantIndex());
 }
 
 const StaticVarCompensator::RegulationMode& StaticVarCompensator::getRegulationMode() const {
-    return m_regulationMode.at(m_network.get().getVariantIndex());
+    return m_regulationMode.at(getNetwork().getVariantIndex());
 }
 
 const std::string& StaticVarCompensator::getTypeDescription() const {
@@ -70,7 +69,7 @@ const std::string& StaticVarCompensator::getTypeDescription() const {
 }
 
 double StaticVarCompensator::getVoltageSetpoint() const {
-    return m_voltageSetpoint.at(m_network.get().getVariantIndex());
+    return m_voltageSetpoint.at(getNetwork().getVariantIndex());
 }
 
 void StaticVarCompensator::reduceVariantArraySize(unsigned long number) {
@@ -95,21 +94,21 @@ StaticVarCompensator& StaticVarCompensator::setBmin(double bMin) {
 
 StaticVarCompensator& StaticVarCompensator::setReactivePowerSetpoint(double reactivePowerSetpoint) {
     checkSvcRegulator(*this, getVoltageSetpoint(), reactivePowerSetpoint, getRegulationMode());
-    m_reactivePowerSetpoint[m_network.get().getVariantIndex()] = reactivePowerSetpoint;
+    m_reactivePowerSetpoint[getNetwork().getVariantIndex()] = reactivePowerSetpoint;
 
     return *this;
 }
 
 StaticVarCompensator& StaticVarCompensator::setRegulationMode(const RegulationMode& regulationMode) {
     checkSvcRegulator(*this, getVoltageSetpoint(), getReactivePowerSetpoint(), regulationMode);
-    m_regulationMode[m_network.get().getVariantIndex()] = regulationMode;
+    m_regulationMode[getNetwork().getVariantIndex()] = regulationMode;
 
     return *this;
 }
 
 StaticVarCompensator& StaticVarCompensator::setVoltageSetpoint(double voltageSetpoint) {
     checkSvcRegulator(*this, voltageSetpoint, getReactivePowerSetpoint(), getRegulationMode());
-    m_voltageSetpoint[m_network.get().getVariantIndex()] = voltageSetpoint;
+    m_voltageSetpoint[getNetwork().getVariantIndex()] = voltageSetpoint;
 
     return *this;
 }

--- a/src/iidm/StaticVarCompensatorAdder.cpp
+++ b/src/iidm/StaticVarCompensatorAdder.cpp
@@ -18,7 +18,7 @@ namespace powsybl {
 namespace iidm {
 
 StaticVarCompensatorAdder::StaticVarCompensatorAdder(VoltageLevel& voltageLevel) :
-    m_voltageLevel(voltageLevel) {
+    InjectionAdder(voltageLevel) {
 }
 
 StaticVarCompensator& StaticVarCompensatorAdder::add() {
@@ -30,13 +30,9 @@ StaticVarCompensator& StaticVarCompensatorAdder::add() {
     auto& svc = getNetwork().checkAndAdd<StaticVarCompensator>(std::move(ptrSvc));
 
     Terminal& terminal = svc.addTerminal(checkAndGetTerminal());
-    m_voltageLevel.attach(terminal, false);
+    getVoltageLevel().attach(terminal, false);
 
     return svc;
-}
-
-Network& StaticVarCompensatorAdder::getNetwork() {
-    return m_voltageLevel.getNetwork();
 }
 
 const std::string& StaticVarCompensatorAdder::getTypeDescription() const {

--- a/src/iidm/Substation.cpp
+++ b/src/iidm/Substation.cpp
@@ -144,6 +144,10 @@ Substation& Substation::setCountry(const stdcxx::optional<Country>& country) {
     return *this;
 }
 
+void Substation::setNetworkRef(Network& network) {
+    m_network.set(network);
+}
+
 Substation& Substation::setTso(const std::string& tso) {
     m_tso = tso;
     return *this;

--- a/src/iidm/TerminalBuilder.cpp
+++ b/src/iidm/TerminalBuilder.cpp
@@ -17,8 +17,8 @@ namespace powsybl {
 
 namespace iidm {
 
-TerminalBuilder::TerminalBuilder(Network& network, Validable& validable) :
-    m_network(network),
+TerminalBuilder::TerminalBuilder(VoltageLevel& voltageLevel, Validable& validable) :
+    m_voltageLevel(voltageLevel),
     m_validable(validable) {
 
 }
@@ -47,9 +47,9 @@ std::unique_ptr<Terminal> TerminalBuilder::build() {
             throw ValidationException(m_validable, "connectable bus is not set");
         }
 
-        ptrTerminal = createBusTerminal(m_network, connectionBus, !m_bus.empty());
+        ptrTerminal = createBusTerminal(m_voltageLevel, connectionBus, !m_bus.empty());
     } else {
-        ptrTerminal = createNodeTerminal(m_network, *m_node);
+        ptrTerminal = createNodeTerminal(m_voltageLevel, *m_node);
     }
 
     return ptrTerminal;

--- a/src/iidm/ThreeWindingsTransformerAdder.cpp
+++ b/src/iidm/ThreeWindingsTransformerAdder.cpp
@@ -36,8 +36,8 @@ std::unique_ptr<ThreeWindingsTransformer::Leg> ThreeWindingsTransformerAdder::Le
     return stdcxx::make_unique<ThreeWindingsTransformer::Leg>(m_legNumber, m_r, m_x, m_g, m_b, m_ratedU);
 }
 
-std::unique_ptr<Terminal> ThreeWindingsTransformerAdder::LegAdder::checkAndGetTerminal() {
-    return TerminalBuilder(m_parent.getNetwork(), *this)
+std::unique_ptr<Terminal> ThreeWindingsTransformerAdder::LegAdder::checkAndGetTerminal(VoltageLevel& voltageLevel) {
+    return TerminalBuilder(voltageLevel, *this)
         .setNode(m_node)
         .setBus(m_bus)
         .setConnectableBus(m_connectableBus)
@@ -145,15 +145,15 @@ ThreeWindingsTransformerAdder::ThreeWindingsTransformerAdder(Substation& substat
 ThreeWindingsTransformer& ThreeWindingsTransformerAdder::add() {
     std::unique_ptr<ThreeWindingsTransformer::Leg> ptrLeg1 = m_adder1.checkAndGetLeg();
     VoltageLevel& voltageLevel1 = m_adder1.checkAndGetVoltageLevel();
-    std::unique_ptr<Terminal> ptrTerminal1 = m_adder1.checkAndGetTerminal();
+    std::unique_ptr<Terminal> ptrTerminal1 = m_adder1.checkAndGetTerminal(voltageLevel1);
 
     std::unique_ptr<ThreeWindingsTransformer::Leg> ptrLeg2 = m_adder2.checkAndGetLeg();
     VoltageLevel& voltageLevel2 = m_adder2.checkAndGetVoltageLevel();
-    std::unique_ptr<Terminal> ptrTerminal2 = m_adder2.checkAndGetTerminal();
+    std::unique_ptr<Terminal> ptrTerminal2 = m_adder2.checkAndGetTerminal(voltageLevel2);
 
     std::unique_ptr<ThreeWindingsTransformer::Leg> ptrLeg3 = m_adder3.checkAndGetLeg();
     VoltageLevel& voltageLevel3 = m_adder3.checkAndGetVoltageLevel();
-    std::unique_ptr<Terminal> ptrTerminal3 = m_adder3.checkAndGetTerminal();
+    std::unique_ptr<Terminal> ptrTerminal3 = m_adder3.checkAndGetTerminal(voltageLevel3);
 
     // check that the 3 windings transformer is attachable on the 3 sides
     voltageLevel1.attach(*ptrTerminal1, true);

--- a/src/iidm/TieLineAdder.cpp
+++ b/src/iidm/TieLineAdder.cpp
@@ -25,8 +25,8 @@ TieLineAdder::TieLineAdder(Network& network) :
 TieLine& TieLineAdder::add() {
     VoltageLevel& voltageLevel1 = checkAndGetVoltageLevel1();
     VoltageLevel& voltageLevel2 = checkAndGetVoltageLevel2();
-    std::unique_ptr<Terminal> ptrTerminal1 = checkAndGetTerminal1();
-    std::unique_ptr<Terminal> ptrTerminal2 = checkAndGetTerminal2();
+    std::unique_ptr<Terminal> ptrTerminal1 = checkAndGetTerminal1(voltageLevel1);
+    std::unique_ptr<Terminal> ptrTerminal2 = checkAndGetTerminal2(voltageLevel2);
 
     checkNotEmpty(*this, m_ucteXnodeCode, "ucteXnodeCode is not set");
     checkHalf(*this, m_half1, 1);

--- a/src/iidm/TwoWindingsTransformerAdder.cpp
+++ b/src/iidm/TwoWindingsTransformerAdder.cpp
@@ -29,8 +29,8 @@ TwoWindingsTransformer& TwoWindingsTransformerAdder::add() {
         throw ValidationException(*this, logging::format("the 2 windings of the transformer shall belong to the substation '%1%' ('%2%', '%3%')",
                                                          m_substation.getId(), voltageLevel1.getSubstation().getId(), voltageLevel2.getSubstation().getId()));
     }
-    std::unique_ptr<Terminal> ptrTerminal1 = checkAndGetTerminal1();
-    std::unique_ptr<Terminal> ptrTerminal2 = checkAndGetTerminal2();
+    std::unique_ptr<Terminal> ptrTerminal1 = checkAndGetTerminal1(voltageLevel1);
+    std::unique_ptr<Terminal> ptrTerminal2 = checkAndGetTerminal2(voltageLevel2);
 
     checkR(*this, m_r);
     checkX(*this, m_x);

--- a/src/iidm/VariantArray.hpp
+++ b/src/iidm/VariantArray.hpp
@@ -8,11 +8,9 @@
 #ifndef POWSYBL_IIDM_VARIANTARRAY_HPP
 #define POWSYBL_IIDM_VARIANTARRAY_HPP
 
+#include <functional>
 #include <memory>
-
-#include <powsybl/iidm/MultiVariantObject.hpp>
-#include <powsybl/iidm/VariantManagerHolder.hpp>
-#include <powsybl/stdcxx/reference_wrapper.hpp>
+#include <set>
 
 #include "Variant.hpp"
 
@@ -20,13 +18,15 @@ namespace powsybl {
 
 namespace iidm {
 
+class VoltageLevel;
+
 template <typename T>
 class VariantArray {
 public:
     using VariantFactory = std::function<std::unique_ptr<T>()>;
 
 public:
-    VariantArray(VariantManagerHolder& variantManagerHolder, const VariantFactory& variantFactory);
+    VariantArray(VoltageLevel& voltageLevel, const VariantFactory& variantFactory);
 
     ~VariantArray() noexcept = default;
 
@@ -45,7 +45,7 @@ public:
     void reduceVariantArraySize(unsigned long number);
 
 private:
-    VariantManagerHolder& m_variantManagerHolder;
+    VoltageLevel& m_voltageLevel;
 
     std::vector<std::unique_ptr<T> > m_variants;
 };

--- a/src/iidm/VariantArray.hxx
+++ b/src/iidm/VariantArray.hxx
@@ -17,10 +17,10 @@ namespace powsybl {
 namespace iidm {
 
 template <typename T>
-VariantArray<T>::VariantArray(VariantManagerHolder& variantManagerHolder, const VariantFactory& variantFactory) :
-    m_variantManagerHolder(variantManagerHolder) {
+VariantArray<T>::VariantArray(VoltageLevel& voltageLevel, const VariantFactory& variantFactory) :
+    m_voltageLevel(voltageLevel) {
 
-    const auto& variantManager = variantManagerHolder.getVariantManager();
+    const auto& variantManager = voltageLevel.getNetwork().getVariantManager();
     m_variants.resize(variantManager.getVariantArraySize());
     for (unsigned long i : variantManager.getVariantIndices()) {
         m_variants.at(i) = variantFactory();
@@ -53,12 +53,12 @@ void VariantArray<T>::extendVariantArraySize(unsigned long /*initVariantArraySiz
 
 template <typename T>
 const T& VariantArray<T>::get() const {
-    return *m_variants.at(m_variantManagerHolder.getVariantIndex());
+    return *m_variants.at(m_voltageLevel.getNetwork().getVariantIndex());
 }
 
 template <typename T>
 T& VariantArray<T>::get() {
-    return *m_variants.at(m_variantManagerHolder.getVariantIndex());
+    return *m_variants.at(m_voltageLevel.getNetwork().getVariantIndex());
 }
 
 template <typename T>

--- a/src/iidm/VariantManager.cpp
+++ b/src/iidm/VariantManager.cpp
@@ -29,8 +29,8 @@ VariantManager::VariantManager(Network& network) :
     m_variantsById.insert(std::make_pair(getInitialVariantId(), INITIAL_VARIANT_INDEX));
 }
 
-VariantManager::VariantManager(VariantManager&& variantManager) noexcept :
-    m_network(variantManager.m_network),
+VariantManager::VariantManager(Network& network, VariantManager&& variantManager) noexcept :
+    m_network(network),
     m_variantContext(std::move(variantManager.m_variantContext)),
     m_variantsById(std::move(variantManager.m_variantsById)),
     m_unusedIndexes(std::move(variantManager.m_unusedIndexes)),

--- a/test/iidm/NetworkTest.cpp
+++ b/test/iidm/NetworkTest.cpp
@@ -328,6 +328,23 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_CHECK_EQUAL(caseDate, network.getCaseDate());
 }
 
+BOOST_AUTO_TEST_CASE(move) {
+    Network n1("id", "test");
+    Substation& s1 = n1.newSubstation()
+        .setId("S1")
+        .add();
+
+    n1.getVariantManager().cloneVariant(VariantManager::getInitialVariantId(), "variant2");
+    n1.getVariantManager().setWorkingVariant("variant2");
+
+    Network n2 = std::move(n1);
+
+    BOOST_TEST(stdcxx::areSame(n2, s1.getNetwork()));
+    BOOST_TEST(1, n2.getSubstationCount());
+    BOOST_TEST(2, n2.getVariantManager().getVariantArraySize());
+    BOOST_TEST("variant2", n2.getVariantManager().getWorkingVariantId());
+}
+
 BOOST_AUTO_TEST_CASE(forecastDistance) {
     Network network("id", "test");
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The move constructor of a network doesn't update the back references to all identifiables


**What is the new behavior (if this is a feature change)?**
The back reference is updated at the end of the move constructor


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
