### PR TITLE
Allow to write IIDM-XML files in previous versions

### DIFF
--- a/include/powsybl/iidm/converter/Constants.hpp
+++ b/include/powsybl/iidm/converter/Constants.hpp
@@ -67,7 +67,6 @@ static const char* const HIGH_VOLTAGE_LIMIT = "highVoltageLimit";
 static const char* const HVDC_LINE = "hvdcLine";
 static const char* const ID = "id";
 static const char* const ID_ = "id_";
-static const char* const IIDM_PREFIX = "iidm";
 static const char* const INTERNAL_CONNECTION = "internalConnection";
 static const char* const KIND = "kind";
 static const char* const LCC_CONVERTER_STATION = "lccConverterStation";

--- a/include/powsybl/iidm/converter/xml/CurrentLimitsXml.hpp
+++ b/include/powsybl/iidm/converter/xml/CurrentLimitsXml.hpp
@@ -13,7 +13,7 @@
 #include <boost/optional.hpp>
 
 #include <powsybl/iidm/CurrentLimitsAdder.hpp>
-#include <powsybl/iidm/converter/Constants.hpp>
+#include <powsybl/iidm/converter/xml/IidmXmlVersion.hpp>
 
 namespace powsybl {
 
@@ -35,7 +35,7 @@ public:
     template <typename S, typename O>
     static void readCurrentLimits(CurrentLimitsAdder<S, O>& adder, const powsybl::xml::XmlStreamReader& reader, const boost::optional<int>& index = boost::optional<int>());
 
-    static void writeCurrentLimits(const CurrentLimits& limits, powsybl::xml::XmlStreamWriter& writer, const boost::optional<int>& index = boost::optional<int>(), const std::string& nsPrefix = IIDM_PREFIX);
+    static void writeCurrentLimits(const CurrentLimits& limits, powsybl::xml::XmlStreamWriter& writer, const std::string& nsPrefix, const IidmXmlVersion& version, const boost::optional<int>& index = boost::optional<int>());
 };
 
 }  // namespace xml

--- a/include/powsybl/iidm/converter/xml/IidmXmlVersion.hpp
+++ b/include/powsybl/iidm/converter/xml/IidmXmlVersion.hpp
@@ -22,8 +22,6 @@ namespace xml {
 
 class IidmXmlVersion {
 public:
-    static const std::vector<std::reference_wrapper<const IidmXmlVersion>>& all();
-
     /**
      * The current IIDM version supported by this version of the project
      */
@@ -41,6 +39,13 @@ public:
 
 public:
     /**
+     * Return the list of all supported XIIDM versions
+     *
+     * @return the supported versions
+     */
+    static const std::vector<std::reference_wrapper<const IidmXmlVersion>>& all();
+
+    /**
      * Get an {@link IidmXmlVersion} instance from a namespace URI
      *
      * @param namespaceURI the namespace URI of the searched IIDM version
@@ -50,6 +55,13 @@ public:
      * @throw a {@link PowsyblException} if the namespace URI is associated to no version
      */
     static const IidmXmlVersion& fromNamespaceURI(const std::string& namespaceURI);
+
+    /**
+     * Get the default XIIDM prefix
+     *
+     * @return the default XIIDM prefix
+     */
+     static const std::string& getDefaultPrefix();
 
     /**
      * Get an {@link IidmXmlVersion} instance from its string representation
@@ -112,6 +124,13 @@ public:
      * @return the namespace URI of this version
      */
     std::string getNamespaceUri() const;
+
+    /**
+     * Get the XML prefix associated to this IIDM version
+     *
+     * @return the XML prefix of this version
+     */
+    const std::string& getPrefix() const;
 
     /**
      * Get the name of the XSD file for this IIDM version

--- a/src/iidm/converter/xml/AbstractConnectableXml.hpp
+++ b/src/iidm/converter/xml/AbstractConnectableXml.hpp
@@ -40,7 +40,7 @@ public:
     template <typename S, typename O>
     static void readCurrentLimits(CurrentLimitsAdder<S, O>& adder, const powsybl::xml::XmlStreamReader& reader, const boost::optional<int>& index = boost::optional<int>());
 
-    static void writeCurrentLimits(const CurrentLimits& limits, powsybl::xml::XmlStreamWriter& writer, const boost::optional<int>& index = boost::optional<int>(), const std::string& nsPrefix = IIDM_PREFIX);
+    static void writeCurrentLimits(const CurrentLimits& limits, powsybl::xml::XmlStreamWriter& writer, const IidmXmlVersion& version, const boost::optional<int>& index = boost::optional<int>());
 
 protected:
     static void readNodeOrBus(BranchAdder<Adder>& adder, const NetworkXmlReaderContext& context);

--- a/src/iidm/converter/xml/AbstractConnectableXml.hxx
+++ b/src/iidm/converter/xml/AbstractConnectableXml.hxx
@@ -111,8 +111,8 @@ void AbstractConnectableXml<Added, Adder, Parent>::writeBus(const stdcxx::CRefer
 }
 
 template <typename Added, typename Adder, typename Parent>
-void AbstractConnectableXml<Added, Adder, Parent>::writeCurrentLimits(const CurrentLimits& limits, powsybl::xml::XmlStreamWriter& writer, const boost::optional<int>& index, const std::string& nsPrefix) {
-    CurrentLimitsXml::writeCurrentLimits(limits, writer, index, nsPrefix);
+void AbstractConnectableXml<Added, Adder, Parent>::writeCurrentLimits(const CurrentLimits& limits, powsybl::xml::XmlStreamWriter& writer, const IidmXmlVersion& version, const boost::optional<int>& index) {
+    CurrentLimitsXml::writeCurrentLimits(limits, writer, version.getPrefix(), version, index);
 }
 
 template <typename Added, typename Adder, typename Parent>

--- a/src/iidm/converter/xml/AbstractIdentifiableXml.hxx
+++ b/src/iidm/converter/xml/AbstractIdentifiableXml.hxx
@@ -48,7 +48,7 @@ void AbstractIdentifiableXml<Added, Adder, Parent>::readSubElements(Added& ident
 
 template <typename Added, typename Adder, typename Parent>
 void AbstractIdentifiableXml<Added, Adder, Parent>::write(const Added& identifiable, const Parent& parent, NetworkXmlWriterContext& context) const {
-    context.getWriter().writeStartElement(IIDM_PREFIX, getRootElementName());
+    context.getWriter().writeStartElement(context.getVersion().getPrefix(), getRootElementName());
 
     context.getWriter().writeAttribute(ID, context.getAnonymizer().anonymizeString(identifiable.getId()));
     if (identifiable.getId() != identifiable.getName()) {

--- a/src/iidm/converter/xml/AbstractTransformerXml.hxx
+++ b/src/iidm/converter/xml/AbstractTransformerXml.hxx
@@ -156,7 +156,7 @@ void AbstractTransformerXml<Added, Adder>::readTerminalRef(NetworkXmlReaderConte
 
 template <typename Added, typename Adder>
 void AbstractTransformerXml<Added, Adder>::writePhaseTapChanger(const std::string& name, const PhaseTapChanger& ptc, NetworkXmlWriterContext& context) {
-    context.getWriter().writeStartElement(IIDM_PREFIX, name);
+    context.getWriter().writeStartElement(context.getVersion().getPrefix(), name);
     writeTapChanger<PhaseTapChangerHolder, PhaseTapChanger, PhaseTapChangerStep>(ptc, context.getWriter());
     context.getWriter().writeAttribute(REGULATION_MODE, Enum::toString(ptc.getRegulationMode()));
     if (ptc.getRegulationMode() != PhaseTapChanger::RegulationMode::FIXED_TAP || !std::isnan(ptc.getRegulationValue())) {
@@ -170,7 +170,7 @@ void AbstractTransformerXml<Added, Adder>::writePhaseTapChanger(const std::strin
     }
     for (long p = ptc.getLowTapPosition(); p <= ptc.getHighTapPosition(); ++p) {
         const PhaseTapChangerStep& ptcs = ptc.getStep(p);
-        context.getWriter().writeStartElement(IIDM_PREFIX, STEP);
+        context.getWriter().writeStartElement(context.getVersion().getPrefix(), STEP);
         writeTapChangerStep(ptcs, context.getWriter());
         context.getWriter().writeAttribute(ALPHA, ptcs.getAlpha());
         context.getWriter().writeEndElement();
@@ -180,7 +180,7 @@ void AbstractTransformerXml<Added, Adder>::writePhaseTapChanger(const std::strin
 
 template <typename Added, typename Adder>
 void AbstractTransformerXml<Added, Adder>::writeRatioTapChanger(const std::string& name, const RatioTapChanger& rtc, NetworkXmlWriterContext& context) {
-    context.getWriter().writeStartElement(IIDM_PREFIX, name);
+    context.getWriter().writeStartElement(context.getVersion().getPrefix(), name);
     writeTapChanger<RatioTapChangerHolder, RatioTapChanger, RatioTapChangerStep>(rtc, context.getWriter());
     context.getWriter().writeAttribute(LOAD_TAP_CHANGING_CAPABILITIES, rtc.hasLoadTapChangingCapabilities());
     if (rtc.hasLoadTapChangingCapabilities() || rtc.isRegulating()) {
@@ -194,7 +194,7 @@ void AbstractTransformerXml<Added, Adder>::writeRatioTapChanger(const std::strin
     }
     for (long p = rtc.getLowTapPosition(); p <= rtc.getHighTapPosition(); ++p) {
         const RatioTapChangerStep& rtcs = rtc.getStep(p);
-        context.getWriter().writeStartElement(IIDM_PREFIX, STEP);
+        context.getWriter().writeStartElement(context.getVersion().getPrefix(), STEP);
         writeTapChangerStep(rtcs, context.getWriter());
         context.getWriter().writeEndElement();
     }

--- a/src/iidm/converter/xml/CurrentLimitsXml.cpp
+++ b/src/iidm/converter/xml/CurrentLimitsXml.cpp
@@ -17,7 +17,7 @@ namespace converter {
 
 namespace xml {
 
-void CurrentLimitsXml::writeCurrentLimits(const CurrentLimits& limits, powsybl::xml::XmlStreamWriter& writer, const boost::optional<int>& index, const std::string& nsPrefix) {
+void CurrentLimitsXml::writeCurrentLimits(const CurrentLimits& limits, powsybl::xml::XmlStreamWriter& writer, const std::string& nsPrefix, const IidmXmlVersion& version, const boost::optional<int>& index) {
     if (!std::isnan(limits.getPermanentLimit()) || !limits.getTemporaryLimits().empty()) {
         writer.writeStartElement(nsPrefix, toString(CURRENT_LIMITS, index));
         writer.writeAttribute(PERMANENT_LIMIT, limits.getPermanentLimit());
@@ -25,7 +25,7 @@ void CurrentLimitsXml::writeCurrentLimits(const CurrentLimits& limits, powsybl::
         constexpr unsigned long undefinedAcceptableDuration = std::numeric_limits<int>::max();
 
         for (const auto& tl : limits.getTemporaryLimits()) {
-            writer.writeStartElement(nsPrefix, TEMPORARY_LIMIT);
+            writer.writeStartElement(version.getPrefix(), TEMPORARY_LIMIT);
             writer.writeAttribute(NAME, tl.get().getName());
             writer.writeOptionalAttribute(ACCEPTABLE_DURATION, tl.get().getAcceptableDuration(), undefinedAcceptableDuration);
             writer.writeOptionalAttribute(VALUE, tl.get().getValue(), std::numeric_limits<double>::max());

--- a/src/iidm/converter/xml/DanglingLineXml.cpp
+++ b/src/iidm/converter/xml/DanglingLineXml.cpp
@@ -76,7 +76,7 @@ void DanglingLineXml::writeRootElementAttributes(const DanglingLine& line, const
 
 void DanglingLineXml::writeSubElements(const DanglingLine& line, const VoltageLevel& /*voltageLevel*/, NetworkXmlWriterContext& context) const {
     if (line.getCurrentLimits()) {
-        writeCurrentLimits(line.getCurrentLimits(), context.getWriter());
+        writeCurrentLimits(line.getCurrentLimits(), context.getWriter(), context.getVersion());
     }
 }
 

--- a/src/iidm/converter/xml/IidmXmlVersion.cpp
+++ b/src/iidm/converter/xml/IidmXmlVersion.cpp
@@ -84,8 +84,17 @@ const IidmXmlVersion& IidmXmlVersion::fromNamespaceURI(const std::string& namesp
     return v;
 }
 
+const std::string& IidmXmlVersion::getDefaultPrefix() {
+    static std::string s_prefix = "iidm";
+    return s_prefix;
+}
+
 std::string IidmXmlVersion::getNamespaceUri() const {
     return logging::format("http://www.%1%/schema/iidm/%2%", m_domain, toString("_"));
+}
+
+const std::string& IidmXmlVersion::getPrefix() const {
+    return getDefaultPrefix();
 }
 
 std::string IidmXmlVersion::getXsd() const {

--- a/src/iidm/converter/xml/LineXml.cpp
+++ b/src/iidm/converter/xml/LineXml.cpp
@@ -79,10 +79,10 @@ void LineXml::writeRootElementAttributes(const Line& line, const Network& /*netw
 
 void LineXml::writeSubElements(const Line& line, const Network& /*network*/, NetworkXmlWriterContext& context) const {
     if (line.getCurrentLimits1()) {
-        writeCurrentLimits(line.getCurrentLimits1(), context.getWriter(), 1);
+        writeCurrentLimits(line.getCurrentLimits1(), context.getWriter(), context.getVersion(), 1);
     }
     if (line.getCurrentLimits2()) {
-        writeCurrentLimits(line.getCurrentLimits2(), context.getWriter(), 2);
+        writeCurrentLimits(line.getCurrentLimits2(), context.getWriter(), context.getVersion(), 2);
     }
 }
 

--- a/src/iidm/converter/xml/NetworkXml.cpp
+++ b/src/iidm/converter/xml/NetworkXml.cpp
@@ -148,7 +148,7 @@ void writeExtensions(const Network& network, NetworkXmlWriterContext& context) {
         const auto& extensions = identifiable.getExtensions();
         if (context.isExportedEquipment(identifiable.getId()) && boost::size(extensions) > 0) {
 
-            context.getExtensionsWriter().writeStartElement(IIDM_PREFIX, EXTENSION);
+            context.getExtensionsWriter().writeStartElement(context.getVersion().getPrefix(), EXTENSION);
             context.getExtensionsWriter().writeAttribute(ID, context.getAnonymizer().anonymizeString(identifiable.getId()));
             for (const auto& extension : extensions) {
                 if (context.getOptions().withExtension(extension.getName())) {
@@ -169,7 +169,7 @@ Network NetworkXml::read(std::istream& is, const ImportOptions& options, const A
 
     reader.skipComments();
 
-    const IidmXmlVersion& version = IidmXmlVersion::fromNamespaceURI(reader.getNamespaceOrDefault(IIDM_PREFIX));
+    const IidmXmlVersion& version = IidmXmlVersion::fromNamespaceURI(reader.getNamespaceOrDefault(IidmXmlVersion::getDefaultPrefix()));
 
     const std::string& id = reader.getAttributeValue(ID);
     const std::string& sourceFormat = reader.getAttributeValue(SOURCE_FORMAT);
@@ -243,8 +243,8 @@ std::unique_ptr<Anonymizer> NetworkXml::write(std::ostream& ostream, const Netwo
 
     writer.writeStartDocument(powsybl::xml::DEFAULT_ENCODING, "1.0");
 
-    writer.writeStartElement(IIDM_PREFIX, NETWORK);
-    writer.setPrefix(IIDM_PREFIX, version.getNamespaceUri());
+    writer.writeStartElement(context.getVersion().getPrefix(), NETWORK);
+    writer.setPrefix(context.getVersion().getPrefix(), version.getNamespaceUri());
     writeExtensionNamespaces(network, context);
 
     writer.writeAttribute(ID, network.getId());

--- a/src/iidm/converter/xml/NodeBreakerViewInternalConnectionXml.cpp
+++ b/src/iidm/converter/xml/NodeBreakerViewInternalConnectionXml.cpp
@@ -34,7 +34,7 @@ void NodeBreakerViewInternalConnectionXml::read(VoltageLevel& voltageLevel, cons
 }
 
 void NodeBreakerViewInternalConnectionXml::write(unsigned long node1, unsigned long node2, NetworkXmlWriterContext& context) const {
-    context.getWriter().writeStartElement(IIDM_PREFIX, INTERNAL_CONNECTION);
+    context.getWriter().writeStartElement(context.getVersion().getPrefix(), INTERNAL_CONNECTION);
     context.getWriter().writeAttribute(NODE1, node1);
     context.getWriter().writeAttribute(NODE2, node2);
     context.getWriter().writeEndElement();

--- a/src/iidm/converter/xml/PropertiesXml.cpp
+++ b/src/iidm/converter/xml/PropertiesXml.cpp
@@ -31,7 +31,7 @@ void PropertiesXml::read(Identifiable& identifiable, NetworkXmlReaderContext& co
 void PropertiesXml::write(const Identifiable& identifiable, NetworkXmlWriterContext& context) {
     for (const auto& name : identifiable.getPropertyNames()) {
         const auto& value = identifiable.getProperty(name);
-        context.getWriter().writeStartElement(IIDM_PREFIX, PROPERTY);
+        context.getWriter().writeStartElement(context.getVersion().getPrefix(), PROPERTY);
         context.getWriter().writeAttribute(NAME, name);
         context.getWriter().writeAttribute(VALUE, value);
         context.getWriter().writeEndElement();

--- a/src/iidm/converter/xml/ReactiveLimitsXml.cpp
+++ b/src/iidm/converter/xml/ReactiveLimitsXml.cpp
@@ -59,16 +59,16 @@ void ReactiveLimitsXml::read(ReactiveLimitsHolder& holder, const NetworkXmlReade
 }
 
 void ReactiveLimitsXml::write(const MinMaxReactiveLimits& limits, NetworkXmlWriterContext& context) const {
-    context.getWriter().writeStartElement(IIDM_PREFIX, MIN_MAX_REACTIVE_LIMITS);
+    context.getWriter().writeStartElement(context.getVersion().getPrefix(), MIN_MAX_REACTIVE_LIMITS);
     context.getWriter().writeAttribute(MIN_Q, limits.getMinQ());
     context.getWriter().writeAttribute(MAX_Q, limits.getMaxQ());
     context.getWriter().writeEndElement();
 }
 
 void ReactiveLimitsXml::write(const ReactiveCapabilityCurve& curve, NetworkXmlWriterContext& context) const {
-    context.getWriter().writeStartElement(IIDM_PREFIX, REACTIVE_CAPABILITY_CURVE);
+    context.getWriter().writeStartElement(context.getVersion().getPrefix(), REACTIVE_CAPABILITY_CURVE);
     for (const auto& point : curve.getPoints()) {
-        context.getWriter().writeStartElement(IIDM_PREFIX, POINT);
+        context.getWriter().writeStartElement(context.getVersion().getPrefix(), POINT);
         context.getWriter().writeAttribute(P, point.getP());
         context.getWriter().writeAttribute(MIN_Q, point.getMinQ());
         context.getWriter().writeAttribute(MAX_Q, point.getMaxQ());

--- a/src/iidm/converter/xml/TerminalRefXml.cpp
+++ b/src/iidm/converter/xml/TerminalRefXml.cpp
@@ -45,7 +45,7 @@ Terminal& TerminalRefXml::readTerminalRef(Network& network, const std::string& i
 }
 
 void TerminalRefXml::writeTerminalRef(const Terminal& terminal, NetworkXmlWriterContext& context, const std::string& elementName) {
-    writeTerminalRef(terminal, context, IIDM_PREFIX, elementName);
+    writeTerminalRef(terminal, context, context.getVersion().getPrefix(), elementName);
 }
 
 void TerminalRefXml::writeTerminalRef(const Terminal& terminal, NetworkXmlWriterContext& context, const std::string& nsPrefix, const std::string& elementName) {

--- a/src/iidm/converter/xml/ThreeWindingsTransformerXml.cpp
+++ b/src/iidm/converter/xml/ThreeWindingsTransformerXml.cpp
@@ -178,13 +178,13 @@ void ThreeWindingsTransformerXml::writeSubElements(const ThreeWindingsTransforme
     writePhaseTapChanger(twt.getLeg3().getPhaseTapChanger(), 3, context);
 
     if (twt.getLeg1().getCurrentLimits()) {
-        writeCurrentLimits(twt.getLeg1().getCurrentLimits(), context.getWriter(), 1);
+        writeCurrentLimits(twt.getLeg1().getCurrentLimits(), context.getWriter(), context.getVersion(), 1);
     }
     if (twt.getLeg2().getCurrentLimits()) {
-        writeCurrentLimits(twt.getLeg2().getCurrentLimits(), context.getWriter(), 2);
+        writeCurrentLimits(twt.getLeg2().getCurrentLimits(), context.getWriter(), context.getVersion(), 2);
     }
     if (twt.getLeg3().getCurrentLimits()) {
-        writeCurrentLimits(twt.getLeg3().getCurrentLimits(), context.getWriter(), 3);
+        writeCurrentLimits(twt.getLeg3().getCurrentLimits(), context.getWriter(), context.getVersion(), 3);
     }
 }
 

--- a/src/iidm/converter/xml/TieLineXml.cpp
+++ b/src/iidm/converter/xml/TieLineXml.cpp
@@ -105,10 +105,10 @@ void TieLineXml::writeRootElementAttributes(const TieLine& line, const Network& 
 
 void TieLineXml::writeSubElements(const TieLine& line, const Network& /*network*/, NetworkXmlWriterContext& context) const {
     if (line.getCurrentLimits1()) {
-        writeCurrentLimits(line.getCurrentLimits1(), context.getWriter(), 1);
+        writeCurrentLimits(line.getCurrentLimits1(), context.getWriter(), context.getVersion(), 1);
     }
     if (line.getCurrentLimits2()) {
-        writeCurrentLimits(line.getCurrentLimits2(), context.getWriter(), 2);
+        writeCurrentLimits(line.getCurrentLimits2(), context.getWriter(), context.getVersion(), 2);
     }
 }
 

--- a/src/iidm/converter/xml/TwoWindingsTransformerXml.cpp
+++ b/src/iidm/converter/xml/TwoWindingsTransformerXml.cpp
@@ -91,10 +91,10 @@ void TwoWindingsTransformerXml::writeSubElements(const TwoWindingsTransformer& t
         writePhaseTapChanger(PHASE_TAP_CHANGER, ptc, context);
     }
     if (twt.getCurrentLimits1()) {
-        writeCurrentLimits(twt.getCurrentLimits1(), context.getWriter(), 1);
+        writeCurrentLimits(twt.getCurrentLimits1(), context.getWriter(), context.getVersion(), 1);
     }
     if (twt.getCurrentLimits2()) {
-        writeCurrentLimits(twt.getCurrentLimits2(), context.getWriter(), 2);
+        writeCurrentLimits(twt.getCurrentLimits2(), context.getWriter(), context.getVersion(), 2);
     }
 }
 

--- a/src/iidm/converter/xml/VoltageLevelXml.cpp
+++ b/src/iidm/converter/xml/VoltageLevelXml.cpp
@@ -158,7 +158,7 @@ void VoltageLevelXml::writeBatteries(const VoltageLevel& voltageLevel, NetworkXm
 }
 
 void VoltageLevelXml::writeBusBranchTopology(const VoltageLevel& voltageLevel, NetworkXmlWriterContext& context) const {
-    context.getWriter().writeStartElement(IIDM_PREFIX, BUS_BREAKER_TOPOLOGY);
+    context.getWriter().writeStartElement(context.getVersion().getPrefix(), BUS_BREAKER_TOPOLOGY);
     for (const Bus& bus : voltageLevel.getBusView().getBuses()) {
         if (!context.getFilter().test(bus)) {
             continue;
@@ -169,7 +169,7 @@ void VoltageLevelXml::writeBusBranchTopology(const VoltageLevel& voltageLevel, N
 }
 
 void VoltageLevelXml::writeBusBreakerTopology(const VoltageLevel& voltageLevel, NetworkXmlWriterContext& context) const {
-    context.getWriter().writeStartElement(IIDM_PREFIX, BUS_BREAKER_TOPOLOGY);
+    context.getWriter().writeStartElement(context.getVersion().getPrefix(), BUS_BREAKER_TOPOLOGY);
     for (const Bus& bus : voltageLevel.getBusBreakerView().getBuses()) {
         if (!context.getFilter().test(bus)) {
             continue;
@@ -188,7 +188,7 @@ void VoltageLevelXml::writeBusBreakerTopology(const VoltageLevel& voltageLevel, 
 }
 
 void VoltageLevelXml::writeCalculatedBus(const Bus& bus, const std::set<unsigned long>& nodes, NetworkXmlWriterContext& context) {
-    context.getWriter().writeStartElement(IIDM_PREFIX, BUS);
+    context.getWriter().writeStartElement(context.getVersion().getPrefix(), BUS);
     context.getWriter().writeAttribute(V, bus.getV());
     context.getWriter().writeAttribute(ANGLE, bus.getAngle());
     const auto& mapper = [](unsigned long node) { return std::to_string(node); };
@@ -233,7 +233,7 @@ void VoltageLevelXml::writeLoads(const VoltageLevel& voltageLevel, NetworkXmlWri
 }
 
 void VoltageLevelXml::writeNodeBreakerTopology(const VoltageLevel& voltageLevel, NetworkXmlWriterContext& context) const {
-    context.getWriter().writeStartElement(IIDM_PREFIX, NODE_BREAKER_TOPOLOGY);
+    context.getWriter().writeStartElement(context.getVersion().getPrefix(), NODE_BREAKER_TOPOLOGY);
     context.getWriter().writeAttribute(NODE_COUNT, voltageLevel.getNodeBreakerView().getNodeCount());
     for (const BusbarSection& bs : voltageLevel.getNodeBreakerView().getBusbarSections()) {
         BusbarSectionXml::getInstance().write(bs, voltageLevel, context);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#29 
https://github.com/powsybl/powsybl-core/pull/1129


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
All the XIIDM element are exported using the hard coded `iidm` prefix.


**What is the new behavior (if this is a feature change)?**
In this version, the XIIDM element are still exported using the `iidm` prefix, but the code is ready to a prefix change. It looks more like the java implementation, except in Java the XML elements are created using the URI that is different for every version.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
