### PR TITLE
Fix BusbarSection implementation to be compliant with Java implementation

### DIFF
--- a/include/powsybl/iidm/BusbarSection.hpp
+++ b/include/powsybl/iidm/BusbarSection.hpp
@@ -9,8 +9,6 @@
 #define POWSYBL_IIDM_BUSBARSECTION_HPP
 
 #include <powsybl/iidm/Injection.hpp>
-#include <powsybl/iidm/VariantManagerHolder.hpp>
-#include <powsybl/stdcxx/reference_wrapper.hpp>
 
 namespace powsybl {
 
@@ -18,7 +16,7 @@ namespace iidm {
 
 class BusbarSection : public Injection {
 public:
-    BusbarSection(VariantManagerHolder& network, const std::string& id, const std::string& name);
+    BusbarSection(const std::string& id, const std::string& name);
 
     ~BusbarSection() noexcept override = default;
 
@@ -28,9 +26,6 @@ public:
 
 private: // Identifiable
     const std::string& getTypeDescription() const override;
-
-private:
-    stdcxx::Reference<VariantManagerHolder> m_network;
 };
 
 }  // namespace iidm

--- a/src/iidm/BusbarSection.cpp
+++ b/src/iidm/BusbarSection.cpp
@@ -13,10 +13,8 @@ namespace powsybl {
 
 namespace iidm {
 
-BusbarSection::BusbarSection(VariantManagerHolder& network, const std::string& id, const std::string& name) :
-    Injection(id, name, ConnectableType::BUSBAR_SECTION),
-    m_network(network) {
-
+BusbarSection::BusbarSection(const std::string& id, const std::string& name) :
+    Injection(id, name, ConnectableType::BUSBAR_SECTION) {
 }
 
 double BusbarSection::getAngle() const {

--- a/src/iidm/BusbarSectionAdder.cpp
+++ b/src/iidm/BusbarSectionAdder.cpp
@@ -25,7 +25,7 @@ BusbarSectionAdder::BusbarSectionAdder(NodeBreakerVoltageLevel& voltageLevel) :
 BusbarSection& BusbarSectionAdder::add() {
     checkOptional(*this, m_node, "Node is not set");
 
-    std::unique_ptr<BusbarSection> ptrBusbarSection = stdcxx::make_unique<BusbarSection>(getNetwork(), getId(), getName());
+    std::unique_ptr<BusbarSection> ptrBusbarSection = stdcxx::make_unique<BusbarSection>(getId(), getName());
     BusbarSection& busbarSection = getNetwork().checkAndAdd(std::move(ptrBusbarSection));
 
     Terminal& terminal = busbarSection.addTerminal(createNodeTerminal(getNetwork(), *m_node));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
The BusbarSection handles a network reference, whereas it's not the case in Java.


**What is the new behavior (if this is a feature change)?**
The reference to the network has been removed.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
