### PR TITLE
Refactor to do not hide setLossFactor

### DIFF
--- a/include/powsybl/iidm/HvdcConverterStation.hpp
+++ b/include/powsybl/iidm/HvdcConverterStation.hpp
@@ -35,10 +35,10 @@ public:
 
     double getLossFactor() const;
 
+    virtual HvdcConverterStation& setLossFactor(double lossFactor);
+
 protected:
     HvdcConverterStation(const std::string& id, const std::string& name, double lossFactor);
-
-    void setLossFactor(double lossFactor);
 
 private:
     void setHvdcLine(const stdcxx::Reference<HvdcLine>& hvdcLine);

--- a/include/powsybl/iidm/LccConverterStation.hpp
+++ b/include/powsybl/iidm/LccConverterStation.hpp
@@ -18,14 +18,14 @@ class LccConverterStation : public HvdcConverterStation {
 public: // HvdcConverterStation
     HvdcConverterStation::HvdcType getHvdcType() const override;
 
+    LccConverterStation& setLossFactor(double lossFactor) override;
+
 public:
     LccConverterStation(const std::string& id, const std::string& name, double lossFactor, double powerFactor);
 
     ~LccConverterStation() noexcept override = default;
 
     double getPowerFactor() const;
-
-    LccConverterStation& setLossFactor(double lossFactor);
 
     LccConverterStation& setPowerFactor(double powerFactor);
 

--- a/include/powsybl/iidm/VscConverterStation.hpp
+++ b/include/powsybl/iidm/VscConverterStation.hpp
@@ -19,6 +19,8 @@ class VscConverterStation : public HvdcConverterStation, public ReactiveLimitsHo
 public: // HvdcConverterStation
     HvdcType getHvdcType() const override;
 
+    VscConverterStation& setLossFactor(double lossFactor) override;
+
 public:
     VscConverterStation(VariantManagerHolder& network, const std::string& id, const std::string& name, double lossFactor, bool voltageRegulatorOn, double reactivePowerSetpoint, double voltageSetpoint);
 
@@ -29,8 +31,6 @@ public:
     double getVoltageSetpoint() const;
 
     bool isVoltageRegulatorOn() const;
-
-    VscConverterStation& setLossFactor(double lossFactor);
 
     VscConverterStation& setReactivePowerSetpoint(double reactivePowerSetpoint);
 

--- a/src/iidm/HvdcConverterStation.cpp
+++ b/src/iidm/HvdcConverterStation.cpp
@@ -35,8 +35,9 @@ void HvdcConverterStation::setHvdcLine(const stdcxx::Reference<HvdcLine>& hvdcLi
     m_hvdcLine = hvdcLine;
 }
 
-void HvdcConverterStation::setLossFactor(double lossFactor) {
+HvdcConverterStation& HvdcConverterStation::setLossFactor(double lossFactor) {
     m_lossFactor = checkLossFactor(*this, lossFactor);
+    return *this;
 }
 
 }  // namespace iidm

--- a/src/iidm/LccConverterStation.cpp
+++ b/src/iidm/LccConverterStation.cpp
@@ -33,8 +33,7 @@ const std::string& LccConverterStation::getTypeDescription() const {
 }
 
 LccConverterStation& LccConverterStation::setLossFactor(double lossFactor) {
-    HvdcConverterStation::setLossFactor(lossFactor);
-    return *this;
+    return dynamic_cast<LccConverterStation&>(HvdcConverterStation::setLossFactor(lossFactor));
 }
 
 LccConverterStation& LccConverterStation::setPowerFactor(double powerFactor) {

--- a/src/iidm/VscConverterStation.cpp
+++ b/src/iidm/VscConverterStation.cpp
@@ -72,8 +72,7 @@ void VscConverterStation::reduceVariantArraySize(unsigned long number) {
 }
 
 VscConverterStation& VscConverterStation::setLossFactor(double lossFactor) {
-    HvdcConverterStation::setLossFactor(lossFactor);
-    return *this;
+    return dynamic_cast<VscConverterStation&>(HvdcConverterStation::setLossFactor(lossFactor));
 }
 
 VscConverterStation& VscConverterStation::setReactivePowerSetpoint(double reactivePowerSetpoint) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
The HvdcConverterStation::setLossFactor method is hidden in the subcalsses.


**What is the new behavior (if this is a feature change)?**
As the return type is polymorphic, it's possible to override this method by changing the return type.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
