### PR TITLE
Add BOOST_TEST_DYN_LINK to all unit tests targets

### DIFF
--- a/extensions/entsoe/CMakeLists.txt
+++ b/extensions/entsoe/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(${EXT_NAME}-static PUBLIC iidm)
 
 # Unit tests
 add_executable(unit-tests-${EXT_NAME} ${UNIT_TEST_SOURCES})
+target_compile_definitions(unit-tests-${EXT_NAME} PRIVATE BOOST_TEST_DYN_LINK)
 target_link_libraries(unit-tests-${EXT_NAME} PRIVATE ${EXT_NAME} iidm-tests)
 
 add_test(NAME ${EXT_NAME} COMMAND unit-tests-${EXT_NAME} ${BOOST_ARGS_SEPARATOR} --resources=${CMAKE_CURRENT_SOURCE_DIR}/resources)

--- a/extensions/iidm/CMakeLists.txt
+++ b/extensions/iidm/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(${EXT_NAME}-static PUBLIC iidm)
 
 # Unit tests
 add_executable(unit-tests-${EXT_NAME} ${UNIT_TEST_SOURCES})
+target_compile_definitions(unit-tests-${EXT_NAME} PRIVATE BOOST_TEST_DYN_LINK)
 target_link_libraries(unit-tests-${EXT_NAME} PRIVATE ${EXT_NAME} iidm-tests)
 
 add_test(NAME ${EXT_NAME} COMMAND unit-tests-${EXT_NAME} ${BOOST_ARGS_SEPARATOR} --resources=${CMAKE_CURRENT_SOURCE_DIR}/resources)

--- a/test/iidm/CMakeLists.txt
+++ b/test/iidm/CMakeLists.txt
@@ -60,6 +60,7 @@ set(UNIT_TEST_SOURCES
 )
 
 add_executable(unit-tests-iidm ${UNIT_TEST_SOURCES})
+target_compile_definitions(unit-tests-iidm PRIVATE BOOST_TEST_DYN_LINK)
 target_link_libraries(unit-tests-iidm PRIVATE iidm-tests)
 
 add_test(NAME iidm COMMAND unit-tests-iidm ${BOOST_ARGS_SEPARATOR} --resources=${CMAKE_SOURCE_DIR}/test/resources)

--- a/test/logging/CMakeLists.txt
+++ b/test/logging/CMakeLists.txt
@@ -15,6 +15,7 @@ set(UNIT_TEST_SOURCES
 )
 
 add_executable(unit-tests-logging ${UNIT_TEST_SOURCES})
+target_compile_definitions(unit-tests-logging PRIVATE BOOST_TEST_DYN_LINK)
 target_link_libraries(unit-tests-logging PRIVATE iidm-tests)
 
 add_test(NAME logging COMMAND unit-tests-logging)

--- a/test/math/CMakeLists.txt
+++ b/test/math/CMakeLists.txt
@@ -11,6 +11,7 @@ set(UNIT_TEST_SOURCES
 )
 
 add_executable(unit-tests-math ${UNIT_TEST_SOURCES})
+target_compile_definitions(unit-tests-math PRIVATE BOOST_TEST_DYN_LINK)
 target_link_libraries(unit-tests-math PRIVATE iidm-tests)
 
 add_test(NAME math COMMAND unit-tests-math)

--- a/test/network/CMakeLists.txt
+++ b/test/network/CMakeLists.txt
@@ -10,6 +10,7 @@ set(UNIT_TEST_SOURCES
     network.cpp)
 
 add_executable(unit-tests-network ${UNIT_TEST_SOURCES})
+target_compile_definitions(unit-tests-network PRIVATE BOOST_TEST_DYN_LINK)
 target_link_libraries(unit-tests-network PRIVATE iidm-tests)
 
 add_test(NAME network COMMAND unit-tests-network)

--- a/test/stdcxx/CMakeLists.txt
+++ b/test/stdcxx/CMakeLists.txt
@@ -12,6 +12,7 @@ set(UNIT_TEST_SOURCES
     )
 
 add_executable(unit-tests-stdcxx ${UNIT_TEST_SOURCES})
+target_compile_definitions(unit-tests-stdcxx PRIVATE BOOST_TEST_DYN_LINK)
 target_link_libraries(unit-tests-stdcxx PRIVATE iidm-tests)
 
 add_test(NAME stdcxx COMMAND unit-tests-stdcxx)

--- a/test/xml/CMakeLists.txt
+++ b/test/xml/CMakeLists.txt
@@ -11,6 +11,7 @@ set(UNIT_TEST_SOURCES
     XmlStreamWriterTest.cpp)
 
 add_executable(unit-tests-xml ${UNIT_TEST_SOURCES})
+target_compile_definitions(unit-tests-xml PRIVATE BOOST_TEST_DYN_LINK)
 target_link_libraries(unit-tests-xml PRIVATE iidm-tests)
 
 add_test(NAME xml COMMAND unit-tests-xml)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
There is a linkage error under Linux, when the cmake version used is lower than 3.15. Starting from the 3.15, the `Boost::dynamic_linkage` property adds `BOOST_ALL_DYN_LINK` compilation flags for every OS. Before this version, this is done only on Windows.

This is a regression introduced in the PR #42 

**What is the new behavior (if this is a feature change)?**
All the unit-tests are linked correctly even with an old version of cmake


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
**This PR have to be backport in the `integration/v1.1.0` and completed as we introduce a new unit test binary.**

(if any of the questions/checkboxes don't apply, please delete them entirely)
