### PR TITLE
Test extension loading in previous versions

### DIFF
--- a/include/powsybl/test/converter/RoundTrip.hpp
+++ b/include/powsybl/test/converter/RoundTrip.hpp
@@ -42,7 +42,7 @@ public:
 
     static std::string getVersionedNetworkPath(const std::string& filename, const iidm::converter::xml::IidmXmlVersion& version);
 
-    // static void roundTripAllPreviousVersionedXmlTest(const std::string& filename);
+    static void roundTripAllPreviousVersionedXmlTest(const std::string& filename);
 
     static void roundTripVersionedXmlTest(const std::string& filename, const iidm::converter::xml::IidmXmlVersion& version);
 

--- a/src/test/converter/RoundTrip.cpp
+++ b/src/test/converter/RoundTrip.cpp
@@ -46,14 +46,12 @@ std::string RoundTrip::getVersionedNetworkPath(const std::string& filename, cons
     return getVersionDir(version) + filename;
 }
 
-/*
 void RoundTrip::roundTripAllPreviousVersionedXmlTest(const std::string& filename) {
     iidm::converter::xml::IidmXmlVersions versions = iidm::converter::xml::IidmXmlVersion::all();
     versions.pop_back();
 
     roundTripVersionedXmlTest(filename, versions);
 }
-*/
 
 void RoundTrip::roundTripVersionedXmlTest(const std::string& filename, const iidm::converter::xml::IidmXmlVersion& version) {
     const auto& writer = [&version](const iidm::Network& n, std::ostream& stream) {

--- a/test/iidm/converter/xml/IdentifiableExtensionXmlSerializerTest.cpp
+++ b/test/iidm/converter/xml/IdentifiableExtensionXmlSerializerTest.cpp
@@ -55,8 +55,7 @@ BOOST_AUTO_TEST_CASE(TerminalExtension) {
     const auto& terminalMockExt = load2.getExtension<extensions::TerminalMockExt>();
     BOOST_TEST(stdcxx::areSame(load2.getTerminal(), terminalMockExt.getTerminal()));
 
-    // FIXME(mathbagu): it requires to be able to write an extension in a previous version
-    // test::converter::RoundTrip::roundTripAllPreviousVersionedXmlTest("eurostag-tutorial-example1-with-terminalMock-ext.xml");
+    test::converter::RoundTrip::roundTripAllPreviousVersionedXmlTest("eurostag-tutorial-example1-with-terminalMock-ext.xml");
 }
 
 BOOST_AUTO_TEST_CASE(IncompatibleExtensionVersion) {


### PR DESCRIPTION
This PR activates a test for loading extensions in previous version of IIDM API.
The feature is now available (#85) but the associated test was commented.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
