### PR TITLE
Properties moved from iidm to stdcxx namespace

### DIFF
--- a/include/powsybl/iidm/Identifiable.hpp
+++ b/include/powsybl/iidm/Identifiable.hpp
@@ -11,8 +11,8 @@
 #include <string>
 
 #include <powsybl/iidm/Extendable.hpp>
-#include <powsybl/iidm/Properties.hpp>
 #include <powsybl/iidm/Validable.hpp>
+#include <powsybl/stdcxx/Properties.hpp>
 #include <powsybl/stdcxx/optional.hpp>
 #include <powsybl/stdcxx/range.hpp>
 
@@ -68,7 +68,7 @@ private:
 
     std::string m_name;
 
-    Properties m_properties;
+    stdcxx::Properties m_properties;
 };
 
 std::ostream& operator<<(std::ostream& stream, const Identifiable& identifiable);

--- a/include/powsybl/stdcxx/Properties.hpp
+++ b/include/powsybl/stdcxx/Properties.hpp
@@ -5,8 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#ifndef POWSYBL_IIDM_PROPERTIES_HPP
-#define POWSYBL_IIDM_PROPERTIES_HPP
+#ifndef POWSYBL_STDCXX_PROPERTIES_HPP
+#define POWSYBL_STDCXX_PROPERTIES_HPP
 
 #include <map>
 #include <string>
@@ -14,9 +14,7 @@
 #include <powsybl/stdcxx/optional.hpp>
 #include <powsybl/stdcxx/range.hpp>
 
-namespace powsybl {
-
-namespace iidm {
+namespace stdcxx {
 
 class Properties {
 public:
@@ -72,8 +70,6 @@ private:
     std::map<std::string, std::string> m_properties;
 };
 
-}  // namespace iidm
+}  // namespace stdcxx
 
-}  // namespace powsybl
-
-#endif  // POWSYBL_IIDM_PROPERTIES_HPP
+#endif  // POWSYBL_STDCXX_PROPERTIES_HPP

--- a/include/powsybl/stdcxx/exception.hpp
+++ b/include/powsybl/stdcxx/exception.hpp
@@ -13,11 +13,11 @@
 
 namespace stdcxx {
 
-class Exception : public std::runtime_error {
+class PropertyNotFoundException : public std::runtime_error {
 public:
-    explicit Exception(const std::string& message);
+    explicit PropertyNotFoundException(const std::string& message);
 
-    ~Exception() noexcept override = default;
+    ~PropertyNotFoundException() noexcept override = default;
 };
 
 }  // namespace stdcxx

--- a/include/powsybl/stdcxx/exception.hpp
+++ b/include/powsybl/stdcxx/exception.hpp
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef POWSYBL_STDCXX_EXCEPTION_HPP
+#define POWSYBL_STDCXX_EXCEPTION_HPP
+
+#include <stdexcept>
+#include <string>
+
+namespace stdcxx {
+
+class Exception : public std::runtime_error {
+public:
+    explicit Exception(const std::string& message);
+
+    ~Exception() noexcept override = default;
+};
+
+}  // namespace stdcxx
+
+#endif  // POWSYBL_STDCXX_EXCEPTION_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,7 +75,6 @@ set(IIDM_SOURCES
     iidm/PhaseTapChanger.cpp
     iidm/PhaseTapChangerAdder.cpp
     iidm/PhaseTapChangerStep.cpp
-    iidm/Properties.cpp
     iidm/RatioTapChanger.cpp
     iidm/RatioTapChangerAdder.cpp
     iidm/RatioTapChangerStep.cpp
@@ -172,6 +171,7 @@ set(IIDM_SOURCES
     stdcxx/DateTime.cpp
     stdcxx/demangle.cpp
     stdcxx/time.cpp
+    stdcxx/Properties.cpp
 
     xml/XmlCharConversion.cpp
     xml/XmlStreamException.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,6 +170,7 @@ set(IIDM_SOURCES
 
     stdcxx/DateTime.cpp
     stdcxx/demangle.cpp
+    stdcxx/exception.cpp
     stdcxx/time.cpp
     stdcxx/Properties.cpp
 

--- a/src/iidm/Identifiable.cpp
+++ b/src/iidm/Identifiable.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <powsybl/iidm/Identifiable.hpp>
-#include <powsybl/stdcxx/exception.hpp>
 #include <powsybl/stdcxx/format.hpp>
 
 #include "ValidationUtils.hpp"

--- a/src/iidm/Identifiable.cpp
+++ b/src/iidm/Identifiable.cpp
@@ -50,11 +50,7 @@ const std::string& Identifiable::getName() const {
 }
 
 const std::string& Identifiable::getProperty(const std::string& key) const {
-    try {
-        return m_properties.get(key);
-    } catch (const stdcxx::Exception& error) {
-        throw PowsyblException(error.what());
-    }
+    return m_properties.get(key);
 }
 
 const std::string& Identifiable::getProperty(const std::string& key, const std::string& defaultValue) const {

--- a/src/iidm/Identifiable.cpp
+++ b/src/iidm/Identifiable.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <powsybl/iidm/Identifiable.hpp>
+#include <powsybl/stdcxx/exception.hpp>
 #include <powsybl/stdcxx/format.hpp>
 
 #include "ValidationUtils.hpp"
@@ -49,7 +50,11 @@ const std::string& Identifiable::getName() const {
 }
 
 const std::string& Identifiable::getProperty(const std::string& key) const {
-    return m_properties.get(key);
+    try {
+        return m_properties.get(key);
+    } catch (const stdcxx::Exception& error) {
+        throw PowsyblException(error.what());
+    }
 }
 
 const std::string& Identifiable::getProperty(const std::string& key, const std::string& defaultValue) const {

--- a/src/iidm/converter/xml/AbstractIdentifiableXml.hxx
+++ b/src/iidm/converter/xml/AbstractIdentifiableXml.hxx
@@ -8,7 +8,6 @@
 #include "AbstractIdentifiableXml.hpp"
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/iidm/Properties.hpp>
 #include <powsybl/iidm/converter/Anonymizer.hpp>
 #include <powsybl/iidm/converter/Constants.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>

--- a/src/stdcxx/Properties.cpp
+++ b/src/stdcxx/Properties.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/range/adaptor/map.hpp>
 
-#include <powsybl/PowsyblException.hpp>
+#include <powsybl/stdcxx/exception.hpp>
 #include <powsybl/stdcxx/format.hpp>
 
 namespace stdcxx {
@@ -46,7 +46,7 @@ Properties::iterator Properties::end() {
 const std::string& Properties::get(const std::string& key) const {
     const auto& it = m_properties.find(key);
     if (it == m_properties.end()) {
-        throw powsybl::PowsyblException(format("Property %1% does not exist", key));
+        throw stdcxx::Exception(format("Property %1% does not exist", key));
     }
 
     return it->second;

--- a/src/stdcxx/Properties.cpp
+++ b/src/stdcxx/Properties.cpp
@@ -46,7 +46,7 @@ Properties::iterator Properties::end() {
 const std::string& Properties::get(const std::string& key) const {
     const auto& it = m_properties.find(key);
     if (it == m_properties.end()) {
-        throw stdcxx::Exception(format("Property %1% does not exist", key));
+        throw stdcxx::PropertyNotFoundException(format("Property %1% does not exist", key));
     }
 
     return it->second;

--- a/src/stdcxx/Properties.cpp
+++ b/src/stdcxx/Properties.cpp
@@ -5,16 +5,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <powsybl/iidm/Properties.hpp>
+#include <powsybl/stdcxx/Properties.hpp>
 
 #include <boost/range/adaptor/map.hpp>
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/stdcxx/format.hpp>
 
-namespace powsybl {
-
-namespace iidm {
+namespace stdcxx {
 
 Properties::const_iterator Properties::begin() const {
     return m_properties.begin();
@@ -48,7 +46,7 @@ Properties::iterator Properties::end() {
 const std::string& Properties::get(const std::string& key) const {
     const auto& it = m_properties.find(key);
     if (it == m_properties.end()) {
-        throw PowsyblException(stdcxx::format("Property %1% does not exist", key));
+        throw powsybl::PowsyblException(format("Property %1% does not exist", key));
     }
 
     return it->second;
@@ -92,6 +90,4 @@ unsigned long Properties::size() const {
     return m_properties.size();
 }
 
-}  // namespace iidm
-
-}  // namespace powsybl
+}  // namespace stdcxx

--- a/src/stdcxx/exception.cpp
+++ b/src/stdcxx/exception.cpp
@@ -9,7 +9,7 @@
 
 namespace stdcxx {
 
-Exception::Exception(const std::string& message) :
+PropertyNotFoundException::PropertyNotFoundException(const std::string& message) :
     std::runtime_error(message) {
 }
 

--- a/src/stdcxx/exception.cpp
+++ b/src/stdcxx/exception.cpp
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <powsybl/stdcxx/exception.hpp>
+
+namespace stdcxx {
+
+Exception::Exception(const std::string& message) :
+    std::runtime_error(message) {
+}
+
+}  // namespace stdcxx

--- a/test/iidm/CMakeLists.txt
+++ b/test/iidm/CMakeLists.txt
@@ -27,7 +27,6 @@ set(UNIT_TEST_SOURCES
     NetworkTest.cpp
     NodeBreakerVoltageLevelTest.cpp
     PhaseTapChangerTest.cpp
-    PropertiesTest.cpp
     RatioTapChangerTest.cpp
     ReactiveLimitsTest.cpp
     ShuntCompensatorTest.cpp

--- a/test/iidm/NetworkTest.cpp
+++ b/test/iidm/NetworkTest.cpp
@@ -464,6 +464,25 @@ BOOST_AUTO_TEST_CASE(views) {
     BOOST_CHECK_EQUAL(0, boost::size(cBuses4));
     POWSYBL_ASSERT_REF_FALSE(cNetwork2.getBusView().getBus("UNKNOWN"));
 }
+ 
+BOOST_AUTO_TEST_CASE(Properties) {
+    Network n("test", "test");
+
+    BOOST_TEST(!n.hasProperty());
+    BOOST_TEST(!n.hasProperty("unknown"));
+    BOOST_CHECK_EQUAL(0UL, boost::size(n.getPropertyNames()));
+
+    n.setProperty("key1", "value1");
+    n.setProperty("key2", "value2");
+    BOOST_TEST(n.hasProperty());
+    BOOST_CHECK_EQUAL(2UL, boost::size(n.getPropertyNames()));
+
+    BOOST_CHECK_EQUAL("value1", n.getProperty("key1"));
+
+    POWSYBL_ASSERT_THROW(n.getProperty("key3"),
+                         powsybl::PowsyblException, "Property key3 does not exist");
+    BOOST_CHECK_EQUAL("value3", n.getProperty("key3", "value3"));
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/iidm/NetworkTest.cpp
+++ b/test/iidm/NetworkTest.cpp
@@ -19,6 +19,7 @@
 #include <powsybl/iidm/TwoWindingsTransformer.hpp>
 #include <powsybl/iidm/TwoWindingsTransformerAdder.hpp>
 #include <powsybl/iidm/ValidationException.hpp>
+#include <powsybl/stdcxx/exception.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 
 #include <powsybl/test/AssertionUtils.hpp>
@@ -480,7 +481,7 @@ BOOST_AUTO_TEST_CASE(Properties) {
     BOOST_CHECK_EQUAL("value1", n.getProperty("key1"));
 
     POWSYBL_ASSERT_THROW(n.getProperty("key3"),
-                         powsybl::PowsyblException, "Property key3 does not exist");
+                         stdcxx::PropertyNotFoundException, "Property key3 does not exist");
     BOOST_CHECK_EQUAL("value3", n.getProperty("key3", "value3"));
 }
 

--- a/test/stdcxx/CMakeLists.txt
+++ b/test/stdcxx/CMakeLists.txt
@@ -11,6 +11,7 @@ set(UNIT_TEST_SOURCES
     DemangleTest.cpp
     MathTest.cpp
     MessageFormatTest.cpp
+    PropertiesTest.cpp
 )
 
 add_executable(unit-tests-stdcxx ${UNIT_TEST_SOURCES})

--- a/test/stdcxx/PropertiesTest.cpp
+++ b/test/stdcxx/PropertiesTest.cpp
@@ -103,12 +103,10 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
 
     BOOST_CHECK_EQUAL(4UL, props.size());
 
-    POWSYBL_ASSERT_THROW(props.get("key9"),
-                         stdcxx::PropertyNotFoundException, "Property key9 does not exist");
+    POWSYBL_ASSERT_THROW(props.get("key9"), PropertyNotFoundException, "Property key9 does not exist");
     BOOST_CHECK_EQUAL("value9", props.get("key9", "value9"));
 
-    POWSYBL_ASSERT_THROW(props.get("key9"),
-                         stdcxx::PropertyNotFoundException, "Property key9 does not exist");
+    POWSYBL_ASSERT_THROW(props.get("key9"), PropertyNotFoundException, "Property key9 does not exist");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/stdcxx/PropertiesTest.cpp
+++ b/test/stdcxx/PropertiesTest.cpp
@@ -104,11 +104,11 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
     BOOST_CHECK_EQUAL(4UL, props.size());
 
     POWSYBL_ASSERT_THROW(props.get("key9"),
-                         stdcxx::Exception, "Property key9 does not exist");
+                         stdcxx::PropertyNotFoundException, "Property key9 does not exist");
     BOOST_CHECK_EQUAL("value9", props.get("key9", "value9"));
 
     POWSYBL_ASSERT_THROW(props.get("key9"),
-                         stdcxx::Exception, "Property key9 does not exist");
+                         stdcxx::PropertyNotFoundException, "Property key9 does not exist");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/stdcxx/PropertiesTest.cpp
+++ b/test/stdcxx/PropertiesTest.cpp
@@ -7,8 +7,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <powsybl/PowsyblException.hpp>
 #include <powsybl/stdcxx/Properties.hpp>
+#include <powsybl/stdcxx/exception.hpp>
 
 #include <powsybl/test/AssertionUtils.hpp>
 
@@ -104,11 +104,11 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
     BOOST_CHECK_EQUAL(4UL, props.size());
 
     POWSYBL_ASSERT_THROW(props.get("key9"),
-                         powsybl::PowsyblException, "Property key9 does not exist");
+                         stdcxx::Exception, "Property key9 does not exist");
     BOOST_CHECK_EQUAL("value9", props.get("key9", "value9"));
 
     POWSYBL_ASSERT_THROW(props.get("key9"),
-                         powsybl::PowsyblException, "Property key9 does not exist");
+                         stdcxx::Exception, "Property key9 does not exist");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/stdcxx/PropertiesTest.cpp
+++ b/test/stdcxx/PropertiesTest.cpp
@@ -8,13 +8,11 @@
 #include <boost/test/unit_test.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/iidm/Network.hpp>
+#include <powsybl/stdcxx/Properties.hpp>
 
 #include <powsybl/test/AssertionUtils.hpp>
 
-namespace powsybl {
-
-namespace iidm {
+namespace stdcxx {
 
 BOOST_AUTO_TEST_SUITE(PropertiesTestSuite)
 
@@ -113,27 +111,6 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
                          powsybl::PowsyblException, "Property key9 does not exist");
 }
 
-BOOST_AUTO_TEST_CASE(networkProperties) {
-    Network n("test", "test");
-
-    BOOST_TEST(!n.hasProperty());
-    BOOST_TEST(!n.hasProperty("unknown"));
-    BOOST_CHECK_EQUAL(0UL, boost::size(n.getPropertyNames()));
-
-    n.setProperty("key1", "value1");
-    n.setProperty("key2", "value2");
-    BOOST_TEST(n.hasProperty());
-    BOOST_CHECK_EQUAL(2UL, boost::size(n.getPropertyNames()));
-
-    BOOST_CHECK_EQUAL("value1", n.getProperty("key1"));
-
-    POWSYBL_ASSERT_THROW(n.getProperty("key3"),
-                         powsybl::PowsyblException, "Property key3 does not exist");
-    BOOST_CHECK_EQUAL("value3", n.getProperty("key3", "value3"));
-}
-
 BOOST_AUTO_TEST_SUITE_END()
 
-}  // namespace iidm
-
-}  // namespace powsybl
+}  // namespace stdcxx


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
`Properties` are generic feature so can be moved into namespace `stdcxx` instead of `iidm`


**What is the current behavior?** *(You can also link to an open issue here)*
`Properties` are located in `iidm` namespace


**What is the new behavior (if this is a feature change)?**
`Properties` are located in `stdcxx` namespace


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
