### PR TITLE
Fix RoundTrip::run method

### DIFF
--- a/src/test/converter/RoundTrip.cpp
+++ b/src/test/converter/RoundTrip.cpp
@@ -79,7 +79,7 @@ void RoundTrip::roundTripVersionedXmlTest(const std::string& filename, const iid
 iidm::Network RoundTrip::run(const iidm::Network& network, const Writer& out, const Reader& in, const Comparator& compare, const std::string& ref) {
     const std::string& output1 = write(network, out, compare, ref);
     iidm::Network data2 = in(output1);
-    write(network, out, compare, ref);
+    write(data2, out, compare, ref);
     return data2;
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Method `RoundTrip::run` was writing twice the input network, instead of reading the serialized network. So it did not highligh bugs while reading a xml string


**What is the new behavior (if this is a feature change)?**
The bug is fixed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
