### PR TITLE
Network identifiable

### DIFF
--- a/include/powsybl/iidm/Bus.hpp
+++ b/include/powsybl/iidm/Bus.hpp
@@ -34,6 +34,11 @@ class VoltageLevel;
 class VscConverterStation;
 
 class Bus : public Identifiable {
+public:  // Identifiable
+    const Network& getNetwork() const override;
+
+    Network& getNetwork() override;
+
 public:
     ~Bus() noexcept override = default;
 
@@ -87,7 +92,9 @@ public:
 
     virtual double getV() const = 0;
 
-    virtual VoltageLevel& getVoltageLevel() const = 0;
+    virtual const VoltageLevel& getVoltageLevel() const = 0;
+
+    virtual VoltageLevel& getVoltageLevel() = 0;
 
     stdcxx::const_range<VscConverterStation> getVscConverterStations() const;
 

--- a/include/powsybl/iidm/Connectable.hpp
+++ b/include/powsybl/iidm/Connectable.hpp
@@ -23,6 +23,11 @@ namespace iidm {
 class Network;
 
 class Connectable : public Identifiable, public MultiVariantObject {
+public:  // Identifiable
+    const Network& getNetwork() const override;
+
+    Network& getNetwork() override;
+
 public:
     ~Connectable() noexcept override = default;
 
@@ -45,10 +50,6 @@ protected: // MultiVariantObject
 
 protected:
     Connectable(const std::string& id, const std::string& name, const ConnectableType& connectableType);
-
-    const Network& getNetwork() const;
-
-    Network& getNetwork();
 
     const Terminal& getTerminal(unsigned long index) const;
 

--- a/include/powsybl/iidm/HvdcLine.hpp
+++ b/include/powsybl/iidm/HvdcLine.hpp
@@ -34,6 +34,11 @@ public:
         TWO
     };
 
+public:  // Identifiable
+    const Network& getNetwork() const override;
+
+    Network& getNetwork() override;
+
 public:
     HvdcLine(Network& network, const std::string& id, const std::string& name, double r, double nominalVoltage, double maxP,
              const ConvertersMode& convertersMode, double activePowerSetpoint, HvdcConverterStation& converterStation1, HvdcConverterStation& converterStation2);
@@ -57,10 +62,6 @@ public:
     stdcxx::Reference<HvdcConverterStation> getConverterStation2();
 
     double getMaxP() const;
-
-    const Network& getNetwork() const;
-
-    Network& getNetwork();
 
     double getNominalVoltage() const;
 

--- a/include/powsybl/iidm/Identifiable.hpp
+++ b/include/powsybl/iidm/Identifiable.hpp
@@ -20,6 +20,8 @@ namespace powsybl {
 
 namespace iidm {
 
+class Network;
+
 class Identifiable : public virtual Validable, public Extendable {
 public: // Validable
     std::string getMessageHeader() const override;
@@ -38,6 +40,10 @@ public:
     const std::string& getId() const;
 
     const std::string& getName() const;
+
+    virtual const Network& getNetwork() const = 0;
+
+    virtual Network& getNetwork() = 0;
 
     bool hasProperty() const;
 

--- a/include/powsybl/iidm/Network.hpp
+++ b/include/powsybl/iidm/Network.hpp
@@ -69,6 +69,11 @@ public:
 
     static std::unique_ptr<converter::Anonymizer> writeXml(std::ostream& ostream, const Network& network, const converter::ExportOptions& options);
 
+public:  // Identifiable
+    const Network& getNetwork() const override;
+
+    Network& getNetwork() override;
+
 public: // VariantManagerHolder
     unsigned long getVariantIndex() const override;
 

--- a/include/powsybl/iidm/Substation.hpp
+++ b/include/powsybl/iidm/Substation.hpp
@@ -31,6 +31,11 @@ class TwoWindingsTransformer;
 class TwoWindingsTransformerAdder;
 
 class Substation : public Container {
+public:  // Identifiable
+    const Network& getNetwork() const override;
+
+    Network& getNetwork() override;
+
 public:
     Substation(Network& network, const std::string& id, const std::string& name, const stdcxx::optional<Country>& country, const std::string& tso, const std::set<std::string>& geographicalTags);
 
@@ -41,10 +46,6 @@ public:
     const stdcxx::optional<Country>& getCountry() const;
 
     const std::set<std::string>& getGeographicalTags() const;
-
-    const Network& getNetwork() const;
-
-    Network& getNetwork();
 
     unsigned long getThreeWindingsTransformerCount() const;
 

--- a/include/powsybl/iidm/Switch.hpp
+++ b/include/powsybl/iidm/Switch.hpp
@@ -22,6 +22,11 @@ namespace iidm {
 class VoltageLevel;
 
 class Switch : public Identifiable, public MultiVariantObject {
+public:  // Identifiable
+    const Network& getNetwork() const override;
+
+    Network& getNetwork() override;
+
 public:
     Switch(VoltageLevel& voltageLevel, const std::string& id, const std::string& name, SwitchKind kind, bool open,
            bool retained, bool fictitious);
@@ -30,7 +35,9 @@ public:
 
     SwitchKind getKind() const;
 
-    VoltageLevel& getVoltageLevel() const;
+    const VoltageLevel& getVoltageLevel() const;
+
+    VoltageLevel& getVoltageLevel();
 
     bool isFictitious() const;
 

--- a/include/powsybl/iidm/VoltageLevel.hpp
+++ b/include/powsybl/iidm/VoltageLevel.hpp
@@ -49,6 +49,11 @@ public:
 
     using NodeBreakerView = voltage_level::NodeBreakerView;
 
+public:  // Identifiable
+    const Network& getNetwork() const override;
+
+    Network& getNetwork() override;
+
 public:
     ~VoltageLevel() noexcept override = default;
 
@@ -120,10 +125,6 @@ public:
     stdcxx::range<Load> getLoads();
 
     double getLowVoltageLimit() const;
-
-    const Network& getNetwork() const;
-
-    Network& getNetwork();
 
     virtual const NodeBreakerView& getNodeBreakerView() const = 0;
 

--- a/src/iidm/Bus.cpp
+++ b/src/iidm/Bus.cpp
@@ -89,6 +89,14 @@ stdcxx::range<Load> Bus::getLoads() {
     return getAll<Load>();
 }
 
+const Network& Bus::getNetwork() const {
+    return getVoltageLevel().getNetwork();
+}
+
+Network& Bus::getNetwork() {
+    return getVoltageLevel().getNetwork();
+}
+
 stdcxx::const_range<ShuntCompensator> Bus::getShuntCompensators() const {
     return getAll<ShuntCompensator>();
 }

--- a/src/iidm/CalculatedBus.cpp
+++ b/src/iidm/CalculatedBus.cpp
@@ -83,7 +83,11 @@ double CalculatedBus::getV() const {
     return static_cast<bool>(m_terminalRef) ? m_terminalRef.get().getV() : stdcxx::nan();
 }
 
-VoltageLevel& CalculatedBus::getVoltageLevel() const {
+const VoltageLevel& CalculatedBus::getVoltageLevel() const {
+    return m_voltageLevel;
+}
+
+VoltageLevel& CalculatedBus::getVoltageLevel() {
     return m_voltageLevel;
 }
 

--- a/src/iidm/CalculatedBus.hpp
+++ b/src/iidm/CalculatedBus.hpp
@@ -36,7 +36,9 @@ public: // Bus
 
     double getV() const override;
 
-    VoltageLevel& getVoltageLevel() const override;
+    const VoltageLevel& getVoltageLevel() const override;
+
+    VoltageLevel& getVoltageLevel() override;
 
     Bus& setAngle(double angle) override;
 

--- a/src/iidm/ConfiguredBus.cpp
+++ b/src/iidm/ConfiguredBus.cpp
@@ -94,14 +94,6 @@ stdcxx::range<Terminal> ConfiguredBus::getConnectedTerminals() {
     return busTerminals | boost::adaptors::transformed(mapper) | boost::adaptors::filtered(filter);
 }
 
-const Network& ConfiguredBus::getNetwork() const {
-    return m_voltageLevel.get().getNetwork();
-}
-
-Network& ConfiguredBus::getNetwork() {
-    return m_voltageLevel.get().getNetwork();
-}
-
 unsigned long ConfiguredBus::getTerminalCount() const {
     return m_terminals[getNetwork().getVariantIndex()].size();
 }
@@ -126,7 +118,11 @@ double ConfiguredBus::getV() const {
     return m_v[getNetwork().getVariantIndex()];
 }
 
-VoltageLevel& ConfiguredBus::getVoltageLevel() const {
+const VoltageLevel& ConfiguredBus::getVoltageLevel() const {
+    return m_voltageLevel;
+}
+
+VoltageLevel& ConfiguredBus::getVoltageLevel() {
     return m_voltageLevel;
 }
 

--- a/src/iidm/ConfiguredBus.hpp
+++ b/src/iidm/ConfiguredBus.hpp
@@ -37,7 +37,9 @@ public: // Bus
 
     double getV() const override;
 
-    VoltageLevel& getVoltageLevel() const override;
+    const VoltageLevel& getVoltageLevel() const override;
+
+    VoltageLevel& getVoltageLevel() override;
 
     Bus& setAngle(double angle) override;
 
@@ -49,10 +51,6 @@ public:
     ~ConfiguredBus() noexcept override = default;
 
     void addTerminal(BusTerminal& terminal);
-
-    const Network& getNetwork() const;
-
-    Network& getNetwork();
 
     unsigned long getTerminalCount() const;
 

--- a/src/iidm/MergedBus.cpp
+++ b/src/iidm/MergedBus.cpp
@@ -14,6 +14,7 @@
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/Terminal.hpp>
+#include <powsybl/iidm/VoltageLevel.hpp>
 #include <powsybl/stdcxx/math.hpp>
 
 namespace powsybl {
@@ -90,11 +91,15 @@ double MergedBus::getV() const {
     return stdcxx::nan();
 }
 
-VoltageLevel& MergedBus::getVoltageLevel() const {
+const VoltageLevel& MergedBus::getVoltageLevel() const {
     checkValidity();
     assert(!m_buses.empty());
 
     return m_buses.begin()->get().getVoltageLevel();
+}
+
+VoltageLevel& MergedBus::getVoltageLevel() {
+    return const_cast<VoltageLevel&>(static_cast<const MergedBus*>(this)->getVoltageLevel());
 }
 
 void MergedBus::invalidate() {

--- a/src/iidm/MergedBus.hpp
+++ b/src/iidm/MergedBus.hpp
@@ -41,7 +41,9 @@ public: // Bus
 
     double getV() const override;
 
-    VoltageLevel& getVoltageLevel() const override;
+    const VoltageLevel& getVoltageLevel() const override;
+
+    VoltageLevel& getVoltageLevel() override;
 
     Bus& setAngle(double angle) override;
 
@@ -69,7 +71,7 @@ private:
 private:
     BusSet m_buses;
 
-    bool m_valid{true};
+    bool m_valid = true;
 
 };
 

--- a/src/iidm/Network.cpp
+++ b/src/iidm/Network.cpp
@@ -353,6 +353,14 @@ stdcxx::range<Load> Network::getLoads() {
     return m_networkIndex.getAll<Load>();
 }
 
+const Network& Network::getNetwork() const {
+    return *this;
+}
+
+Network& Network::getNetwork() {
+    return *this;
+}
+
 const ShuntCompensator& Network::getShuntCompensator(const std::string& id) const {
     return get<ShuntCompensator>(id);
 }

--- a/src/iidm/Switch.cpp
+++ b/src/iidm/Switch.cpp
@@ -43,13 +43,25 @@ SwitchKind Switch::getKind() const {
     return m_kind;
 }
 
+const Network& Switch::getNetwork() const {
+    return getVoltageLevel().getNetwork();
+}
+
+Network& Switch::getNetwork() {
+    return getVoltageLevel().getNetwork();
+}
+
 const std::string& Switch::getTypeDescription() const {
     static std::string s_typeDescription = "Switch";
 
     return s_typeDescription;
 }
 
-VoltageLevel& Switch::getVoltageLevel() const {
+const VoltageLevel& Switch::getVoltageLevel() const {
+    return m_voltageLevel.get();
+}
+
+VoltageLevel& Switch::getVoltageLevel() {
     return m_voltageLevel.get();
 }
 

--- a/test/iidm/BusBreakerVoltageLevelTest.cpp
+++ b/test/iidm/BusBreakerVoltageLevelTest.cpp
@@ -38,9 +38,12 @@ BOOST_AUTO_TEST_CASE(BusTest) {
         .setId("BUS")
         .setName("BUS_NAME")
         .add();
+    const auto& cBus = bus;
+
     BOOST_CHECK_EQUAL("BUS", bus.getId());
     BOOST_CHECK_EQUAL("BUS_NAME", bus.getName());
     BOOST_TEST(stdcxx::areSame(voltageLevel, bus.getVoltageLevel()));
+    BOOST_TEST(stdcxx::areSame(voltageLevel, cBus.getVoltageLevel()));
     BOOST_CHECK_EQUAL(0UL, bus.getConnectedTerminalCount());
     BOOST_TEST(std::isnan(bus.getV()));
     BOOST_TEST(std::isnan(bus.getAngle()));

--- a/test/iidm/NetworkTest.cpp
+++ b/test/iidm/NetworkTest.cpp
@@ -316,8 +316,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
     POWSYBL_ASSERT_THROW(Network("", ""), PowsyblException, "Invalid id");
     POWSYBL_ASSERT_THROW(Network("id", ""), ValidationException, "Network 'id': Source format is empty");
 
-    Network n("id", "sourceFormat");
-    Network network(std::move(n));
+    Network network("id", "sourceFormat");
     BOOST_CHECK_EQUAL("id", network.getId());
     BOOST_CHECK_EQUAL("id", network.getName());
     BOOST_CHECK_EQUAL("sourceFormat", network.getSourceFormat());
@@ -326,6 +325,10 @@ BOOST_AUTO_TEST_CASE(constructor) {
     stdcxx::DateTime caseDate = stdcxx::DateTime::parse("2013-01-15T18:45:00.000+01:00");
     network.setCaseDate(caseDate);
     BOOST_CHECK_EQUAL(caseDate, network.getCaseDate());
+
+    const auto& cNetwork = network;
+    BOOST_TEST(stdcxx::areSame(network, network.getNetwork()));
+    BOOST_TEST(stdcxx::areSame(cNetwork, cNetwork.getNetwork()));
 }
 
 BOOST_AUTO_TEST_CASE(move) {

--- a/test/iidm/NodeBreakerVoltageLevelTest.cpp
+++ b/test/iidm/NodeBreakerVoltageLevelTest.cpp
@@ -272,6 +272,10 @@ BOOST_AUTO_TEST_CASE(switches) {
     const Network& cNetwork = network;
     BOOST_TEST(stdcxx::areSame(breaker, cNetwork.getSwitch("BK")));
 
+    const auto& cBreaker = breaker;
+    BOOST_TEST(stdcxx::areSame(network, breaker.getNetwork()));
+    BOOST_TEST(stdcxx::areSame(cNetwork, cBreaker.getNetwork()));
+
     BOOST_CHECK_EQUAL(1UL, boost::size(network.getSwitches()));
     BOOST_CHECK_EQUAL(1UL, boost::size(cNetwork.getSwitches()));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#51 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature



**What is the current behavior?** *(You can also link to an open issue here)*
There is no way to get the network instance directly from an identifiable.


**What is the new behavior (if this is a feature change)?**
The getNetwork() method is added to the identifiable class.
Also fix the inconsistencies in getVoltageLevel() return types.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
