### PR TITLE
Remove useless deprecated header

### DIFF
--- a/include/powsybl/test/AssertionUtils.hpp
+++ b/include/powsybl/test/AssertionUtils.hpp
@@ -10,7 +10,6 @@
 
 #include <sstream>
 
-#include <boost/test/floating_point_comparison.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <powsybl/stdcxx/demangle.hpp>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The header `boost/test/floating_point_comparison.hpp` is included in `AssertionUtils.hpp` but is deprecated in recent boost version (> 1.65), so a warning is displayed in the compilation log


**What is the new behavior (if this is a feature change)?**
Remove this header: seems unused?


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
