### PR TITLE
Moved MessageFormat.hpp as stdcxx/format.hpp

### DIFF
--- a/extensions/entsoe/src/EntsoeArea.cpp
+++ b/extensions/entsoe/src/EntsoeArea.cpp
@@ -25,7 +25,7 @@ EntsoeArea::EntsoeArea(Substation& substation, const EntsoeGeographicalCode& cod
 
 void EntsoeArea::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<Substation>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Substation>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Substation>()));
     }
 }
 

--- a/extensions/entsoe/src/EntsoeAreaXmlSerializer.cpp
+++ b/extensions/entsoe/src/EntsoeAreaXmlSerializer.cpp
@@ -35,7 +35,7 @@ EntsoeAreaXmlSerializer::EntsoeAreaXmlSerializer() :
 
 std::unique_ptr<Extension> EntsoeAreaXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<Substation>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Substation>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Substation>()));
     }
     auto& substation = dynamic_cast<Substation&>(extendable);
 

--- a/extensions/entsoe/src/MergedXnode.cpp
+++ b/extensions/entsoe/src/MergedXnode.cpp
@@ -36,20 +36,20 @@ MergedXnode::MergedXnode(Line& line, double rdp, double xdp, double xnodeP1, dou
 
 void MergedXnode::assertExtendable(const stdcxx::Reference<powsybl::iidm::Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<Line>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Line>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Line>()));
     }
 }
 
 double MergedXnode::checkDividerPosition(double dp) {
     if (dp < 0.0 || dp > 1.0) {
-        throw PowsyblException(logging::format("Invalid divider position: %1%", dp));
+        throw PowsyblException(stdcxx::format("Invalid divider position: %1%", dp));
     }
     return dp;
 }
 
 double MergedXnode::checkPowerFlow(double value) {
     if (std::isnan(value)) {
-        throw PowsyblException(logging::format("Power flow is invalid"));
+        throw PowsyblException(stdcxx::format("Power flow is invalid"));
     }
     return value;
 }

--- a/extensions/entsoe/src/MergedXnodeXmlSerializer.cpp
+++ b/extensions/entsoe/src/MergedXnodeXmlSerializer.cpp
@@ -31,7 +31,7 @@ MergedXnodeXmlSerializer::MergedXnodeXmlSerializer() :
 
 std::unique_ptr<Extension> MergedXnodeXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<Line>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Line>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Line>()));
     }
     auto& line = dynamic_cast<Line&>(extendable);
 

--- a/extensions/entsoe/src/Xnode.cpp
+++ b/extensions/entsoe/src/Xnode.cpp
@@ -26,7 +26,7 @@ Xnode::Xnode(DanglingLine& dl, const std::string& code) :
 
 void Xnode::assertExtendable(const stdcxx::Reference<powsybl::iidm::Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<DanglingLine>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<DanglingLine>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<DanglingLine>()));
     }
 }
 

--- a/extensions/entsoe/src/XnodeXmlSerializer.cpp
+++ b/extensions/entsoe/src/XnodeXmlSerializer.cpp
@@ -31,7 +31,7 @@ XnodeXmlSerializer::XnodeXmlSerializer() :
 
 std::unique_ptr<Extension> XnodeXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<DanglingLine>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<DanglingLine>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<DanglingLine>()));
     }
     auto& dl = dynamic_cast<DanglingLine&>(extendable);
 

--- a/extensions/iidm/src/ActivePowerControl.cpp
+++ b/extensions/iidm/src/ActivePowerControl.cpp
@@ -32,7 +32,7 @@ ActivePowerControl::ActivePowerControl(Generator& generator, bool participate, d
 
 void ActivePowerControl::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<Battery>(extendable.get()) && !stdcxx::isInstanceOf<Generator>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% or %3% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Battery>(), stdcxx::demangle<Generator>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% or %3% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Battery>(), stdcxx::demangle<Generator>()));
     }
 }
 

--- a/extensions/iidm/src/ActivePowerControlXmlSerializer.cpp
+++ b/extensions/iidm/src/ActivePowerControlXmlSerializer.cpp
@@ -48,7 +48,7 @@ std::unique_ptr<Extension> ActivePowerControlXmlSerializer::read(Extendable& ext
         return stdcxx::make_unique<Extension, ActivePowerControl>(generator, participate, droop);
     }
 
-    throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Generator>()));
+    throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Generator>()));
 }
 
 void ActivePowerControlXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {

--- a/extensions/iidm/src/CoordinatedReactiveControl.cpp
+++ b/extensions/iidm/src/CoordinatedReactiveControl.cpp
@@ -28,7 +28,7 @@ CoordinatedReactiveControl::CoordinatedReactiveControl(Generator& generator, dou
 
 void CoordinatedReactiveControl::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<Generator>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Generator>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Generator>()));
     }
 }
 
@@ -37,7 +37,7 @@ double CoordinatedReactiveControl::checkQPercent(double qPercent) {
         throw PowsyblException("Undefined value for qPercent");
     }
     if (qPercent < 0.0 || qPercent > 100.0) {
-        throw PowsyblException(logging::format("Unexpected value for qPercent: %1%", qPercent));
+        throw PowsyblException(stdcxx::format("Unexpected value for qPercent: %1%", qPercent));
     }
     return qPercent;
 }

--- a/extensions/iidm/src/CoordinatedReactiveControlXmlSerializer.cpp
+++ b/extensions/iidm/src/CoordinatedReactiveControlXmlSerializer.cpp
@@ -35,7 +35,7 @@ CoordinatedReactiveControlXmlSerializer::CoordinatedReactiveControlXmlSerializer
 
 std::unique_ptr<Extension> CoordinatedReactiveControlXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<Generator>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Generator>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Generator>()));
     }
     auto& generator = dynamic_cast<Generator&>(extendable);
 

--- a/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClock.cpp
+++ b/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClock.cpp
@@ -12,8 +12,8 @@
 #include <powsybl/iidm/PhaseTapChanger.hpp>
 #include <powsybl/iidm/RatioTapChanger.hpp>
 #include <powsybl/iidm/ThreeWindingsTransformer.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/instanceof.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
 

--- a/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClock.cpp
+++ b/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClock.cpp
@@ -12,7 +12,7 @@
 #include <powsybl/iidm/PhaseTapChanger.hpp>
 #include <powsybl/iidm/RatioTapChanger.hpp>
 #include <powsybl/iidm/ThreeWindingsTransformer.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
 #include <powsybl/stdcxx/instanceof.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
@@ -33,13 +33,13 @@ ThreeWindingsTransformerPhaseAngleClock::ThreeWindingsTransformerPhaseAngleClock
 
 void ThreeWindingsTransformerPhaseAngleClock::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<ThreeWindingsTransformer>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<ThreeWindingsTransformer>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<ThreeWindingsTransformer>()));
     }
 }
 
 unsigned long ThreeWindingsTransformerPhaseAngleClock::checkPhaseAngleClock(unsigned long phaseAngleClock) const {
     if (phaseAngleClock > 11) {
-        throw PowsyblException(logging::format("Unexpected value for phaseAngleClock: %1%1", phaseAngleClock));
+        throw PowsyblException(stdcxx::format("Unexpected value for phaseAngleClock: %1%1", phaseAngleClock));
     }
     return phaseAngleClock;
 }

--- a/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.cpp
+++ b/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.cpp
@@ -35,7 +35,7 @@ ThreeWindingsTransformerPhaseAngleClockXmlSerializer::ThreeWindingsTransformerPh
 
 std::unique_ptr<Extension> ThreeWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<ThreeWindingsTransformer>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<ThreeWindingsTransformer>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<ThreeWindingsTransformer>()));
     }
     auto& transformer = dynamic_cast<ThreeWindingsTransformer&>(extendable);
 

--- a/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClock.cpp
+++ b/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClock.cpp
@@ -10,7 +10,7 @@
 #include <powsybl/AssertionError.hpp>
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/TwoWindingsTransformer.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
 #include <powsybl/stdcxx/instanceof.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
@@ -30,13 +30,13 @@ TwoWindingsTransformerPhaseAngleClock::TwoWindingsTransformerPhaseAngleClock(Two
 
 void TwoWindingsTransformerPhaseAngleClock::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<TwoWindingsTransformer>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<TwoWindingsTransformer>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<TwoWindingsTransformer>()));
     }
 }
 
 unsigned long TwoWindingsTransformerPhaseAngleClock::checkPhaseAngleClock(unsigned long phaseAngleClock) const {
     if (phaseAngleClock > 11) {
-        throw PowsyblException(logging::format("Unexpected value for phaseAngleClock: %1%1", phaseAngleClock));
+        throw PowsyblException(stdcxx::format("Unexpected value for phaseAngleClock: %1%1", phaseAngleClock));
     }
     return phaseAngleClock;
 }

--- a/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClock.cpp
+++ b/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClock.cpp
@@ -10,8 +10,8 @@
 #include <powsybl/AssertionError.hpp>
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/TwoWindingsTransformer.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/instanceof.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
 

--- a/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClockXmlSerializer.cpp
+++ b/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClockXmlSerializer.cpp
@@ -33,7 +33,7 @@ TwoWindingsTransformerPhaseAngleClockXmlSerializer::TwoWindingsTransformerPhaseA
 
 std::unique_ptr<Extension> TwoWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<TwoWindingsTransformer>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<TwoWindingsTransformer>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<TwoWindingsTransformer>()));
     }
     auto& transformer = dynamic_cast<TwoWindingsTransformer&>(extendable);
 

--- a/include/powsybl/iidm/BranchAdder.hxx
+++ b/include/powsybl/iidm/BranchAdder.hxx
@@ -12,7 +12,7 @@
 #include <powsybl/iidm/TerminalBuilder.hpp>
 #include <powsybl/iidm/ValidationException.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/include/powsybl/iidm/BranchAdder.hxx
+++ b/include/powsybl/iidm/BranchAdder.hxx
@@ -12,7 +12,7 @@
 #include <powsybl/iidm/TerminalBuilder.hpp>
 #include <powsybl/iidm/ValidationException.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -44,7 +44,7 @@ VoltageLevel& BranchAdder<Adder>::checkAndGetVoltageLevel1() {
 
     stdcxx::Reference<VoltageLevel> voltageLevel1 = this->getNetwork().template find<VoltageLevel>(m_voltageLevelId1);
     if (!voltageLevel1) {
-        throw ValidationException(*this, logging::format("First voltage level '%1%' not found", m_voltageLevelId1));
+        throw ValidationException(*this, stdcxx::format("First voltage level '%1%' not found", m_voltageLevelId1));
     }
 
     return voltageLevel1.get();
@@ -58,7 +58,7 @@ VoltageLevel& BranchAdder<Adder>::checkAndGetVoltageLevel2() {
 
     stdcxx::Reference<VoltageLevel> voltageLevel2 = this->getNetwork().template find<VoltageLevel>(m_voltageLevelId2);
     if (!voltageLevel2) {
-        throw ValidationException(*this, logging::format("Second voltage level '%1%' not found", m_voltageLevelId2));
+        throw ValidationException(*this, stdcxx::format("Second voltage level '%1%' not found", m_voltageLevelId2));
     }
 
     return voltageLevel2.get();

--- a/include/powsybl/iidm/CurrentLimitsAdder.hxx
+++ b/include/powsybl/iidm/CurrentLimitsAdder.hxx
@@ -125,7 +125,7 @@ void CurrentLimitsAdder<S, O>::checkTemporaryLimits() const {
     std::for_each(m_temporaryLimits.cbegin(), m_temporaryLimits.cend(), [this, &names](const std::pair<unsigned long, CurrentLimits::TemporaryLimit>& element) {
         const auto& res = names.insert(element.second.getName());
         if (!res.second) {
-            throw ValidationException(m_owner, logging::format("2 temporary limits have the same name %1%", element.second.getName()));
+            throw ValidationException(m_owner, stdcxx::format("2 temporary limits have the same name %1%", element.second.getName()));
         }
     });
 }

--- a/include/powsybl/iidm/Enum.hxx
+++ b/include/powsybl/iidm/Enum.hxx
@@ -11,8 +11,8 @@
 #include <powsybl/iidm/Enum.hpp>
 
 #include <powsybl/AssertionError.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/include/powsybl/iidm/Enum.hxx
+++ b/include/powsybl/iidm/Enum.hxx
@@ -11,7 +11,7 @@
 #include <powsybl/iidm/Enum.hpp>
 
 #include <powsybl/AssertionError.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
 
 namespace powsybl {
@@ -25,7 +25,7 @@ E fromString(const std::string& name) {
     const auto& names = getNames<E>();
     const auto& it = std::find(names.begin(), names.end(), name);
     if (it == names.end()) {
-        throw powsybl::AssertionError(powsybl::logging::format("Unexpected %1% name: %2%", stdcxx::simpleClassName<E>(), name));
+        throw powsybl::AssertionError(stdcxx::format("Unexpected %1% name: %2%", stdcxx::simpleClassName<E>(), name));
     }
 
     return static_cast<E>(it - names.begin());
@@ -36,7 +36,7 @@ std::string toString(const E& value) {
     auto index = static_cast<unsigned long>(value);
     const auto& names = getNames<E>();
     if (index >= names.size()) {
-        throw powsybl::AssertionError(powsybl::logging::format("Unexpected %1% value: %2%", stdcxx::simpleClassName<E>(), index));
+        throw powsybl::AssertionError(stdcxx::format("Unexpected %1% value: %2%", stdcxx::simpleClassName<E>(), index));
     }
     return *(names.begin() + index);
 }

--- a/include/powsybl/iidm/Extendable.hxx
+++ b/include/powsybl/iidm/Extendable.hxx
@@ -10,7 +10,7 @@
 
 #include <powsybl/iidm/Extendable.hpp>
 
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
 
 namespace powsybl {
@@ -45,7 +45,7 @@ template <typename E, typename>
 const E& Extendable::getExtension() const {
     const auto& it = m_extensionsByType.find(typeid(E));
     if (it == m_extensionsByType.end()) {
-        throw PowsyblException(logging::format("Extension %1% not found", stdcxx::demangle<E>()));
+        throw PowsyblException(stdcxx::format("Extension %1% not found", stdcxx::demangle<E>()));
     }
     return dynamic_cast<E&>(it->second.get());
 }

--- a/include/powsybl/iidm/Extendable.hxx
+++ b/include/powsybl/iidm/Extendable.hxx
@@ -10,8 +10,8 @@
 
 #include <powsybl/iidm/Extendable.hpp>
 
-#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/include/powsybl/iidm/Extension.hxx
+++ b/include/powsybl/iidm/Extension.hxx
@@ -11,7 +11,7 @@
 #include <powsybl/iidm/Extension.hpp>
 
 #include <powsybl/AssertionError.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
 #include <powsybl/stdcxx/instanceof.hpp>
 #include <powsybl/stdcxx/memory.hpp>
@@ -28,7 +28,7 @@ std::unique_ptr<Extension> Extension::create(Args&&... args) {
 template <typename E, typename>
 stdcxx::CReference<E> Extension::getExtendable() const {
     if (m_extendable && !stdcxx::isInstanceOf<E>(m_extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle<E>(), stdcxx::demangle(m_extendable.get())));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle<E>(), stdcxx::demangle(m_extendable.get())));
     }
     return stdcxx::cref<E>(m_extendable);
 }
@@ -36,7 +36,7 @@ stdcxx::CReference<E> Extension::getExtendable() const {
 template <typename E, typename>
 stdcxx::Reference<E> Extension::getExtendable() {
     if (m_extendable && !stdcxx::isInstanceOf<E>(m_extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle<E>(), stdcxx::demangle(m_extendable.get())));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle<E>(), stdcxx::demangle(m_extendable.get())));
     }
     return stdcxx::ref<E>(m_extendable);
 }

--- a/include/powsybl/iidm/Extension.hxx
+++ b/include/powsybl/iidm/Extension.hxx
@@ -11,8 +11,8 @@
 #include <powsybl/iidm/Extension.hpp>
 
 #include <powsybl/AssertionError.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/instanceof.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 

--- a/include/powsybl/iidm/IdentifiableAdder.hxx
+++ b/include/powsybl/iidm/IdentifiableAdder.hxx
@@ -25,7 +25,7 @@ std::string IdentifiableAdder<Adder>::getMessageHeader() const {
 template <typename Adder>
 std::string IdentifiableAdder<Adder>::checkAndGetUniqueId() const {
     if (m_id.empty()) {
-        throw PowsyblException(logging::format("%1% id is not set", getTypeDescription()));
+        throw PowsyblException(stdcxx::format("%1% id is not set", getTypeDescription()));
     }
 
     const auto& network = getNetwork();
@@ -38,7 +38,7 @@ std::string IdentifiableAdder<Adder>::checkAndGetUniqueId() const {
     } else {
         const auto& obj = network.find(m_id);
         if (obj) {
-            throw PowsyblException(logging::format("The network %1% already contains an object '%2%' with the id '%3%'", network.getId(), stdcxx::simpleClassName(obj.get()), m_id));
+            throw PowsyblException(stdcxx::format("The network %1% already contains an object '%2%' with the id '%3%'", network.getId(), stdcxx::simpleClassName(obj.get()), m_id));
         }
         uniqueId = m_id;
     }

--- a/include/powsybl/iidm/NetworkIndex.hxx
+++ b/include/powsybl/iidm/NetworkIndex.hxx
@@ -15,7 +15,7 @@
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/LccConverterStation.hpp>
 #include <powsybl/iidm/VscConverterStation.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
 
@@ -35,7 +35,7 @@ T& NetworkIndex::checkAndAdd(std::unique_ptr<T>&& identifiable) {
 
     auto other = m_objectsById.find(identifiable->getId());
     if (other != m_objectsById.end()) {
-        throw PowsyblException(logging::format("Object '%1%' already exists (%2%)", identifiable->getId(), stdcxx::demangle(*other->second)));
+        throw PowsyblException(stdcxx::format("Object '%1%' already exists (%2%)", identifiable->getId(), stdcxx::demangle(*other->second)));
     }
 
     auto it = m_objectsById.emplace(std::make_pair(identifiable->getId(), std::move(identifiable)));
@@ -52,12 +52,12 @@ const T& NetworkIndex::get(const std::string& id) const {
 
     const auto& it = m_objectsById.find(id);
     if (it == m_objectsById.end()) {
-        throw PowsyblException(logging::format("Unable to find to the identifiable '%1%'", id));
+        throw PowsyblException(stdcxx::format("Unable to find to the identifiable '%1%'", id));
     }
 
     auto* identifiable = dynamic_cast<T*>(it->second.get());
     if (identifiable == nullptr) {
-        throw PowsyblException(logging::format("Identifiable '%1%' is not a %2%", id, stdcxx::demangle<T>()));
+        throw PowsyblException(stdcxx::format("Identifiable '%1%' is not a %2%", id, stdcxx::demangle<T>()));
     }
 
     return *identifiable;

--- a/include/powsybl/iidm/NetworkIndex.hxx
+++ b/include/powsybl/iidm/NetworkIndex.hxx
@@ -15,8 +15,8 @@
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/LccConverterStation.hpp>
 #include <powsybl/iidm/VscConverterStation.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
 
 namespace powsybl {

--- a/include/powsybl/iidm/ReactiveLimitsHolder.hxx
+++ b/include/powsybl/iidm/ReactiveLimitsHolder.hxx
@@ -11,8 +11,8 @@
 #include <powsybl/iidm/ReactiveLimitsHolder.hpp>
 
 #include <powsybl/iidm/ValidationException.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/instanceof.hpp>
 
 namespace powsybl {

--- a/include/powsybl/iidm/ReactiveLimitsHolder.hxx
+++ b/include/powsybl/iidm/ReactiveLimitsHolder.hxx
@@ -11,7 +11,7 @@
 #include <powsybl/iidm/ReactiveLimitsHolder.hpp>
 
 #include <powsybl/iidm/ValidationException.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
 #include <powsybl/stdcxx/instanceof.hpp>
 
@@ -27,7 +27,7 @@ const T& ReactiveLimitsHolder::getReactiveLimits() const {
     }
 
     const auto& validable = dynamic_cast<const Validable&>(*this);
-    throw ValidationException(validable, logging::format("Incorrect reactive limits type %1%, expected %2%", stdcxx::simpleClassName<T>(), stdcxx::simpleClassName(*m_reactiveLimits)));
+    throw ValidationException(validable, stdcxx::format("Incorrect reactive limits type %1%, expected %2%", stdcxx::simpleClassName<T>(), stdcxx::simpleClassName(*m_reactiveLimits)));
 }
 
 template <typename T, typename>

--- a/include/powsybl/iidm/VoltageLevel.hxx
+++ b/include/powsybl/iidm/VoltageLevel.hxx
@@ -38,23 +38,23 @@ stdcxx::CReference<T> VoltageLevel::getConnectable(const std::string& id) const 
         if (stdcxx::isInstanceOf<Injection>(connectable.get())) {
             const auto& injection = dynamic_cast<const Injection&>(connectable.get());
             if (!stdcxx::areSame(injection.getTerminal().getVoltageLevel(), *this)) {
-                throw PowsyblException(logging::format("The injection '%1%' is not connected to the voltage level '%2%'", id, getId()));
+                throw PowsyblException(stdcxx::format("The injection '%1%' is not connected to the voltage level '%2%'", id, getId()));
             }
         } else if (stdcxx::isInstanceOf<Branch>(connectable.get())) {
             const auto& branch = dynamic_cast<const Branch&>(connectable.get());
             if (!stdcxx::areSame(branch.getTerminal1().getVoltageLevel(), *this) &&
                 !stdcxx::areSame(branch.getTerminal2().getVoltageLevel(), *this)) {
-                throw PowsyblException(logging::format("The branch '%1%' is not connected to the voltage level '%2%'", id, getId()));
+                throw PowsyblException(stdcxx::format("The branch '%1%' is not connected to the voltage level '%2%'", id, getId()));
             }
         } else if (stdcxx::isInstanceOf<ThreeWindingsTransformer>(connectable.get())) {
             const auto& transformer = dynamic_cast<const ThreeWindingsTransformer&>(connectable.get());
             if (!stdcxx::areSame(transformer.getTerminal(ThreeWindingsTransformer::Side::ONE).getVoltageLevel(), *this) &&
                 !stdcxx::areSame(transformer.getTerminal(ThreeWindingsTransformer::Side::TWO).getVoltageLevel(), *this) &&
                 !stdcxx::areSame(transformer.getTerminal(ThreeWindingsTransformer::Side::THREE).getVoltageLevel(), *this)) {
-                throw PowsyblException(logging::format("The 3 windings transformer '%1%' is not connected to the voltage level '%2%'", id, getId()));
+                throw PowsyblException(stdcxx::format("The 3 windings transformer '%1%' is not connected to the voltage level '%2%'", id, getId()));
             }
         } else {
-            throw AssertionError(logging::format("Unexpected ConnectableType value: %1%", connectable.get().getType()));
+            throw AssertionError(stdcxx::format("Unexpected ConnectableType value: %1%", connectable.get().getType()));
         }
     }
 

--- a/include/powsybl/iidm/converter/xml/ExtensionXmlSerializer.hxx
+++ b/include/powsybl/iidm/converter/xml/ExtensionXmlSerializer.hxx
@@ -11,7 +11,7 @@
 #include <powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
 #include <powsybl/stdcxx/instanceof.hpp>
 
@@ -26,7 +26,7 @@ namespace xml {
 template <typename E>
 const E& ExtensionXmlSerializer::safeCast(const Extension& extension) const {
     if (!stdcxx::isInstanceOf<E>(extension)) {
-        throw PowsyblException(logging::format("Unexpected extension type: %1% (%2% expected)", stdcxx::demangle(extension), stdcxx::demangle<E>()));
+        throw PowsyblException(stdcxx::format("Unexpected extension type: %1% (%2% expected)", stdcxx::demangle(extension), stdcxx::demangle<E>()));
     }
 
     return dynamic_cast<const E&>(extension);

--- a/include/powsybl/iidm/converter/xml/ExtensionXmlSerializer.hxx
+++ b/include/powsybl/iidm/converter/xml/ExtensionXmlSerializer.hxx
@@ -11,8 +11,8 @@
 #include <powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/instanceof.hpp>
 
 namespace powsybl {

--- a/include/powsybl/logging/Logger.hxx
+++ b/include/powsybl/logging/Logger.hxx
@@ -10,7 +10,7 @@
 
 #include <powsybl/logging/Logger.hpp>
 
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/include/powsybl/logging/Logger.hxx
+++ b/include/powsybl/logging/Logger.hxx
@@ -10,7 +10,7 @@
 
 #include <powsybl/logging/Logger.hpp>
 
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -19,35 +19,35 @@ namespace logging {
 template <typename... T>
 void Logger::debug(const std::string& message, const T&... args) {
     if (isDebugEnabled()) {
-        log(Level::DEBUG, format(message, args...));
+        log(Level::DEBUG, stdcxx::format(message, args...));
     }
 }
 
 template <typename... T>
 void Logger::error(const std::string& message, const T&... args) {
     if (isErrorEnabled()) {
-        log(Level::ERROR, format(message, args...));
+        log(Level::ERROR, stdcxx::format(message, args...));
     }
 }
 
 template <typename... T>
 void Logger::info(const std::string& message, const T&... args) {
     if (isInfoEnabled()) {
-        log(Level::INFO, format(message, args...));
+        log(Level::INFO, stdcxx::format(message, args...));
     }
 }
 
 template <typename... T>
 void Logger::trace(const std::string& message, const T&... args) {
     if (isTraceEnabled()) {
-        log(Level::TRACE, format(message, args...));
+        log(Level::TRACE, stdcxx::format(message, args...));
     }
 }
 
 template <typename... T>
 void Logger::warn(const std::string& message, const T&... args) {
     if (isWarnEnabled()) {
-        log(Level::WARN, format(message, args...));
+        log(Level::WARN, stdcxx::format(message, args...));
     }
 }
 

--- a/include/powsybl/math/UndirectedGraph.hxx
+++ b/include/powsybl/math/UndirectedGraph.hxx
@@ -17,7 +17,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/counting_range.hpp>
 
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 
 namespace powsybl {

--- a/include/powsybl/math/UndirectedGraph.hxx
+++ b/include/powsybl/math/UndirectedGraph.hxx
@@ -17,7 +17,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/counting_range.hpp>
 
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 
 namespace powsybl {
@@ -27,14 +27,14 @@ namespace math {
 template <typename V, typename E>
 void UndirectedGraph<V, E>::checkEdge(unsigned long e) const {
     if (e >= m_edges.size() || !m_edges[e]) {
-        throw PowsyblException(logging::format("Edge %1% not found", e));
+        throw PowsyblException(stdcxx::format("Edge %1% not found", e));
     }
 }
 
 template <typename V, typename E>
 void UndirectedGraph<V, E>::checkVertex(unsigned long v) const {
     if (v >= m_vertices.size() || !m_vertices[v]) {
-        throw PowsyblException(logging::format("Vertex %1% not found", v));
+        throw PowsyblException(stdcxx::format("Vertex %1% not found", v));
     }
 }
 
@@ -126,7 +126,7 @@ void UndirectedGraph<V, E>::findAllPaths(unsigned long v, const VertexVisitor& p
                 continue;
             }
         } else {
-            throw PowsyblException(logging::format("Edge %1% is not connected to vertex %2%", e, v));
+            throw PowsyblException(stdcxx::format("Edge %1% is not connected to vertex %2%", e, v));
         }
     }
 }
@@ -357,7 +357,7 @@ stdcxx::Reference<V> UndirectedGraph<V, E>::removeVertex(unsigned long v) {
 
     for (const auto& edge : m_edges) {
         if (edge && (edge->getVertex1() == v || edge->getVertex2() == v)) {
-            throw PowsyblException(logging::format("An edge is connected to the vertex %1%", v));
+            throw PowsyblException(stdcxx::format("An edge is connected to the vertex %1%", v));
 
         }
     }

--- a/include/powsybl/stdcxx/MessageFormat.hpp
+++ b/include/powsybl/stdcxx/MessageFormat.hpp
@@ -5,16 +5,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#ifndef POWSYBL_LOGGING_MESSAGEFORMAT_HPP
-#define POWSYBL_LOGGING_MESSAGEFORMAT_HPP
+#ifndef POWSYBL_STDCXX_MESSAGEFORMAT_HPP
+#define POWSYBL_STDCXX_MESSAGEFORMAT_HPP
 
-#include <array>
-#include <set>
 #include <string>
 
-namespace powsybl {
-
-namespace logging {
+namespace stdcxx {
 
 /**
  * Format a message with the specified parameters
@@ -41,10 +37,8 @@ std::string format(const std::string& message, const Args&... args);
 template <typename T>
 std::string toString(const T& value);
 
-}  // namespace logging
+}  // namespace stdcxx
 
-}  // namespace powsybl
+#include <powsybl/stdcxx/MessageFormat.hxx>
 
-#include <powsybl/logging/MessageFormat.hxx>
-
-#endif  // POWSYBL_LOGGING_MESSAGEFORMAT_HPP
+#endif  // POWSYBL_STDCXX_MESSAGEFORMAT_HPP

--- a/include/powsybl/stdcxx/MessageFormat.hxx
+++ b/include/powsybl/stdcxx/MessageFormat.hxx
@@ -5,21 +5,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#ifndef POWSYBL_LOGGING_MESSAGEFORMAT_HXX
-#define POWSYBL_LOGGING_MESSAGEFORMAT_HXX
+#ifndef POWSYBL_STDCXX_MESSAGEFORMAT_HXX
+#define POWSYBL_STDCXX_MESSAGEFORMAT_HXX
 
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 #include <iterator>
+#include <set>
 #include <sstream>
+#include <vector>
 
 #include <boost/format.hpp>
 
 #include <powsybl/stdcxx/range.hpp>
 
-namespace powsybl {
-
-namespace logging {
+namespace stdcxx {
 
 inline void format(const boost::format& /*fmt*/) {
     // This function is used to stop the recursion
@@ -103,8 +103,6 @@ std::ostream& operator<<(std::ostream& stream, const std::reference_wrapper<T>& 
     return stream;
 }
 
-}  // namespace logging
+}  // namespace stdcxx
 
-}  // namespace powsybl
-
-#endif  // POWSYBL_LOGGING_MESSAGEFORMAT_HXX
+#endif  // POWSYBL_STDCXX_MESSAGEFORMAT_HXX

--- a/include/powsybl/stdcxx/format.hpp
+++ b/include/powsybl/stdcxx/format.hpp
@@ -39,6 +39,6 @@ std::string toString(const T& value);
 
 }  // namespace stdcxx
 
-#include <powsybl/stdcxx/MessageFormat.hxx>
+#include <powsybl/stdcxx/format.hxx>
 
 #endif  // POWSYBL_STDCXX_MESSAGEFORMAT_HPP

--- a/include/powsybl/stdcxx/format.hxx
+++ b/include/powsybl/stdcxx/format.hxx
@@ -8,7 +8,7 @@
 #ifndef POWSYBL_STDCXX_MESSAGEFORMAT_HXX
 #define POWSYBL_STDCXX_MESSAGEFORMAT_HXX
 
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 #include <iterator>
 #include <set>

--- a/src/iidm/AbstractMultiVariantConnectableExtension.cpp
+++ b/src/iidm/AbstractMultiVariantConnectableExtension.cpp
@@ -13,7 +13,7 @@
 #include <powsybl/iidm/Terminal.hpp>
 #include <powsybl/iidm/VariantManagerHolder.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/iidm/AbstractMultiVariantConnectableExtension.cpp
+++ b/src/iidm/AbstractMultiVariantConnectableExtension.cpp
@@ -13,7 +13,7 @@
 #include <powsybl/iidm/Terminal.hpp>
 #include <powsybl/iidm/VariantManagerHolder.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -40,7 +40,7 @@ const VariantManagerHolder& AbstractMultiVariantConnectableExtension::getVariant
         return dynamic_cast<const VariantManagerHolder&>(network);
     }
 
-    throw PowsyblException(logging::format("Network cannot be converted to VariantManagerHolder"));
+    throw PowsyblException(stdcxx::format("Network cannot be converted to VariantManagerHolder"));
 }
 
 }  // namespace iidm

--- a/src/iidm/Branch.cpp
+++ b/src/iidm/Branch.cpp
@@ -13,7 +13,7 @@
 #include <powsybl/iidm/Enum.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
 #include <powsybl/iidm/util/LimitViolationUtils.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 
 namespace powsybl {

--- a/src/iidm/Branch.cpp
+++ b/src/iidm/Branch.cpp
@@ -13,7 +13,7 @@
 #include <powsybl/iidm/Enum.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
 #include <powsybl/iidm/util/LimitViolationUtils.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 
 namespace powsybl {
@@ -123,7 +123,7 @@ const std::unique_ptr<CurrentLimits>& Branch::getCurrentLimitsPtr(const Side& si
             return m_limits2;
 
         default:
-            throw AssertionError(logging::format("Unexpected side value: %1%", side));
+            throw AssertionError(stdcxx::format("Unexpected side value: %1%", side));
     }
 }
 
@@ -157,7 +157,7 @@ const Terminal& Branch::getTerminal(const Side& side) const {
             return getTerminals().at(1).get();
 
         default:
-            throw AssertionError(logging::format("Unexpected side value: %1%", side));
+            throw AssertionError(stdcxx::format("Unexpected side value: %1%", side));
     }
 }
 
@@ -169,7 +169,7 @@ const Terminal& Branch::getTerminal(const std::string& voltageLevelId) const {
     bool side1 = getTerminal1().getVoltageLevel().getId() == voltageLevelId;
     bool side2 = getTerminal2().getVoltageLevel().getId() == voltageLevelId;
     if (side1 && side2) {
-        throw PowsyblException(logging::format("Both terminals are connected to voltage level %1%", voltageLevelId));
+        throw PowsyblException(stdcxx::format("Both terminals are connected to voltage level %1%", voltageLevelId));
     }
     if (side1) {
         return getTerminal1();
@@ -178,7 +178,7 @@ const Terminal& Branch::getTerminal(const std::string& voltageLevelId) const {
         return getTerminal2();
     }
 
-    throw PowsyblException(logging::format("No terminal connected to voltage level %1%", voltageLevelId));
+    throw PowsyblException(stdcxx::format("No terminal connected to voltage level %1%", voltageLevelId));
 }
 
 Terminal& Branch::getTerminal(const std::string& voltageLevelId) {
@@ -228,7 +228,7 @@ void Branch::setCurrentLimits(const Branch::Side& side, std::unique_ptr<CurrentL
             break;
 
         default:
-            throw AssertionError(logging::format("Unexpected side value: %1%", side));
+            throw AssertionError(stdcxx::format("Unexpected side value: %1%", side));
     }
 }
 

--- a/src/iidm/BusBreakerVoltageLevel.cpp
+++ b/src/iidm/BusBreakerVoltageLevel.cpp
@@ -71,7 +71,7 @@ void BusBreakerVoltageLevel::attach(Terminal& terminal, bool test) {
 void BusBreakerVoltageLevel::checkTerminal(Terminal& terminal) const {
     if (!stdcxx::isInstanceOf<BusTerminal>(terminal)) {
         throw ValidationException(terminal.getConnectable(),
-                                  logging::format("Voltage level '%1%' has a bus/breaker topology, a bus connection should be specified instead of a node connection",
+                                  stdcxx::format("Voltage level '%1%' has a bus/breaker topology, a bus connection should be specified instead of a node connection",
                                                   getId()));
     }
 
@@ -165,7 +165,7 @@ stdcxx::CReference<ConfiguredBus> BusBreakerVoltageLevel::getConfiguredBus(const
     if (v.is_initialized()) {
         bus = m_graph.getVertexObject(*v);
         if (bus.get().getId() != busId) {
-            throw PowsyblException(logging::format("Invalid bus id (expected: '%1%', actual: '%2%')", busId, bus.get().getId()));
+            throw PowsyblException(stdcxx::format("Invalid bus id (expected: '%1%', actual: '%2%')", busId, bus.get().getId()));
         }
     }
 
@@ -199,7 +199,7 @@ stdcxx::optional<unsigned long> BusBreakerVoltageLevel::getEdge(const std::strin
         return {};
     }
 
-    throw PowsyblException(logging::format("Switch '%1%' not found in the voltage level '%2%'", switchId, getId()));
+    throw PowsyblException(stdcxx::format("Switch '%1%' not found in the voltage level '%2%'", switchId, getId()));
 }
 
 const BusBreakerVoltageLevel::Graph& BusBreakerVoltageLevel::getGraph() const {
@@ -225,7 +225,7 @@ stdcxx::Reference<Switch> BusBreakerVoltageLevel::getSwitch(const std::string& s
     if (e.is_initialized()) {
         aSwitch = m_graph.getEdgeObject(*e);
         if (aSwitch.get().getId() != switchId) {
-            throw PowsyblException(logging::format("Invalid switch id (expected: '%1%', actual: '%2%')", switchId, aSwitch.get().getId()));
+            throw PowsyblException(stdcxx::format("Invalid switch id (expected: '%1%', actual: '%2%')", switchId, aSwitch.get().getId()));
         }
     }
 
@@ -283,7 +283,7 @@ stdcxx::optional<unsigned long> BusBreakerVoltageLevel::getVertex(const std::str
         return {};
     }
 
-    throw PowsyblException(logging::format("Bus '%1%' not found in the voltage level '%2%'", busId, getId()));
+    throw PowsyblException(stdcxx::format("Bus '%1%' not found in the voltage level '%2%'", busId, getId()));
 }
 
 void BusBreakerVoltageLevel::invalidateCache() {
@@ -299,12 +299,12 @@ void BusBreakerVoltageLevel::reduceVariantArraySize(unsigned long number) {
 
 void BusBreakerVoltageLevel::removeAllBuses() {
     if (m_graph.getEdgeCount() > 0) {
-        throw ValidationException(*this, logging::format("Cannot remove all buses because there is still some switches"));
+        throw ValidationException(*this, stdcxx::format("Cannot remove all buses because there is still some switches"));
     }
     for (const auto& it : m_graph.getVertexObjects()) {
         const auto& bus = it.get();
         if (bus.getTerminalCount() > 0) {
-            throw ValidationException(*this, logging::format("Cannot remove bus '%1%' due to connected equipments", bus.getId()));
+            throw ValidationException(*this, stdcxx::format("Cannot remove bus '%1%' due to connected equipments", bus.getId()));
         }
     }
     for (const auto& it : m_graph.getVertexObjects()) {
@@ -327,7 +327,7 @@ void BusBreakerVoltageLevel::removeAllSwitches() {
 void BusBreakerVoltageLevel::removeBus(const std::string& busId) {
     const auto& bus = getConfiguredBus(busId, true);
     if (bus.get().getTerminalCount() > 0) {
-        throw ValidationException(*this, logging::format("Cannot remove bus '%1%' due to connectable equipments", busId));
+        throw ValidationException(*this, stdcxx::format("Cannot remove bus '%1%' due to connectable equipments", busId));
     }
 
     for (const auto& it : m_switches) {
@@ -339,7 +339,7 @@ void BusBreakerVoltageLevel::removeBus(const std::string& busId) {
         const auto& bus1 = m_graph.getVertexObject(v1);
         const auto& bus2 = m_graph.getVertexObject(v2);
         if ((bus == bus1) || (bus == bus2)) {
-            throw PowsyblException(logging::format("Cannot remove bus '%1%' due to the connected switch '%2%'", busId, switchId));
+            throw PowsyblException(stdcxx::format("Cannot remove bus '%1%' due to the connected switch '%2%'", busId, switchId));
         }
     }
 
@@ -352,7 +352,7 @@ void BusBreakerVoltageLevel::removeBus(const std::string& busId) {
 void BusBreakerVoltageLevel::removeSwitch(const std::string& switchId) {
     const auto& it = m_switches.find(switchId);
     if (it == m_switches.end()) {
-        throw PowsyblException(logging::format("Switch '%1%' not found in voltage level '%2%'", switchId, getId()));
+        throw PowsyblException(stdcxx::format("Switch '%1%' not found in voltage level '%2%'", switchId, getId()));
     }
 
     const auto& aSwitch = m_graph.removeEdge(it->second);

--- a/src/iidm/BusBreakerVoltageLevelTopology.cpp
+++ b/src/iidm/BusBreakerVoltageLevelTopology.cpp
@@ -9,8 +9,8 @@
 
 #include <powsybl/AssertionError.hpp>
 #include <powsybl/iidm/Switch.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
 #include <powsybl/math/TraverseResult.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
 #include <powsybl/stdcxx/set.hpp>
@@ -28,8 +28,8 @@ CalculatedBusTopology::CalculatedBusTopology(BusBreakerVoltageLevel& voltageLeve
 }
 
 std::unique_ptr<MergedBus> CalculatedBusTopology::createMergedBus(unsigned long busCount, const MergedBus::BusSet& busSet) const {
-    const std::string& mergedBusId = logging::format("%1%_%2%", m_voltageLevel.getId(), busCount);
-    const std::string& mergedBusName = m_voltageLevel.getName().empty() ? "" : logging::format("%1%_%2%", m_voltageLevel.getName(), busCount);
+    const std::string& mergedBusId = stdcxx::format("%1%_%2%", m_voltageLevel.getId(), busCount);
+    const std::string& mergedBusName = m_voltageLevel.getName().empty() ? "" : stdcxx::format("%1%_%2%", m_voltageLevel.getName(), busCount);
 
     return stdcxx::make_unique<MergedBus>(mergedBusId, mergedBusName, busSet);
 }
@@ -39,7 +39,7 @@ stdcxx::Reference<MergedBus> CalculatedBusTopology::getMergedBus(const std::stri
 
     stdcxx::Reference<MergedBus> bus = m_cache->getMergedBus(id);
     if (throwException && !bus) {
-        throw PowsyblException(logging::format("Bus %1% not found in voltage level %2%", id, m_voltageLevel.getId()));
+        throw PowsyblException(stdcxx::format("Bus %1% not found in voltage level %2%", id, m_voltageLevel.getId()));
     }
 
     return bus;
@@ -90,7 +90,7 @@ bool CalculatedBusTopology::isBusValid(const MergedBus::BusSet& buses) const {
                     break;
 
                 case ConnectableType::BUSBAR_SECTION: // must not happen in a bus/breaker topology
-                    throw AssertionError(logging::format("Unexpected ConnectableType value: %1%", connectable.getType()));
+                    throw AssertionError(stdcxx::format("Unexpected ConnectableType value: %1%", connectable.getType()));
             }
         }
     }

--- a/src/iidm/BusBreakerVoltageLevelTopology.cpp
+++ b/src/iidm/BusBreakerVoltageLevelTopology.cpp
@@ -10,7 +10,7 @@
 #include <powsybl/AssertionError.hpp>
 #include <powsybl/iidm/Switch.hpp>
 #include <powsybl/math/TraverseResult.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
 #include <powsybl/stdcxx/set.hpp>

--- a/src/iidm/ConfiguredBus.cpp
+++ b/src/iidm/ConfiguredBus.cpp
@@ -10,7 +10,7 @@
 #include <cmath>
 
 #include <powsybl/iidm/Connectable.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/math.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 
@@ -141,7 +141,7 @@ void ConfiguredBus::removeTerminal(BusTerminal& terminal) {
     if (it != terminals.end()) {
         terminals.erase(it);
     } else {
-        throw PowsyblException(logging::format("Terminal %1% not found", terminal));
+        throw PowsyblException(stdcxx::format("Terminal %1% not found", terminal));
     }
 }
 

--- a/src/iidm/ConfiguredBus.cpp
+++ b/src/iidm/ConfiguredBus.cpp
@@ -10,7 +10,7 @@
 #include <cmath>
 
 #include <powsybl/iidm/Connectable.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/math.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 

--- a/src/iidm/Country.cpp
+++ b/src/iidm/Country.cpp
@@ -11,7 +11,7 @@
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/Enum.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/iidm/Country.cpp
+++ b/src/iidm/Country.cpp
@@ -11,7 +11,7 @@
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/Enum.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -272,7 +272,7 @@ std::string getCountryName(const Country& country) {
 
     auto index = static_cast<unsigned long>(country);
     if (index >= s_countryNames.size()) {
-        throw powsybl::AssertionError(powsybl::logging::format("Unexpected %1% value: %2%", stdcxx::simpleClassName<Country>(), index));
+        throw powsybl::AssertionError(stdcxx::format("Unexpected %1% value: %2%", stdcxx::simpleClassName<Country>(), index));
     }
     return *(s_countryNames.begin() + index);
 }

--- a/src/iidm/Extension.cpp
+++ b/src/iidm/Extension.cpp
@@ -7,7 +7,7 @@
 
 #include <powsybl/iidm/Extension.hpp>
 
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 
 namespace powsybl {

--- a/src/iidm/Extension.cpp
+++ b/src/iidm/Extension.cpp
@@ -7,7 +7,7 @@
 
 #include <powsybl/iidm/Extension.hpp>
 
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 
 namespace powsybl {
@@ -26,7 +26,7 @@ void Extension::setExtendable(const stdcxx::Reference<Extendable>& extendable) {
     assertExtendable(extendable);
 
     if (m_extendable && extendable && !stdcxx::areSame(m_extendable.get(), extendable.get())) {
-        throw PowsyblException(logging::format("Extension is already associated to the extendable %1%", m_extendable));
+        throw PowsyblException(stdcxx::format("Extension is already associated to the extendable %1%", m_extendable));
     }
     m_extendable = extendable;
 }

--- a/src/iidm/ExtensionProviders.cpp
+++ b/src/iidm/ExtensionProviders.cpp
@@ -17,7 +17,7 @@
 #include <powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp>
 #include <powsybl/logging/Logger.hpp>
 #include <powsybl/logging/LoggerFactory.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -39,7 +39,7 @@ template <typename T, typename Dummy>
 const T& ExtensionProviders<T, Dummy>::findProviderOrThrowException(const std::string& name) const {
     const auto& it = m_providers.find(name);
     if (it == m_providers.end()) {
-        throw PowsyblException(logging::format("No provider found for extension '%1'", name));
+        throw PowsyblException(stdcxx::format("No provider found for extension '%1'", name));
     }
     return *it->second;
 }
@@ -63,11 +63,11 @@ stdcxx::range<T> ExtensionProviders<T, Dummy>::getProviders() {
 template <typename T, typename Dummy>
 void ExtensionProviders<T, Dummy>::loadExtensions(const boost::filesystem::path& directory, const std::regex& pattern) {
     if (!boost::filesystem::exists(directory)) {
-        throw PowsyblException(logging::format("Path %1% does not exist", directory));
+        throw PowsyblException(stdcxx::format("Path %1% does not exist", directory));
     }
 
     if (!boost::filesystem::is_directory(directory)) {
-        throw PowsyblException(logging::format("Path %1% is not a directory", directory));
+        throw PowsyblException(stdcxx::format("Path %1% is not a directory", directory));
     }
 
     for (const auto& it : boost::filesystem::directory_iterator(directory)) {
@@ -91,14 +91,14 @@ void ExtensionProviders<T, Dummy>::loadLibrary(const boost::filesystem::path& li
                     const std::string& extensionName = it->getExtensionName();
                     const auto& status = m_providers.emplace(std::make_pair(extensionName, std::move(it)));
                     if (!status.second) {
-                        throw PowsyblException(logging::format("Extension %1% was already registered", extensionName));
+                        throw PowsyblException(stdcxx::format("Extension %1% was already registered", extensionName));
                     }
-                    logger.debug(logging::format("Extension %1% has been loaded from %2%", extensionName, libraryPath));
+                    logger.debug(stdcxx::format("Extension %1% has been loaded from %2%", extensionName, libraryPath));
                 }
                 m_loadedLibraries.insert(libraryPath);
             }
         } catch (const boost::system::system_error& err) {
-            logger.info(logging::format("Unable to load file %1%: %2%", libraryPath, err.what()));
+            logger.info(stdcxx::format("Unable to load file %1%: %2%", libraryPath, err.what()));
         }
     }
 }

--- a/src/iidm/ExtensionProviders.cpp
+++ b/src/iidm/ExtensionProviders.cpp
@@ -17,7 +17,7 @@
 #include <powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp>
 #include <powsybl/logging/Logger.hpp>
 #include <powsybl/logging/LoggerFactory.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/iidm/HvdcLineAdder.cpp
+++ b/src/iidm/HvdcLineAdder.cpp
@@ -42,11 +42,11 @@ HvdcLine& HvdcLineAdder::add() {
 }
 
 HvdcConverterStation& HvdcLineAdder::getConverterStation(const std::string& converterStationId, unsigned int side) const {
-    checkNotEmpty(converterStationId, logging::format("Side %1% converter station not set", side));
+    checkNotEmpty(converterStationId, stdcxx::format("Side %1% converter station not set", side));
 
     stdcxx::Reference<HvdcConverterStation> converterStation = m_network.find<HvdcConverterStation>(converterStationId);
     if (!converterStation) {
-        throw PowsyblException(logging::format("Side %1% converter station %2% not found", side, converterStationId));
+        throw PowsyblException(stdcxx::format("Side %1% converter station %2% not found", side, converterStationId));
     }
     return converterStation.get();
 }

--- a/src/iidm/Identifiable.cpp
+++ b/src/iidm/Identifiable.cpp
@@ -6,20 +6,20 @@
  */
 
 #include <powsybl/iidm/Identifiable.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 #include "ValidationUtils.hpp"
 
-namespace powsybl {
-
-namespace logging {
+namespace stdcxx {
 
 template <>
-std::string toString(const iidm::Identifiable& value) {
+std::string toString(const powsybl::iidm::Identifiable& value) {
     return value.getId();
 }
 
-}  // namespace logging
+}  // namespace stdcxx
+
+namespace powsybl {
 
 namespace iidm {
 
@@ -73,7 +73,7 @@ stdcxx::optional<std::string> Identifiable::setProperty(const std::string& key, 
 }
 
 std::ostream& operator<<(std::ostream& stream, const Identifiable& identifiable) {
-    stream << logging::toString(identifiable);
+    stream << stdcxx::toString(identifiable);
 
     return stream;
 }

--- a/src/iidm/Identifiable.cpp
+++ b/src/iidm/Identifiable.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <powsybl/iidm/Identifiable.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 #include "ValidationUtils.hpp"
 

--- a/src/iidm/NetworkIndex.cpp
+++ b/src/iidm/NetworkIndex.cpp
@@ -40,7 +40,7 @@ const Identifiable& NetworkIndex::get(const std::string& id) const {
 
     const auto& it = m_objectsById.find(id);
     if (it == m_objectsById.end()) {
-        throw PowsyblException(logging::format("Unable to find to the identifiable '%1%'", id));
+        throw PowsyblException(stdcxx::format("Unable to find to the identifiable '%1%'", id));
     }
 
     return *(it->second.get());

--- a/src/iidm/NodeBreakerVoltageLevel.cpp
+++ b/src/iidm/NodeBreakerVoltageLevel.cpp
@@ -56,7 +56,7 @@ void NodeBreakerVoltageLevel::attach(Terminal& terminal, bool test) {
         const stdcxx::Reference<NodeTerminal>& tmp = m_graph.getVertexObject(node);
         if (static_cast<bool>(tmp)) {
             throw ValidationException(terminal.getConnectable(),
-                logging::format("An equipment (%1%) is already connected to the node %2% of voltage level %3%",
+                stdcxx::format("An equipment (%1%) is already connected to the node %2% of voltage level %3%",
                                 tmp.get().getConnectable().get().getId(), node, getId()));
         }
 
@@ -68,7 +68,7 @@ void NodeBreakerVoltageLevel::attach(Terminal& terminal, bool test) {
 void NodeBreakerVoltageLevel::checkTerminal(Terminal& terminal) const {
     if (!stdcxx::isInstanceOf<NodeTerminal>(terminal)) {
         throw ValidationException(terminal.getConnectable(),
-            logging::format("Voltage level %1% has a node/breaker topology, a node connection should be specified instead of a bus connection",
+            stdcxx::format("Voltage level %1% has a node/breaker topology, a node connection should be specified instead of a bus connection",
                             getId()));
     }
 }
@@ -211,7 +211,7 @@ stdcxx::optional<unsigned long> NodeBreakerVoltageLevel::getEdge(const std::stri
         return {};
     }
 
-    throw PowsyblException(logging::format("Switch '%1%' not found in the voltage level '%2%'", switchId, getId()));
+    throw PowsyblException(stdcxx::format("Switch '%1%' not found in the voltage level '%2%'", switchId, getId()));
 }
 
 const node_breaker_voltage_level::Graph& NodeBreakerVoltageLevel::getGraph() const {
@@ -252,7 +252,7 @@ stdcxx::CReference<Switch> NodeBreakerVoltageLevel::getSwitch(const std::string&
     if (e.is_initialized()) {
         aSwitch = m_graph.getEdgeObject(*e);
         if (aSwitch.get().getId() != switchId) {
-            throw PowsyblException(logging::format("Invalid switch id (expected: '%1%', actual: '%2%')", switchId, aSwitch.get().getId()));
+            throw PowsyblException(stdcxx::format("Invalid switch id (expected: '%1%', actual: '%2%')", switchId, aSwitch.get().getId()));
         }
     }
 
@@ -328,7 +328,7 @@ void NodeBreakerVoltageLevel::reduceVariantArraySize(unsigned long number) {
 void NodeBreakerVoltageLevel::removeSwitch(const std::string& switchId) {
     const auto& it = m_switches.find(switchId);
     if (it == m_switches.end()) {
-        throw PowsyblException(logging::format("Switch '%1%' not found in voltage level '%2%'", switchId, getId()));
+        throw PowsyblException(stdcxx::format("Switch '%1%' not found in voltage level '%2%'", switchId, getId()));
     }
 
     const auto& aSwitch = m_graph.removeEdge(it->second);

--- a/src/iidm/NodeBreakerVoltageLevelBusNamingStrategy.cpp
+++ b/src/iidm/NodeBreakerVoltageLevelBusNamingStrategy.cpp
@@ -7,7 +7,7 @@
 
 #include "NodeBreakerVoltageLevelBusNamingStrategy.hpp"
 
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 #include "NodeBreakerVoltageLevel.hpp"
 

--- a/src/iidm/NodeBreakerVoltageLevelBusNamingStrategy.cpp
+++ b/src/iidm/NodeBreakerVoltageLevelBusNamingStrategy.cpp
@@ -7,7 +7,7 @@
 
 #include "NodeBreakerVoltageLevelBusNamingStrategy.hpp"
 
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 #include "NodeBreakerVoltageLevel.hpp"
 
@@ -23,13 +23,13 @@ BusNamingStrategy::BusNamingStrategy(NodeBreakerVoltageLevel& voltageLevel) :
 
 std::string BusNamingStrategy::getId(const std::vector<unsigned long>& nodes) {
     const auto& iter = std::min_element(nodes.cbegin(), nodes.cend());
-    return logging::format("%1%_%2%", m_voltageLevel.getId(), *iter);
+    return stdcxx::format("%1%_%2%", m_voltageLevel.getId(), *iter);
 }
 
 std::string BusNamingStrategy::getName(const std::vector<unsigned long>& nodes) {
     if (!m_voltageLevel.getName().empty()) {
         const auto& iter = std::min_element(nodes.cbegin(), nodes.cend());
-        return logging::format("%1%_%2%", m_voltageLevel.getName(), *iter);
+        return stdcxx::format("%1%_%2%", m_voltageLevel.getName(), *iter);
     }
 
     return "";

--- a/src/iidm/NodeBreakerVoltageLevelTopology.cpp
+++ b/src/iidm/NodeBreakerVoltageLevelTopology.cpp
@@ -22,7 +22,7 @@ namespace iidm {
 namespace node_breaker_voltage_level {
 
 PowsyblException createSwitchNotFoundException(const std::string& switchId) {
-    return PowsyblException(logging::format("Switch %1% not found", switchId));
+    return PowsyblException(stdcxx::format("Switch %1% not found", switchId));
 }
 
 CalculatedBusBreakerTopology::CalculatedBusBreakerTopology(NodeBreakerVoltageLevel& voltageLevel) :
@@ -142,7 +142,7 @@ stdcxx::Reference<CalculatedBus> CalculatedBusTopology::getBus(const std::string
 
     stdcxx::Reference<CalculatedBus> bus = m_cache->getBus(id);
     if (throwException && !bus) {
-        throw PowsyblException(logging::format("Bus %1% not found in voltage level %2%", id, m_voltageLevel.getId()));
+        throw PowsyblException(stdcxx::format("Bus %1% not found in voltage level %2%", id, m_voltageLevel.getId()));
     }
 
     return bus;
@@ -239,7 +239,7 @@ bool CalculatedBusTopology::isBusValid(const node_breaker_voltage_level::Graph& 
                     break;
 
                 default:
-                    throw AssertionError(logging::format("Unexpected ConnectableType value: %1%", connectableType));
+                    throw AssertionError(stdcxx::format("Unexpected ConnectableType value: %1%", connectableType));
             }
         }
     }
@@ -295,7 +295,7 @@ void CalculatedBusTopology::updateCache(const SwitchPredicate& predicate) {
     }
 
     logging::Logger& logger = logging::LoggerFactory::getLogger<CalculatedBusTopology>();
-    logger.trace(logging::format("Update bus topology of voltage level %1%", m_voltageLevel.getId()));
+    logger.trace(stdcxx::format("Update bus topology of voltage level %1%", m_voltageLevel.getId()));
 
     const auto& graph = m_voltageLevel.getGraph();
 
@@ -310,7 +310,7 @@ void CalculatedBusTopology::updateCache(const SwitchPredicate& predicate) {
 
     m_cache = stdcxx::make_unique<BusCache>(std::move(busByNode), std::move(busById));
 
-    logger.trace(logging::format("Found buses %1%", logging::toString<CalculatedBus>(m_cache->getBuses())));
+    logger.trace(stdcxx::format("Found buses %1%", stdcxx::toString<CalculatedBus>(m_cache->getBuses())));
 }
 
 }  // namespace node_breaker_voltage_level

--- a/src/iidm/PhaseTapChanger.cpp
+++ b/src/iidm/PhaseTapChanger.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/iidm/Enum.hpp>
 #include <powsybl/iidm/TwoWindingsTransformer.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 #include "ValidationUtils.hpp"
 

--- a/src/iidm/PhaseTapChanger.cpp
+++ b/src/iidm/PhaseTapChanger.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/iidm/Enum.hpp>
 #include <powsybl/iidm/TwoWindingsTransformer.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 #include "ValidationUtils.hpp"
 

--- a/src/iidm/Properties.cpp
+++ b/src/iidm/Properties.cpp
@@ -10,7 +10,7 @@
 #include <boost/range/adaptor/map.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -48,7 +48,7 @@ Properties::iterator Properties::end() {
 const std::string& Properties::get(const std::string& key) const {
     const auto& it = m_properties.find(key);
     if (it == m_properties.end()) {
-        throw PowsyblException(logging::format("Property %1% does not exist", key));
+        throw PowsyblException(stdcxx::format("Property %1% does not exist", key));
     }
 
     return it->second;

--- a/src/iidm/Properties.cpp
+++ b/src/iidm/Properties.cpp
@@ -10,7 +10,7 @@
 #include <boost/range/adaptor/map.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/iidm/ReactiveCapabilityCurveAdder.cpp
+++ b/src/iidm/ReactiveCapabilityCurveAdder.cpp
@@ -10,7 +10,7 @@
 #include <powsybl/iidm/ReactiveLimitsHolder.hpp>
 #include <powsybl/iidm/Validable.hpp>
 #include <powsybl/iidm/ValidationException.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 
 #include "ValidationUtils.hpp"
@@ -69,7 +69,7 @@ ReactiveCapabilityCurveAdder& ReactiveCapabilityCurveAdder::addPoint(ReactiveCap
     const auto& owner = getValidable();
 
     if (m_points.find(point.getP()) != m_points.end()) {
-        throw ValidationException(owner, logging::format("A point is already defined for active power %1%", point.getP()));
+        throw ValidationException(owner, stdcxx::format("A point is already defined for active power %1%", point.getP()));
     }
 
     // TODO(mathbagu): to be activated in IIDM v1.1

--- a/src/iidm/ReactiveCapabilityCurveAdder.cpp
+++ b/src/iidm/ReactiveCapabilityCurveAdder.cpp
@@ -10,7 +10,7 @@
 #include <powsybl/iidm/ReactiveLimitsHolder.hpp>
 #include <powsybl/iidm/Validable.hpp>
 #include <powsybl/iidm/ValidationException.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 
 #include "ValidationUtils.hpp"

--- a/src/iidm/StaticVarCompensator.cpp
+++ b/src/iidm/StaticVarCompensator.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/iidm/Enum.hpp>
 #include <powsybl/iidm/VariantManager.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 #include "ValidationUtils.hpp"
 

--- a/src/iidm/StaticVarCompensator.cpp
+++ b/src/iidm/StaticVarCompensator.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/iidm/Enum.hpp>
 #include <powsybl/iidm/VariantManager.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 #include "ValidationUtils.hpp"
 

--- a/src/iidm/Switch.cpp
+++ b/src/iidm/Switch.cpp
@@ -105,7 +105,7 @@ Switch& Switch::setOpen(bool open) {
 
 Switch& Switch::setRetained(bool retained) {
     if (m_voltageLevel.get().getTopologyKind() != TopologyKind::NODE_BREAKER) {
-        throw ValidationException(*this, logging::format("retain status is not modifiable in a non node/breaker voltage level"));
+        throw ValidationException(*this, stdcxx::format("retain status is not modifiable in a non node/breaker voltage level"));
     }
 
     unsigned long index = m_voltageLevel.get().getNetwork().getVariantIndex();

--- a/src/iidm/ThreeWindingsTransformer.cpp
+++ b/src/iidm/ThreeWindingsTransformer.cpp
@@ -46,7 +46,7 @@ double ThreeWindingsTransformer::Leg::getG() const {
 }
 
 std::string ThreeWindingsTransformer::Leg::getMessageHeader() const {
-    return logging::format("%1% '%2%': ", getTypeDescription(), m_transformer.get().getId());
+    return stdcxx::format("%1% '%2%': ", getTypeDescription(), m_transformer.get().getId());
 }
 
 const Network& ThreeWindingsTransformer::Leg::getNetwork() const {
@@ -186,7 +186,7 @@ void ThreeWindingsTransformer::Leg::setTransformer(ThreeWindingsTransformer& tra
 }
 
 std::string ThreeWindingsTransformer::Leg::toString() const {
-    return logging::format("%1% leg%2%", m_transformer.get().getId(), m_legNumber);
+    return stdcxx::format("%1% leg%2%", m_transformer.get().getId(), m_legNumber);
 }
 
 ThreeWindingsTransformer::ThreeWindingsTransformer(const std::string& id, const std::string& name, std::unique_ptr<Leg> leg1, std::unique_ptr<Leg> leg2, std::unique_ptr<Leg> leg3, double ratedU0) :
@@ -324,7 +324,7 @@ const Terminal& ThreeWindingsTransformer::getTerminal(const Side& side) const {
         case Side::THREE:
             return m_leg3->getTerminal().get();
         default:
-            throw AssertionError(logging::format("Unexpected side value: %1%", side));
+            throw AssertionError(stdcxx::format("Unexpected side value: %1%", side));
     }
 }
 

--- a/src/iidm/ThreeWindingsTransformerAdder.cpp
+++ b/src/iidm/ThreeWindingsTransformerAdder.cpp
@@ -50,10 +50,10 @@ VoltageLevel& ThreeWindingsTransformerAdder::LegAdder::checkAndGetVoltageLevel()
 
     stdcxx::Reference<VoltageLevel> voltageLevel = m_parent.getNetwork().template find<VoltageLevel>(m_voltageLevelId);
     if (!voltageLevel) {
-        throw ValidationException(*this, logging::format("voltage level '%1%' not found", m_voltageLevelId));
+        throw ValidationException(*this, stdcxx::format("voltage level '%1%' not found", m_voltageLevelId));
     }
     if (!stdcxx::areSame(voltageLevel.get().getSubstation(), m_parent.getSubstation())) {
-        throw ValidationException(*this, logging::format("voltage level shall belong to the substation '%1%'", m_parent.getSubstation().getId()));
+        throw ValidationException(*this, stdcxx::format("voltage level shall belong to the substation '%1%'", m_parent.getSubstation().getId()));
     }
 
     return voltageLevel.get();
@@ -166,7 +166,7 @@ ThreeWindingsTransformer& ThreeWindingsTransformerAdder::add() {
     // Define ratedU0 equal to ratedU1 if it has not been defined
     if (std::isnan(m_ratedU0)) {
         m_ratedU0 = ptrLeg1->getRatedU();
-        logger.info(logging::format("RatedU0 is not set. Fixed to leg1 ratedU: %1%", ptrLeg1->getRatedU()));
+        logger.info(stdcxx::format("RatedU0 is not set. Fixed to leg1 ratedU: %1%", ptrLeg1->getRatedU()));
     }
 
     std::unique_ptr<ThreeWindingsTransformer> ptrTransformer = stdcxx::make_unique<ThreeWindingsTransformer>(checkAndGetUniqueId(), getName(), std::move(ptrLeg1), std::move(ptrLeg2), std::move(ptrLeg3), m_ratedU0);

--- a/src/iidm/TieLine.cpp
+++ b/src/iidm/TieLine.cpp
@@ -7,7 +7,7 @@
 
 #include <powsybl/iidm/TieLine.hpp>
 #include <powsybl/iidm/ValidationException.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/math.hpp>
 
 namespace powsybl {
@@ -39,7 +39,7 @@ const std::string& TieLine::HalfLine::getId() const {
 }
 
 std::string TieLine::HalfLine::getMessageHeader() const {
-    return logging::format("Half line '%1%': ", m_id);
+    return stdcxx::format("Half line '%1%': ", m_id);
 }
 
 const std::string& TieLine::HalfLine::getName() const {

--- a/src/iidm/TieLine.cpp
+++ b/src/iidm/TieLine.cpp
@@ -7,7 +7,7 @@
 
 #include <powsybl/iidm/TieLine.hpp>
 #include <powsybl/iidm/ValidationException.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/math.hpp>
 
 namespace powsybl {

--- a/src/iidm/TopologyLevel.cpp
+++ b/src/iidm/TopologyLevel.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/Enum.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/iidm/TopologyLevel.cpp
+++ b/src/iidm/TopologyLevel.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/Enum.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -30,7 +30,7 @@ TopologyKind getTopologyKind(const TopologyLevel& topologyLevel) {
             return TopologyKind::BUS_BREAKER;
 
         default:
-            throw PowsyblException(logging::format("No topology kind associated to topology level %1%", topologyLevel));
+            throw PowsyblException(stdcxx::format("No topology kind associated to topology level %1%", topologyLevel));
     }
 }
 

--- a/src/iidm/TwoWindingsTransformerAdder.cpp
+++ b/src/iidm/TwoWindingsTransformerAdder.cpp
@@ -26,7 +26,7 @@ TwoWindingsTransformer& TwoWindingsTransformerAdder::add() {
     VoltageLevel& voltageLevel1 = checkAndGetVoltageLevel1();
     VoltageLevel& voltageLevel2 = checkAndGetVoltageLevel2();
     if (!stdcxx::areSame(voltageLevel1.getSubstation(), m_substation) || !stdcxx::areSame(voltageLevel2.getSubstation(), m_substation)) {
-        throw ValidationException(*this, logging::format("the 2 windings of the transformer shall belong to the substation '%1%' ('%2%', '%3%')",
+        throw ValidationException(*this, stdcxx::format("the 2 windings of the transformer shall belong to the substation '%1%' ('%2%', '%3%')",
                                                          m_substation.getId(), voltageLevel1.getSubstation().getId(), voltageLevel2.getSubstation().getId()));
     }
     std::unique_ptr<Terminal> ptrTerminal1 = checkAndGetTerminal1(voltageLevel1);

--- a/src/iidm/ValidationUtils.cpp
+++ b/src/iidm/ValidationUtils.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/iidm/LoadType.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/math.hpp>
 
 namespace powsybl {
@@ -17,13 +17,13 @@ namespace powsybl {
 namespace iidm {
 
 ValidationException createInvalidValueException(const Validable& validable, double value, const std::string& valueName, const std::string& reason = "") {
-    std::string r = reason.empty() ? "" : logging::format(" (%1%)", reason);
-    return ValidationException(validable, logging::format("invalid value (%1%) for %2%%3%", value, valueName, r));
+    std::string r = reason.empty() ? "" : stdcxx::format(" (%1%)", reason);
+    return ValidationException(validable, stdcxx::format("invalid value (%1%) for %2%%3%", value, valueName, r));
 }
 
 void checkActivePowerLimits(const Validable& validable, double minP, double maxP) {
     if (minP > maxP) {
-        throw ValidationException(validable, logging::format("Invalid active limits [%1%, %2%]", minP, maxP));
+        throw ValidationException(validable, stdcxx::format("Invalid active limits [%1%, %2%]", minP, maxP));
     }
 }
 
@@ -31,10 +31,10 @@ void checkActivePowerLimits(const Validable& validable, double minP, double maxP
     checkActivePowerLimits(validable, minP, maxP);
 
     if (p > maxP) {
-        throw ValidationException(validable, logging::format("Invalid active power p > maxP: %1% > %2%", p, maxP));
+        throw ValidationException(validable, stdcxx::format("Invalid active power p > maxP: %1% > %2%", p, maxP));
     }
     if (p < minP) {
-        throw ValidationException(validable, logging::format("Invalid active power p < minP: %1% < %2%", p, minP));
+        throw ValidationException(validable, stdcxx::format("Invalid active power p < minP: %1% < %2%", p, minP));
     }
 }
 
@@ -97,7 +97,7 @@ const HvdcLine::ConvertersMode& checkConvertersMode(const Validable& /*validable
             break;
 
         default:
-            throw AssertionError(logging::format("Unexpected converter mode value: %1%", converterMode));
+            throw AssertionError(stdcxx::format("Unexpected converter mode value: %1%", converterMode));
     }
     return converterMode;
 }
@@ -131,30 +131,30 @@ double checkG2(const Validable& validable, double g2) {
 }
 
 void checkHalf(const Validable& validable, const TieLine::HalfLine& half, int num) {
-    checkNotEmpty(validable, half.getId(), logging::format("id is not set for half line %1%", num));
+    checkNotEmpty(validable, half.getId(), stdcxx::format("id is not set for half line %1%", num));
     if (std::isnan(half.getB1())) {
-        throw ValidationException(validable, logging::format("b1 is not set for half line %1%", num));
+        throw ValidationException(validable, stdcxx::format("b1 is not set for half line %1%", num));
     }
     if (std::isnan(half.getB2())) {
-        throw ValidationException(validable, logging::format("b2 is not set for half line %1%", num));
+        throw ValidationException(validable, stdcxx::format("b2 is not set for half line %1%", num));
     }
     if (std::isnan(half.getG1())) {
-        throw ValidationException(validable, logging::format("g1 is not set for half line %1%", num));
+        throw ValidationException(validable, stdcxx::format("g1 is not set for half line %1%", num));
     }
     if (std::isnan(half.getG2())) {
-        throw ValidationException(validable, logging::format("g2 is not set for half line %1%", num));
+        throw ValidationException(validable, stdcxx::format("g2 is not set for half line %1%", num));
     }
     if (std::isnan(half.getR())) {
-        throw ValidationException(validable, logging::format("r is not set for half line %1%", num));
+        throw ValidationException(validable, stdcxx::format("r is not set for half line %1%", num));
     }
     if (std::isnan(half.getX())) {
-        throw ValidationException(validable, logging::format("x is not set for half line %1%", num));
+        throw ValidationException(validable, stdcxx::format("x is not set for half line %1%", num));
     }
     if (std::isnan(half.getXnodeP())) {
-        throw ValidationException(validable, logging::format("xnodeP is not set for half line %1%", num));
+        throw ValidationException(validable, stdcxx::format("xnodeP is not set for half line %1%", num));
     }
     if (std::isnan(half.getXnodeQ())) {
-        throw ValidationException(validable, logging::format("xnodeQ is not set for half line %1%", num));
+        throw ValidationException(validable, stdcxx::format("xnodeQ is not set for half line %1%", num));
     }
 }
 
@@ -166,7 +166,7 @@ const LoadType& checkLoadType(const Validable& /*validable*/, const LoadType& lo
             break;
 
         default:
-            throw AssertionError(logging::format("Unexpected load type value: %1%", loadType));
+            throw AssertionError(stdcxx::format("Unexpected load type value: %1%", loadType));
     }
     return loadType;
 }
@@ -260,7 +260,7 @@ void checkPhaseTapChangerRegulation(const Validable& validable, const PhaseTapCh
             break;
 
         default:
-            throw AssertionError(logging::format("Unexpected regulation mode value: %1%", regulationMode));
+            throw AssertionError(stdcxx::format("Unexpected regulation mode value: %1%", regulationMode));
     }
 
     if ((regulationMode != PhaseTapChanger::RegulationMode::FIXED_TAP) && std::isnan(regulationValue)) {
@@ -300,7 +300,7 @@ double checkR(const Validable& validable, double r) {
 
 double checkRatedS(const Validable& validable, double ratedS) {
     if (!std::isnan(ratedS) && ratedS <= 0.0) {
-        throw ValidationException(validable, logging::format("Invalid rated S value: %1%", ratedS));
+        throw ValidationException(validable, stdcxx::format("Invalid rated S value: %1%", ratedS));
     }
     return ratedS;
 }
@@ -308,7 +308,7 @@ double checkRatedS(const Validable& validable, double ratedS) {
 double checkRatedU(const Validable& validable, double ratedU, const stdcxx::optional<unsigned long>& num) {
     if (std::isnan(ratedU)) {
         std::string strNum = num.is_initialized() ? std::to_string(num.get()) : "";
-        throw ValidationException(validable, logging::format("rated U%1% is invalid", strNum));
+        throw ValidationException(validable, stdcxx::format("rated U%1% is invalid", strNum));
     }
     return ratedU;
 }
@@ -327,7 +327,7 @@ void checkRatioTapChangerRegulation(const Validable& validable, bool regulating,
             throw ValidationException(validable, "a target voltage has to be set for a regulating ratio tap changer");
         }
         if (std::islessequal(targetV, 0.0)) {
-            throw ValidationException(validable, logging::format("bad target voltage %1%", targetV));
+            throw ValidationException(validable, stdcxx::format("bad target voltage %1%", targetV));
         }
         if (!static_cast<bool>(regulationTerminal)) {
             throw ValidationException(validable, "a regulation terminal has to be set for a regulating ratio tap changer");
@@ -346,10 +346,10 @@ void checkRegulatingTerminal(const Validable& validable, const stdcxx::Reference
 
 void checkSections(const Validable& validable, unsigned long currentSectionCount, unsigned long maximumSectionCount) {
     if (maximumSectionCount == 0UL) {
-        throw ValidationException(validable, logging::format("the maximum number of section (%1%) should be greater than 0", maximumSectionCount));
+        throw ValidationException(validable, stdcxx::format("the maximum number of section (%1%) should be greater than 0", maximumSectionCount));
     }
     if (currentSectionCount > maximumSectionCount) {
-        throw ValidationException(validable, logging::format("the current number (%1%) of section should be lesser than the maximum number of section (%2%)", currentSectionCount, maximumSectionCount));
+        throw ValidationException(validable, stdcxx::format("the current number (%1%) of section should be lesser than the maximum number of section (%2%)", currentSectionCount, maximumSectionCount));
     }
 }
 
@@ -374,20 +374,20 @@ void checkSvcRegulator(const Validable& validable, double voltageSetpoint, doubl
             break;
 
         default:
-            throw AssertionError(logging::format("Unexpected regulation mode value: %1%", *regulationMode));
+            throw AssertionError(stdcxx::format("Unexpected regulation mode value: %1%", *regulationMode));
     }
 }
 
 long checkTapPosition(const Validable& validable, long tapPosition, long lowTapPosition, long highTapPosition) {
     if ((tapPosition < lowTapPosition) || (tapPosition > highTapPosition)) {
-        throw ValidationException(validable, logging::format("incorrect tap position %1% [%2%, %3%]", tapPosition, lowTapPosition, highTapPosition));
+        throw ValidationException(validable, stdcxx::format("incorrect tap position %1% [%2%, %3%]", tapPosition, lowTapPosition, highTapPosition));
     }
     return tapPosition;
 }
 
 double checkTargetDeadband(const Validable& validable, double targetDeadband) {
     if (!std::isnan(targetDeadband) && targetDeadband < 0) {
-        throw ValidationException(validable, logging::format("Unexpected value for target deadband of tap changer: %1%", targetDeadband));
+        throw ValidationException(validable, stdcxx::format("Unexpected value for target deadband of tap changer: %1%", targetDeadband));
     }
     return targetDeadband;
 }
@@ -402,10 +402,10 @@ double checkVoltage(const Validable& validable, double voltage) {
 void checkVoltageControl(const Validable& validable, bool voltageRegulatorOn, double voltageSetpoint, double reactivePowerSetpoint) {
     if (voltageRegulatorOn) {
         if (std::isnan(voltageSetpoint) || voltageSetpoint <= 0) {
-            throw ValidationException(validable, logging::format("Invalid voltage setpoint value (%1%) while voltage regulator is on", voltageSetpoint));
+            throw ValidationException(validable, stdcxx::format("Invalid voltage setpoint value (%1%) while voltage regulator is on", voltageSetpoint));
         }
     } else if (std::isnan(reactivePowerSetpoint)) {
-        throw ValidationException(validable, logging::format("Invalid reactive power setpoint (%1%) while voltage regulator is off", reactivePowerSetpoint));
+        throw ValidationException(validable, stdcxx::format("Invalid reactive power setpoint (%1%) while voltage regulator is off", reactivePowerSetpoint));
     }
 }
 
@@ -417,7 +417,7 @@ void checkVoltageLimits(const Validable& validable, double lowVoltageLimit, doub
         throw ValidationException(validable, "High voltage limit is < 0");
     }
     if (lowVoltageLimit > highVoltageLimit) {
-        throw ValidationException(validable, logging::format("Inconsistent voltage limit range [%1%, %2%]", lowVoltageLimit, highVoltageLimit));
+        throw ValidationException(validable, stdcxx::format("Inconsistent voltage limit range [%1%, %2%]", lowVoltageLimit, highVoltageLimit));
     }
 }
 

--- a/src/iidm/ValidationUtils.cpp
+++ b/src/iidm/ValidationUtils.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/iidm/LoadType.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/math.hpp>
 
 namespace powsybl {

--- a/src/iidm/VariantManager.cpp
+++ b/src/iidm/VariantManager.cpp
@@ -48,7 +48,7 @@ void VariantManager::cloneVariant(const std::string& sourceVariantId, const std:
         throw PowsyblException("Empty target variant id list");
     }
 
-    logger.debug("Creating variants %1%", logging::toString(targetVariantIds));
+    logger.debug("Creating variants %1%", stdcxx::toString(targetVariantIds));
 
     std::lock_guard<std::mutex> lock(m_variantMutex);
 
@@ -58,7 +58,7 @@ void VariantManager::cloneVariant(const std::string& sourceVariantId, const std:
     std::set<unsigned long> recycled;
     for (const auto& targetVariantId : targetVariantIds) {
         if (m_variantsById.find(targetVariantId) != m_variantsById.end()) {
-            throw PowsyblException(logging::format("Target variant '%1%' already exists", targetVariantId));
+            throw PowsyblException(stdcxx::format("Target variant '%1%' already exists", targetVariantId));
         }
         if (m_unusedIndexes.empty()) {
             // extend variant array size
@@ -79,7 +79,7 @@ void VariantManager::cloneVariant(const std::string& sourceVariantId, const std:
         for (auto& multiVariantObject : m_network.getStatefulObjects()) {
             multiVariantObject.allocateVariantArrayElement(recycled, sourceIndex);
         }
-        logger.trace("Recycling variant array indexes %1%", logging::toString(recycled));
+        logger.trace("Recycling variant array indexes %1%", stdcxx::toString(recycled));
     }
     if (extendedCount > 0) {
         for (auto& multiVariantObject : m_network.getStatefulObjects()) {
@@ -128,7 +128,7 @@ unsigned long VariantManager::getVariantIndex() const {
 unsigned long VariantManager::getVariantIndex(const std::string& variantId) const {
     const auto& it = m_variantsById.find(variantId);
     if (it == m_variantsById.end()) {
-        throw PowsyblException(logging::format("Variant '%1%' not found", variantId));
+        throw PowsyblException(stdcxx::format("Variant '%1%' not found", variantId));
     }
 
     return it->second;

--- a/src/iidm/VoltageLevelAdder.cpp
+++ b/src/iidm/VoltageLevelAdder.cpp
@@ -39,7 +39,7 @@ VoltageLevel& VoltageLevelAdder::add() {
             break;
 
         default:
-            throw AssertionError(logging::format("Unexpected TopologyKind value: %1%", *m_topologyKind));
+            throw AssertionError(stdcxx::format("Unexpected TopologyKind value: %1%", *m_topologyKind));
     }
 
     auto& voltageLevel = getNetwork().checkAndAdd<VoltageLevel>(std::move(ptrVoltageLevel));

--- a/src/iidm/converter/ExportOptions.cpp
+++ b/src/iidm/converter/ExportOptions.cpp
@@ -8,7 +8,7 @@
 #include <powsybl/iidm/converter/ExportOptions.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/iidm/converter/ExportOptions.cpp
+++ b/src/iidm/converter/ExportOptions.cpp
@@ -8,7 +8,7 @@
 #include <powsybl/iidm/converter/ExportOptions.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -33,10 +33,10 @@ ExportOptions& ExportOptions::addExtension(const std::string& extension) {
 
 ExportOptions& ExportOptions::addExtensionVersion(const std::string& extensionName, const std::string& extensionVersion) {
     if (!m_extensions.empty() && m_extensions.find(extensionName) == m_extensions.end()) {
-        throw PowsyblException(logging::format("%1% is not an extension you have passed in the extensions list to export.", extensionName));
+        throw PowsyblException(stdcxx::format("%1% is not an extension you have passed in the extensions list to export.", extensionName));
     }
     if (m_extensionsVersions.find(extensionName) != m_extensionsVersions.end()) {
-        throw PowsyblException(logging::format("The version of %1%'s XML serializer has already been set.", extensionName));
+        throw PowsyblException(stdcxx::format("The version of %1%'s XML serializer has already been set.", extensionName));
     }
 
     m_extensionsVersions.insert(std::make_pair(extensionName, extensionVersion));

--- a/src/iidm/converter/xml/AbstractConnectableXml.hxx
+++ b/src/iidm/converter/xml/AbstractConnectableXml.hxx
@@ -134,7 +134,7 @@ void AbstractConnectableXml<Added, Adder, Parent>::writeNodeOrBus(const Terminal
             writeBus(terminal.getBusView().getBus(), terminal.getBusView().getConnectableBus(), context, index);
             break;
         default:
-            throw powsybl::xml::XmlStreamException(logging::format("Unexpected TopologyLevel value: ", topologyLevel));
+            throw powsybl::xml::XmlStreamException(stdcxx::format("Unexpected TopologyLevel value: ", topologyLevel));
     }
 
     if (index.is_initialized()) {

--- a/src/iidm/converter/xml/AbstractIdentifiableXml.hxx
+++ b/src/iidm/converter/xml/AbstractIdentifiableXml.hxx
@@ -13,7 +13,7 @@
 #include <powsybl/iidm/converter/Constants.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/xml/XmlStreamReader.hpp>
 #include <powsybl/xml/XmlStreamWriter.hpp>
 
@@ -42,7 +42,7 @@ void AbstractIdentifiableXml<Added, Adder, Parent>::readSubElements(Added& ident
     if (context.getReader().getLocalName() == PROPERTY) {
         PropertiesXml::read(identifiable, context);
     } else {
-        throw PowsyblException(logging::format("Unknown element name <%1%> in <%2%>", context.getReader().getLocalName(), identifiable.getId()));
+        throw PowsyblException(stdcxx::format("Unknown element name <%1%> in <%2%>", context.getReader().getLocalName(), identifiable.getId()));
     }
 }
 

--- a/src/iidm/converter/xml/AbstractIdentifiableXml.hxx
+++ b/src/iidm/converter/xml/AbstractIdentifiableXml.hxx
@@ -13,7 +13,7 @@
 #include <powsybl/iidm/converter/Constants.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/xml/XmlStreamReader.hpp>
 #include <powsybl/xml/XmlStreamWriter.hpp>
 

--- a/src/iidm/converter/xml/AbstractTransformerXml.hxx
+++ b/src/iidm/converter/xml/AbstractTransformerXml.hxx
@@ -70,7 +70,7 @@ void AbstractTransformerXml<Added, Adder>::readPhaseTapChanger(const std::string
             stepAdder.setAlpha(alpha)
                 .endStep();
         } else {
-            throw PowsyblException(logging::format("Unknown element <%1%>", context.getReader().getLocalName()));
+            throw PowsyblException(stdcxx::format("Unknown element <%1%>", context.getReader().getLocalName()));
         }
     });
     if (!hasTerminalRef) {
@@ -124,7 +124,7 @@ void AbstractTransformerXml<Added, Adder>::readRatioTapChanger(const std::string
                     .endStep();
             });
         } else {
-            throw PowsyblException(logging::format("Unexpected XML element <%1%>", context.getReader().getLocalName()));
+            throw PowsyblException(stdcxx::format("Unexpected XML element <%1%>", context.getReader().getLocalName()));
         }
     });
     if (!hasTerminalRef) {

--- a/src/iidm/converter/xml/AbstractVersionableExtensionXmlSerializer.cpp
+++ b/src/iidm/converter/xml/AbstractVersionableExtensionXmlSerializer.cpp
@@ -10,7 +10,7 @@
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/converter/xml/IidmXmlVersion.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -29,7 +29,7 @@ AbstractVersionableExtensionXmlSerializer::AbstractVersionableExtensionXmlSerial
 
 void AbstractVersionableExtensionXmlSerializer::checkExtensionVersionSupported(const std::string& extensionVersion) const {
     if (m_namespaceUris.find(extensionVersion) == m_namespaceUris.end()) {
-        throw PowsyblException(logging::format("The version %1% of the %2% extension is not supported.", extensionVersion, getExtensionName()));
+        throw PowsyblException(stdcxx::format("The version %1% of the %2% extension is not supported.", extensionVersion, getExtensionName()));
     }
 }
 
@@ -37,14 +37,14 @@ void AbstractVersionableExtensionXmlSerializer::checkReadingCompatibility(const 
     const auto& version = networkContext.getVersion().toString(".");
     const auto& it = m_extensionVersions.find(version);
     if (it == m_extensionVersions.end()) {
-        throw PowsyblException(logging::format("IIDM-XML version of network (%1%) is not supported by the %2% extension's XML serializer", version, getExtensionName()));
+        throw PowsyblException(stdcxx::format("IIDM-XML version of network (%1%) is not supported by the %2% extension's XML serializer", version, getExtensionName()));
     }
     for (const auto& v : it->second) {
         if (networkContext.containsExtensionNamespaceUri(getNamespaceUri(v))) {
             return;
         }
     }
-    throw PowsyblException(logging::format("IIDM-XML version of network (%1%) is not compatible with the %2% extension's namespace URI", version, getExtensionName()));
+    throw PowsyblException(stdcxx::format("IIDM-XML version of network (%1%) is not compatible with the %2% extension's namespace URI", version, getExtensionName()));
 }
 
 void AbstractVersionableExtensionXmlSerializer::checkWritingCompatibility(const std::string& extensionVersion, const IidmXmlVersion& version) const {
@@ -52,10 +52,10 @@ void AbstractVersionableExtensionXmlSerializer::checkWritingCompatibility(const 
     const auto& strVersion = version.toString(".");
     const auto& it = m_extensionVersions.find(strVersion);
     if (it == m_extensionVersions.end()) {
-        throw PowsyblException(logging::format("IIDM-XML version of network (%1%) is not supported by the %2% extension's XML serializer", strVersion, getExtensionName()));
+        throw PowsyblException(stdcxx::format("IIDM-XML version of network (%1%) is not supported by the %2% extension's XML serializer", strVersion, getExtensionName()));
     }
     if (std::find(it->second.begin(), it->second.end(), extensionVersion) == it->second.end()) {
-        throw PowsyblException(logging::format("IIDM-XML version of network (%1%) is not compatible with the version %2% of the %3% extension", strVersion, extensionVersion, getExtensionName()));
+        throw PowsyblException(stdcxx::format("IIDM-XML version of network (%1%) is not compatible with the version %2% of the %3% extension", strVersion, extensionVersion, getExtensionName()));
     }
 }
 
@@ -66,7 +66,7 @@ const std::string& AbstractVersionableExtensionXmlSerializer::getNamespaceUri() 
 const std::string& AbstractVersionableExtensionXmlSerializer::getNamespaceUri(const std::string& extensionVersion) const {
     const auto& it = m_namespaceUris.find(extensionVersion);
     if (it == m_namespaceUris.end()) {
-        throw PowsyblException(logging::format("Namespace URI null for %1% extension's version %2%", getExtensionName(), extensionVersion));
+        throw PowsyblException(stdcxx::format("Namespace URI null for %1% extension's version %2%", getExtensionName(), extensionVersion));
     }
 
     return it->second;

--- a/src/iidm/converter/xml/AbstractVersionableExtensionXmlSerializer.cpp
+++ b/src/iidm/converter/xml/AbstractVersionableExtensionXmlSerializer.cpp
@@ -10,7 +10,7 @@
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/converter/xml/IidmXmlVersion.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/iidm/converter/xml/ExtensionXmlSerializer.cpp
+++ b/src/iidm/converter/xml/ExtensionXmlSerializer.cpp
@@ -8,7 +8,7 @@
 #include <powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -25,7 +25,7 @@ ExtensionXmlSerializer::ExtensionXmlSerializer(std::string&& extensionName, std:
 
 void ExtensionXmlSerializer::checkExtensionVersionSupported(const std::string& extensionVersion) const {
     if (extensionVersion != "1.0") {
-        throw PowsyblException(logging::format("The version %1% of the %2% extension's XML serializer is not supported", extensionVersion, getExtensionName()));
+        throw PowsyblException(stdcxx::format("The version %1% of the %2% extension's XML serializer is not supported", extensionVersion, getExtensionName()));
     }
 }
 

--- a/src/iidm/converter/xml/ExtensionXmlSerializer.cpp
+++ b/src/iidm/converter/xml/ExtensionXmlSerializer.cpp
@@ -8,7 +8,7 @@
 #include <powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/iidm/converter/xml/IidmXmlUtil.cpp
+++ b/src/iidm/converter/xml/IidmXmlUtil.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/math.hpp>
 #include <powsybl/xml/XmlStreamWriter.hpp>
 
@@ -22,7 +22,7 @@ namespace converter {
 namespace xml {
 
 PowsyblException createException(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& version, const IidmXmlVersion& contextVersion, const std::string& reason) {
-    return PowsyblException(logging::format("%1%.%2% is %3% for IIDM-XML version %4%. %5%%6%", rootElementName, elementName, errorMessage, contextVersion.toString("."), reason, version.toString(".")));
+    return PowsyblException(stdcxx::format("%1%.%2% is %3% for IIDM-XML version %4%. %5%%6%", rootElementName, elementName, errorMessage, contextVersion.toString("."), reason, version.toString(".")));
 }
 
 void IidmXmlUtil::assertMaximumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& maxVersion, const IidmXmlVersion& contextVersion) {

--- a/src/iidm/converter/xml/IidmXmlUtil.cpp
+++ b/src/iidm/converter/xml/IidmXmlUtil.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/math.hpp>
 #include <powsybl/xml/XmlStreamWriter.hpp>
 

--- a/src/iidm/converter/xml/IidmXmlVersion.cpp
+++ b/src/iidm/converter/xml/IidmXmlVersion.cpp
@@ -13,7 +13,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 
 namespace powsybl {

--- a/src/iidm/converter/xml/IidmXmlVersion.cpp
+++ b/src/iidm/converter/xml/IidmXmlVersion.cpp
@@ -13,7 +13,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 
 #include <powsybl/PowsyblException.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/memory.hpp>
 
 namespace powsybl {
@@ -76,7 +76,7 @@ const IidmXmlVersion& IidmXmlVersion::fromNamespaceURI(const std::string& namesp
     const std::string version = namespaceURI.substr(namespaceURI.find_last_of('/') + 1);
     const IidmXmlVersion& v = of(version, "_");
     if (namespaceURI != v.getNamespaceUri()) {
-        throw PowsyblException(logging::format(
+        throw PowsyblException(stdcxx::format(
             "Namespace %1% is not supported. The namespace for IIDM XML version %2% is: %3%.",
             namespaceURI, v.toString("."), v.getNamespaceUri()));
     }
@@ -90,7 +90,7 @@ const std::string& IidmXmlVersion::getDefaultPrefix() {
 }
 
 std::string IidmXmlVersion::getNamespaceUri() const {
-    return logging::format("http://www.%1%/schema/iidm/%2%", m_domain, toString("_"));
+    return stdcxx::format("http://www.%1%/schema/iidm/%2%", m_domain, toString("_"));
 }
 
 const std::string& IidmXmlVersion::getPrefix() const {
@@ -98,7 +98,7 @@ const std::string& IidmXmlVersion::getPrefix() const {
 }
 
 std::string IidmXmlVersion::getXsd() const {
-    return logging::format("iidm_V%1%.xsd", toString("_"));
+    return stdcxx::format("iidm_V%1%.xsd", toString("_"));
 }
 
 const IidmXmlVersion& IidmXmlVersion::of(const std::string& version, const std::string& separator) {
@@ -108,7 +108,7 @@ const IidmXmlVersion& IidmXmlVersion::of(const std::string& version, const std::
         }
     }
 
-    throw PowsyblException(logging::format("Version %1% is not supported.", version));
+    throw PowsyblException(stdcxx::format("Version %1% is not supported.", version));
 }
 
 std::string IidmXmlVersion::toString(const std::string& separator) const {

--- a/src/iidm/converter/xml/NetworkXml.cpp
+++ b/src/iidm/converter/xml/NetworkXml.cpp
@@ -42,7 +42,7 @@ namespace xml {
 
 void checkExtensionsNotFound(const NetworkXmlReaderContext& context, const std::set<std::string>& extensionsNotFound) {
     if (!extensionsNotFound.empty()) {
-        const std::string& message = logging::format("Extensions %1% not found!", logging::toString(extensionsNotFound));
+        const std::string& message = stdcxx::format("Extensions %1% not found!", stdcxx::toString(extensionsNotFound));
 
         if (context.getOptions().isThrowExceptionIfExtensionNotFound()) {
             throw PowsyblException(message);
@@ -144,11 +144,11 @@ void writeExtensionNamespaces(const Network& network, NetworkXmlWriterContext& c
             const std::string& prefix = serializer.get().getNamespacePrefix();
 
             if (extensionUris.find(uri) != extensionUris.end()) {
-                throw PowsyblException(logging::format("Extension namespace URI collision"));
+                throw PowsyblException(stdcxx::format("Extension namespace URI collision"));
             }
 
             if (extensionPrefixes.find(prefix) != extensionPrefixes.end()) {
-                throw PowsyblException(logging::format("Extension namespace prefix collision"));
+                throw PowsyblException(stdcxx::format("Extension namespace prefix collision"));
             }
 
             extensionUris.insert(uri);
@@ -239,7 +239,7 @@ Network NetworkXml::read(std::istream& is, const ImportOptions& options, const A
             Identifiable& identifiable = network.get(id2);
             readExtensions(identifiable, context, extensionsNotFound);
         } else {
-            throw powsybl::xml::XmlStreamException(logging::format("Unexpected element: %1%", context.getReader().getLocalName()));
+            throw powsybl::xml::XmlStreamException(stdcxx::format("Unexpected element: %1%", context.getReader().getLocalName()));
         }
     });
 

--- a/src/iidm/converter/xml/ReactiveLimitsXml.cpp
+++ b/src/iidm/converter/xml/ReactiveLimitsXml.cpp
@@ -42,7 +42,7 @@ void ReactiveLimitsXml::read(ReactiveLimitsHolder& holder, const NetworkXmlReade
                     .setMaxQ(maxQ)
                     .endPoint();
             } else {
-                throw PowsyblException(logging::format("Unexpected element <%1%>", context.getReader().getLocalName()));
+                throw PowsyblException(stdcxx::format("Unexpected element <%1%>", context.getReader().getLocalName()));
             }
         });
         curveAdder.add();
@@ -54,7 +54,7 @@ void ReactiveLimitsXml::read(ReactiveLimitsHolder& holder, const NetworkXmlReade
             .setMaxQ(max)
             .add();
     } else {
-        throw PowsyblException(logging::format("Unknown XML element <%1%>", context.getReader().getLocalName()));
+        throw PowsyblException(stdcxx::format("Unknown XML element <%1%>", context.getReader().getLocalName()));
     }
 }
 
@@ -88,7 +88,7 @@ void ReactiveLimitsXml::write(const ReactiveLimitsHolder& holder, NetworkXmlWrit
             break;
 
         default:
-            throw PowsyblException(logging::format("Unknown reactive limit kind"));
+            throw PowsyblException(stdcxx::format("Unknown reactive limit kind"));
     }
 }
 

--- a/src/iidm/converter/xml/TerminalRefXml.cpp
+++ b/src/iidm/converter/xml/TerminalRefXml.cpp
@@ -41,7 +41,7 @@ Terminal& TerminalRefXml::readTerminalRef(Network& network, const std::string& i
         return twt.getTerminal(Enum::fromString<ThreeWindingsTransformer::Side>(side));
     }
 
-    throw AssertionError(logging::format("Unexpected Identifiable instance: %1%", stdcxx::demangle(identifiable)));
+    throw AssertionError(stdcxx::format("Unexpected Identifiable instance: %1%", stdcxx::demangle(identifiable)));
 }
 
 void TerminalRefXml::writeTerminalRef(const Terminal& terminal, NetworkXmlWriterContext& context, const std::string& elementName) {
@@ -55,7 +55,7 @@ void TerminalRefXml::writeTerminalRef(const Terminal& terminal, NetworkXmlWriter
 void TerminalRefXml::writeTerminalRef(const Terminal& terminal, NetworkXmlWriterContext& context, const std::string& nsPrefix, const std::string& elementName, powsybl::xml::XmlStreamWriter& writer) {
     const auto& c = terminal.getConnectable();
     if (!context.getFilter().test(c)) {
-        throw PowsyblException(logging::format("Oups, terminal ref point to a filtered equipment %1%", c.get().getId()));
+        throw PowsyblException(stdcxx::format("Oups, terminal ref point to a filtered equipment %1%", c.get().getId()));
     }
     writer.writeStartElement(nsPrefix, elementName);
     writer.writeAttribute(ID, context.getAnonymizer().anonymizeString(c.get().getId()));
@@ -69,7 +69,7 @@ void TerminalRefXml::writeTerminalRef(const Terminal& terminal, NetworkXmlWriter
             const auto& twt = dynamic_cast<const ThreeWindingsTransformer&>(c.get());
             writer.writeAttribute(SIDE, Enum::toString(twt.getSide(terminal)));
         } else {
-            throw AssertionError(logging::format("Unexpected Connectable instance: %1%", stdcxx::demangle(c.get())));
+            throw AssertionError(stdcxx::format("Unexpected Connectable instance: %1%", stdcxx::demangle(c.get())));
         }
     }
     writer.writeEndElement();

--- a/src/iidm/converter/xml/ThreeWindingsTransformerXml.cpp
+++ b/src/iidm/converter/xml/ThreeWindingsTransformerXml.cpp
@@ -10,7 +10,7 @@
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/converter/xml/IidmXmlUtil.hpp>
 #include <powsybl/iidm/converter/xml/IidmXmlVersion.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 

--- a/src/iidm/converter/xml/ThreeWindingsTransformerXml.cpp
+++ b/src/iidm/converter/xml/ThreeWindingsTransformerXml.cpp
@@ -10,7 +10,7 @@
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/converter/xml/IidmXmlUtil.hpp>
 #include <powsybl/iidm/converter/xml/IidmXmlVersion.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/iidm/converter/xml/VoltageLevelXml.cpp
+++ b/src/iidm/converter/xml/VoltageLevelXml.cpp
@@ -63,7 +63,7 @@ void VoltageLevelXml::readBusBreakerTopology(VoltageLevel& voltageLevel, Network
         } else if (context.getReader().getLocalName() == SWITCH) {
             BusBreakerViewSwitchXml::getInstance().read(voltageLevel, context);
         } else {
-            throw AssertionError(logging::format("Unsupported element %1%", context.getReader().getLocalName()));
+            throw AssertionError(stdcxx::format("Unsupported element %1%", context.getReader().getLocalName()));
         }
     });
 }
@@ -103,7 +103,7 @@ void VoltageLevelXml::readNodeBreakerTopology(VoltageLevel& voltageLevel, Networ
         } else if (context.getReader().getLocalName() == BUS) {
             readCalculatedBus(voltageLevel, context);
         } else {
-            throw AssertionError(logging::format("Unexpected element %1%", context.getReader().getLocalName()));
+            throw AssertionError(stdcxx::format("Unexpected element %1%", context.getReader().getLocalName()));
         }
     });
 }
@@ -305,7 +305,7 @@ void VoltageLevelXml::writeSubElements(const VoltageLevel& voltageLevel, const S
             break;
 
         default:
-            throw AssertionError(logging::format("Unexpected TopologyLevel value: ", topologyLevel));
+            throw AssertionError(stdcxx::format("Unexpected TopologyLevel value: ", topologyLevel));
     }
 
     writeGenerators(voltageLevel, context);

--- a/src/iidm/util/Networks.cpp
+++ b/src/iidm/util/Networks.cpp
@@ -21,7 +21,7 @@ namespace util {
 
 stdcxx::CReference<Terminal> Networks::getEquivalentTerminal(const VoltageLevel& voltageLevel, unsigned long node) {
     if (voltageLevel.getTopologyKind() != TopologyKind::NODE_BREAKER) {
-        throw PowsyblException(logging::format("The voltage level %1% is not described in Node/Breaker topology", voltageLevel.getId()));
+        throw PowsyblException(stdcxx::format("The voltage level %1% is not described in Node/Breaker topology", voltageLevel.getId()));
     }
 
     stdcxx::CReference<Terminal> equivalentTerminal;
@@ -44,7 +44,7 @@ stdcxx::CReference<Terminal> Networks::getEquivalentTerminal(const VoltageLevel&
 
 std::map<std::string, std::set<unsigned long>> Networks::getNodesByBus(const VoltageLevel& voltageLevel) {
     if (voltageLevel.getTopologyKind() != TopologyKind::NODE_BREAKER) {
-        throw PowsyblException(logging::format("The voltage level %1% is not described in Node/Breaker topology", voltageLevel.getId()));
+        throw PowsyblException(stdcxx::format("The voltage level %1% is not described in Node/Breaker topology", voltageLevel.getId()));
     }
 
     std::map<std::string, std::set<unsigned long>> nodesByBus;

--- a/src/logging/Level.cpp
+++ b/src/logging/Level.cpp
@@ -10,8 +10,8 @@
 #include <array>
 
 #include <powsybl/AssertionError.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/logging/Level.cpp
+++ b/src/logging/Level.cpp
@@ -10,7 +10,7 @@
 #include <array>
 
 #include <powsybl/AssertionError.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
 
 namespace powsybl {
@@ -28,7 +28,7 @@ std::string getLevelName(const Level& level) {
 
     auto index = static_cast<unsigned char>(level);
     if (index >= s_levelNames.size()) {
-        throw powsybl::AssertionError(powsybl::logging::format("Unexpected %1% value: %2%", stdcxx::simpleClassName<Level>(), index));
+        throw powsybl::AssertionError(stdcxx::format("Unexpected %1% value: %2%", stdcxx::simpleClassName<Level>(), index));
     }
     return *(s_levelNames.begin() + index);
 }

--- a/src/logging/LogMessage.cpp
+++ b/src/logging/LogMessage.cpp
@@ -9,7 +9,7 @@
 
 #include <chrono>
 
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/time.hpp>
 
 #include <powsybl/AssertionError.hpp>

--- a/src/logging/LogMessage.cpp
+++ b/src/logging/LogMessage.cpp
@@ -9,7 +9,7 @@
 
 #include <chrono>
 
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/time.hpp>
 
 #include <powsybl/AssertionError.hpp>

--- a/src/network/LoadBarExt.cpp
+++ b/src/network/LoadBarExt.cpp
@@ -19,7 +19,7 @@ LoadBarExt::LoadBarExt(iidm::Load& load) :
 
 void LoadBarExt::assertExtendable(const stdcxx::Reference<iidm::Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<iidm::Load>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<iidm::Load>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<iidm::Load>()));
     }
 }
 

--- a/src/network/LoadFooExt.cpp
+++ b/src/network/LoadFooExt.cpp
@@ -19,7 +19,7 @@ LoadFooExt::LoadFooExt(iidm::Load& load) :
 
 void LoadFooExt::assertExtendable(const stdcxx::Reference<iidm::Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<iidm::Load>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<iidm::Load>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<iidm::Load>()));
     }
 }
 

--- a/src/stdcxx/DateTime.cpp
+++ b/src/stdcxx/DateTime.cpp
@@ -32,7 +32,7 @@ DateTime DateTime::parse(const std::string& date) {
         return DateTime(localDateTime);
     }
 
-    throw powsybl::PowsyblException(powsybl::logging::format("Unable to parse the date '%1%'", date));
+    throw powsybl::PowsyblException(stdcxx::format("Unable to parse the date '%1%'", date));
 }
 
 DateTime::DateTime() :

--- a/src/test/ExtensionFixture.cpp
+++ b/src/test/ExtensionFixture.cpp
@@ -20,7 +20,7 @@ namespace powsybl {
 namespace test {
 
 ExtensionFixture::ExtensionFixture() {
-    std::regex fileRegex(logging::format(".*\\%1%.*", boost::dll::shared_library::suffix().string()));
+    std::regex fileRegex(stdcxx::format(".*\\%1%.*", boost::dll::shared_library::suffix().string()));
     iidm::ExtensionProviders<iidm::converter::xml::ExtensionXmlSerializer>::getInstance().loadExtensions(boost::dll::program_location().parent_path().string(), fileRegex);
 }
 

--- a/src/test/ResourceFixture.cpp
+++ b/src/test/ResourceFixture.cpp
@@ -13,7 +13,7 @@
 #include <boost/filesystem/path.hpp>
 
 #include <powsybl/AssertionError.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
 

--- a/src/test/ResourceFixture.cpp
+++ b/src/test/ResourceFixture.cpp
@@ -13,7 +13,7 @@
 #include <boost/filesystem/path.hpp>
 
 #include <powsybl/AssertionError.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
 namespace powsybl {
 
@@ -33,14 +33,14 @@ std::string ResourceFixture::getResource(const std::string& name) const {
     path /= name;
 
     if (!boost::filesystem::exists(path)) {
-        throw powsybl::AssertionError(powsybl::logging::format("Unable to find the resource: %1%", path.string()));
+        throw powsybl::AssertionError(stdcxx::format("Unable to find the resource: %1%", path.string()));
     }
 
     std::stringstream buffer;
     std::ifstream stream(path.string());
     if (!stream) {
         throw powsybl::AssertionError(
-            powsybl::logging::format("Unable to access to the resource: %1%", path.string()));
+            stdcxx::format("Unable to access to the resource: %1%", path.string()));
     }
     buffer << stream.rdbuf();
 

--- a/src/xml/XmlStreamReader.cpp
+++ b/src/xml/XmlStreamReader.cpp
@@ -11,7 +11,7 @@
 #include <libxml/xmlreader.h>
 
 #include <powsybl/AssertionError.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 #include <powsybl/xml/XmlCharConversion.hpp>
 #include <powsybl/xml/XmlStreamException.hpp>
@@ -25,7 +25,7 @@ namespace xml {
 void checkNodeType(xmlTextReader& reader, const xmlReaderTypes& expected) {
     int nodeType = xmlTextReaderNodeType(&reader);
     if (nodeType != expected) {
-        throw XmlStreamException(logging::format("Unexpected node type: %1% (expected: %2%)", nodeType, expected));
+        throw XmlStreamException(stdcxx::format("Unexpected node type: %1% (expected: %2%)", nodeType, expected));
     }
 }
 
@@ -102,7 +102,7 @@ XmlString XmlStreamReader::getAttributeValue(const std::string& attributeName, b
 
     XmlString value(xmlTextReaderGetAttribute(m_reader.get(), S2XML(attributeName)));
     if (!value && throwException) {
-        throw XmlStreamException(logging::format("Attribute %1% does not exists", attributeName.c_str()));
+        throw XmlStreamException(stdcxx::format("Attribute %1% does not exists", attributeName.c_str()));
     }
 
     return value;
@@ -133,7 +133,7 @@ std::string XmlStreamReader::getNamespace(const std::string& prefix) const {
 
     XmlString namespaceXml(xmlTextReaderLookupNamespace(m_reader.get(), S2XML(prefix)));
     if (!namespaceXml) {
-        throw XmlStreamException(logging::format("Unknown prefix %1%", prefix));
+        throw XmlStreamException(stdcxx::format("Unknown prefix %1%", prefix));
     }
     return XML2S(namespaceXml.get());
 }
@@ -273,7 +273,7 @@ std::string XmlStreamReader::readUntilEndElement(const std::string& elementName,
     int emptyElement = xmlTextReaderIsEmptyElement(m_reader.get());
     if (emptyElement == -1) {
         // Error
-        throw XmlStreamException(logging::format("An error occurred while reading <%1%>", elementName.c_str()));
+        throw XmlStreamException(stdcxx::format("An error occurred while reading <%1%>", elementName.c_str()));
     }
     if (emptyElement == 1) {
         // if current element is an empty element, XML_READER_TYPE_END_ELEMENT is never reached => nothing to do
@@ -302,7 +302,7 @@ std::string XmlStreamReader::readUntilEndElement(const std::string& elementName,
     }
 
     if (res != 1) {
-        throw XmlStreamException(logging::format("Unexpected end of file: expecting %1%", elementName.c_str()));
+        throw XmlStreamException(stdcxx::format("Unexpected end of file: expecting %1%", elementName.c_str()));
     }
 
     return text;

--- a/src/xml/XmlStreamReader.cpp
+++ b/src/xml/XmlStreamReader.cpp
@@ -11,7 +11,7 @@
 #include <libxml/xmlreader.h>
 
 #include <powsybl/AssertionError.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 #include <powsybl/xml/XmlCharConversion.hpp>
 #include <powsybl/xml/XmlStreamException.hpp>

--- a/src/xml/XmlStreamWriter.cpp
+++ b/src/xml/XmlStreamWriter.cpp
@@ -9,7 +9,7 @@
 
 #include <libxml/xmlwriter.h>
 
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/math.hpp>
 #include <powsybl/xml/XmlCharConversion.hpp>
 #include <powsybl/xml/XmlStreamException.hpp>
@@ -57,7 +57,7 @@ void XmlStreamWriter::writeAttribute(const std::string& attributeName, int attri
 void XmlStreamWriter::writeAttribute(const std::string& attributeName, const std::string& attributeValue) {
     int written = xmlTextWriterWriteAttribute(m_writer.get(), S2XML(attributeName), S2XML(attributeValue));
     if (written < 0) {
-        throw XmlStreamException(logging::format("Failed to write attribute %1%", attributeName));
+        throw XmlStreamException(stdcxx::format("Failed to write attribute %1%", attributeName));
     }
 }
 
@@ -72,7 +72,7 @@ void XmlStreamWriter::writeAttribute(const std::string& attributeName, unsigned 
 void XmlStreamWriter::writeCharacters(const std::string& content) {
     int written = xmlTextWriterWriteString(m_writer.get(), S2XML(content));
     if (written < 0) {
-        throw XmlStreamException(logging::format("Failed to write characters %1%", content));
+        throw XmlStreamException(stdcxx::format("Failed to write characters %1%", content));
     }
 }
 
@@ -143,7 +143,7 @@ void XmlStreamWriter::writeStartDocument(const std::string& encoding, const std:
 
     xmlCharEncodingHandlerPtr encoder = xmlFindCharEncodingHandler(encoding.c_str());
     if (encoder == nullptr) {
-        throw XmlStreamException(logging::format("Unable to get encoder for encoding %1%", encoding));
+        throw XmlStreamException(stdcxx::format("Unable to get encoder for encoding %1%", encoding));
     }
 
     // initialize writer
@@ -170,7 +170,7 @@ void XmlStreamWriter::writeStartDocument(const std::string& encoding, const std:
     m_writer = XmlStreamWriterPtr(xmlNewTextWriter(buffer), deleteWriterCallback);
 
     if (!m_writer) {
-        throw XmlStreamException(logging::format("Unable to create xml writer"));
+        throw XmlStreamException(stdcxx::format("Unable to create xml writer"));
     }
 
     int ok = xmlTextWriterSetIndent(m_writer.get(), m_indent ? 1 : 0);
@@ -179,7 +179,7 @@ void XmlStreamWriter::writeStartDocument(const std::string& encoding, const std:
     }
 
     if (ok < 0) {
-        throw XmlStreamException(logging::format("Cannot set indentation"));
+        throw XmlStreamException(stdcxx::format("Cannot set indentation"));
     }
 
     int written = xmlTextWriterStartDocument(m_writer.get(), version.c_str(), encoding.c_str(), nullptr);
@@ -192,7 +192,7 @@ void XmlStreamWriter::writeStartElement(const std::string& prefix, const std::st
     const std::string& fullElementName = prefix.empty() ? elementName : prefix + ":" + elementName;
     int written = xmlTextWriterStartElement(m_writer.get(), S2XML(fullElementName));
     if (written < 0) {
-        throw XmlStreamException(logging::format("Failed to write start element %1%", fullElementName));
+        throw XmlStreamException(stdcxx::format("Failed to write start element %1%", fullElementName));
     }
 }
 

--- a/src/xml/XmlStreamWriter.cpp
+++ b/src/xml/XmlStreamWriter.cpp
@@ -9,7 +9,7 @@
 
 #include <libxml/xmlwriter.h>
 
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/math.hpp>
 #include <powsybl/xml/XmlCharConversion.hpp>
 #include <powsybl/xml/XmlStreamException.hpp>

--- a/test/iidm/ExtensionAdderTest.cpp
+++ b/test/iidm/ExtensionAdderTest.cpp
@@ -26,7 +26,7 @@ public:
 
     void assertExtendable(const stdcxx::Reference<Extendable>& extendable) const override {
         if (extendable && !stdcxx::isInstanceOf<SimpleExtendable>(extendable.get())) {
-            throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<SimpleExtendable>()));
+            throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<SimpleExtendable>()));
         }
     }
 

--- a/test/iidm/converter/xml/extensions/LoadBarXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadBarXmlSerializer.cpp
@@ -26,7 +26,7 @@ LoadBarXmlSerializer::LoadBarXmlSerializer() :
 
 std::unique_ptr<Extension> LoadBarXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& /*context*/) const {
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
     }
     auto& load = dynamic_cast<Load&>(extendable);
 

--- a/test/iidm/converter/xml/extensions/LoadFooXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadFooXmlSerializer.cpp
@@ -26,7 +26,7 @@ LoadFooXmlSerializer::LoadFooXmlSerializer() :
 
 std::unique_ptr<Extension> LoadFooXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& /*context*/) const {
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
     }
     auto& load = dynamic_cast<Load&>(extendable);
 

--- a/test/iidm/converter/xml/extensions/LoadMockExt.cpp
+++ b/test/iidm/converter/xml/extensions/LoadMockExt.cpp
@@ -27,7 +27,7 @@ LoadMockExt::LoadMockExt(Load& load) :
 
 void LoadMockExt::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<Load>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Load>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Load>()));
     }
 }
 

--- a/test/iidm/converter/xml/extensions/LoadMockExtXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadMockExtXmlSerializer.cpp
@@ -41,7 +41,7 @@ std::unique_ptr<Extension> LoadMockExtXmlSerializer::read(Extendable& extendable
     checkReadingCompatibility(context);
 
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
     }
     auto& load = dynamic_cast<Load&>(extendable);
 

--- a/test/iidm/converter/xml/extensions/LoadQuxExt.cpp
+++ b/test/iidm/converter/xml/extensions/LoadQuxExt.cpp
@@ -27,7 +27,7 @@ LoadQuxExt::LoadQuxExt(Load& load) :
 
 void LoadQuxExt::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<Load>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Load>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Load>()));
     }
 }
 

--- a/test/iidm/converter/xml/extensions/LoadQuxXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadQuxXmlSerializer.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<Extension> LoadQuxXmlSerializer::read(Extendable& extendable, Ne
     checkReadingCompatibility(context);
 
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
     }
     auto& load = dynamic_cast<Load&>(extendable);
 

--- a/test/iidm/converter/xml/extensions/TerminalMockExt.cpp
+++ b/test/iidm/converter/xml/extensions/TerminalMockExt.cpp
@@ -27,7 +27,7 @@ TerminalMockExt::TerminalMockExt(Load& load) :
 
 void TerminalMockExt::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
     if (extendable && !stdcxx::isInstanceOf<Load>(extendable.get())) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Load>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Load>()));
     }
 }
 

--- a/test/iidm/converter/xml/extensions/TerminalMockXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/TerminalMockXmlSerializer.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<Extension> TerminalMockXmlSerializer::read(Extendable& extendabl
     checkReadingCompatibility(context);
 
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
-        throw AssertionError(logging::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
     }
     auto& load = dynamic_cast<Load&>(extendable);
 
@@ -58,7 +58,7 @@ std::unique_ptr<Extension> TerminalMockXmlSerializer::read(Extendable& extendabl
             Terminal& terminal = TerminalRefXml::readTerminalRef(load.getNetwork(), id, side);
             terminalMockExt->setTerminal(stdcxx::ref(terminal));
         } else {
-            throw AssertionError(logging::format("Unexpected element: %1%", context.getReader().getLocalName()));
+            throw AssertionError(stdcxx::format("Unexpected element: %1%", context.getReader().getLocalName()));
         }
     });
 

--- a/test/logging/CMakeLists.txt
+++ b/test/logging/CMakeLists.txt
@@ -10,7 +10,6 @@ set(UNIT_TEST_SOURCES
     ContainerLoggerTest.cpp
     LoggerFactoryTest.cpp
     logging.cpp
-    MessageFormatTest.cpp
     NoopLoggerTest.cpp
 )
 

--- a/test/stdcxx/CMakeLists.txt
+++ b/test/stdcxx/CMakeLists.txt
@@ -10,6 +10,7 @@ set(UNIT_TEST_SOURCES
     DateTimeTest.cpp
     DemangleTest.cpp
     MathTest.cpp
+    MessageFormatTest.cpp
 )
 
 add_executable(unit-tests-stdcxx ${UNIT_TEST_SOURCES})

--- a/test/stdcxx/MessageFormatTest.cpp
+++ b/test/stdcxx/MessageFormatTest.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 
 namespace stdcxx {
 

--- a/test/stdcxx/MessageFormatTest.cpp
+++ b/test/stdcxx/MessageFormatTest.cpp
@@ -7,11 +7,9 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 
-namespace powsybl {
-
-namespace logging {
+namespace stdcxx {
 
 BOOST_AUTO_TEST_SUITE(MessageFormatTestSuite)
 
@@ -43,6 +41,4 @@ BOOST_AUTO_TEST_CASE(toStringTest) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
-}  // namespace logging
-
-}  // namespace powsybl
+}  // namespace stdcxx

--- a/tools/benchmark/Benchmark.cpp
+++ b/tools/benchmark/Benchmark.cpp
@@ -10,7 +10,7 @@
 #include <powsybl/iidm/Network.hpp>
 #include <powsybl/logging/ConsoleLogger.hpp>
 #include <powsybl/logging/LoggerFactory.hpp>
-#include <powsybl/logging/MessageFormat.hpp>
+#include <powsybl/stdcxx/MessageFormat.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 
 int main(int argc, char** argv) {
@@ -30,14 +30,14 @@ int main(int argc, char** argv) {
         const auto& inputFile = vm[INPUT_FILE].as<std::string>();
         std::ifstream inputStream(inputFile);
         if (!inputStream.is_open()) {
-            std::cerr << powsybl::logging::format("Unable to open file '%1%' for reading", inputFile) << std::endl;
+            std::cerr << stdcxx::format("Unable to open file '%1%' for reading", inputFile) << std::endl;
             return EXIT_FAILURE;
         }
 
         const auto& outputFile = vm[OUTPUT_FILE].as<std::string>();
         std::ofstream outputStream(outputFile);
         if (!outputStream.is_open()) {
-            std::cerr << powsybl::logging::format("Unable to open file '%1%' for writing", outputFile) << std::endl;
+            std::cerr << stdcxx::format("Unable to open file '%1%' for writing", outputFile) << std::endl;
             return EXIT_FAILURE;
         }
 

--- a/tools/benchmark/Benchmark.cpp
+++ b/tools/benchmark/Benchmark.cpp
@@ -10,7 +10,7 @@
 #include <powsybl/iidm/Network.hpp>
 #include <powsybl/logging/ConsoleLogger.hpp>
 #include <powsybl/logging/LoggerFactory.hpp>
-#include <powsybl/stdcxx/MessageFormat.hpp>
+#include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Moved MessageFormat.hpp from `logging` to `stdcxx` because the feature is not specific to `powsybl`

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
To print a formatted string, developper has to write
```
std::string error = "....";
std::string msg = powsybl::logging::format("My error message : %1%", error);
```


**What is the new behavior (if this is a feature change)?**
To print a formatted string, developper has to write
```
std::string error = "....";
std::string msg = stdcxx::format("My error message : %1%", error);
```


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
