### PR TITLE
Fix boost install commands for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Under Windows, install all the following requirements following the vendor instr
 To build **Boost** (1.56 or higher), download the sources from [Boost website](https://www.boost.org/users/download) and uncompress them into a folder. Then open a MSVC prompt and run the following commands:
 ```
 $> cd <BOOST_SOURCES>
-$> b2 -j 4 --with-date_time --with-filesystem --with-program_options --with-system --with-test --layout=system --prefix=<BOOST_PREFIX> variant=<BOOST_BUILD_TYPE> architecture=x86 address-model=64 link=static,shared stage
-$> b2 install
+$> bootstrap.bat
+$> b2 install -j 4 --with-date_time --with-filesystem --with-program_options --with-system --with-test --layout=system --prefix=<BOOST_PREFIX> variant=<BOOST_BUILD_TYPE> architecture=x86 address-model=64 link=static,shared stage
 ```
 where `BOOST_PREFIX` is the folder where Boost libraries will be installed and the `BOOST_BUILD_TYPE` is the build type (`debug` or `release`).
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Documentation


**What is the current behavior?** *(You can also link to an open issue here)*
There is a mistake in the boost install commands for windows. B2 is not available since bootstrap has not been run.


**What is the new behavior (if this is a feature change)?**
The commands list is OK


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
