### PR TITLE
Add the extension in read method and not by read caller

### DIFF
--- a/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/EntsoeAreaXmlSerializer.hpp
+++ b/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/EntsoeAreaXmlSerializer.hpp
@@ -9,6 +9,7 @@
 #define POWSYBL_IIDM_EXTENSIONS_ENTSOE_ENTSOEAREAXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
+#include <powsybl/iidm/extensions/entsoe/EntsoeArea.hpp>
 
 namespace powsybl {
 
@@ -20,7 +21,7 @@ namespace entsoe {
 
 class EntsoeAreaXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    EntsoeArea& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/EntsoeAreaXmlSerializer.hpp
+++ b/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/EntsoeAreaXmlSerializer.hpp
@@ -9,7 +9,6 @@
 #define POWSYBL_IIDM_EXTENSIONS_ENTSOE_ENTSOEAREAXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
-#include <powsybl/iidm/extensions/entsoe/EntsoeArea.hpp>
 
 namespace powsybl {
 
@@ -21,7 +20,7 @@ namespace entsoe {
 
 class EntsoeAreaXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    EntsoeArea& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/MergedXnodeXmlSerializer.hpp
+++ b/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/MergedXnodeXmlSerializer.hpp
@@ -9,7 +9,6 @@
 #define POWSYBL_IIDM_EXTENSIONS_ENTSOE_MERGEDXNODEXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
-#include <powsybl/iidm/extensions/entsoe/MergedXnode.hpp>
 
 namespace powsybl {
 
@@ -21,7 +20,7 @@ namespace entsoe {
 
 class MergedXnodeXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    MergedXnode& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/MergedXnodeXmlSerializer.hpp
+++ b/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/MergedXnodeXmlSerializer.hpp
@@ -9,6 +9,7 @@
 #define POWSYBL_IIDM_EXTENSIONS_ENTSOE_MERGEDXNODEXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
+#include <powsybl/iidm/extensions/entsoe/MergedXnode.hpp>
 
 namespace powsybl {
 
@@ -20,7 +21,7 @@ namespace entsoe {
 
 class MergedXnodeXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    MergedXnode& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/XnodeXmlSerializer.hpp
+++ b/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/XnodeXmlSerializer.hpp
@@ -9,6 +9,7 @@
 #define POWSYBL_IIDM_EXTENSIONS_ENTSOE_XNODEXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
+#include <powsybl/iidm/extensions/entsoe/Xnode.hpp>
 
 namespace powsybl {
 
@@ -20,7 +21,7 @@ namespace entsoe {
 
 class XnodeXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    Xnode& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/XnodeXmlSerializer.hpp
+++ b/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/XnodeXmlSerializer.hpp
@@ -21,7 +21,7 @@ namespace entsoe {
 
 class XnodeXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    Xnode& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/entsoe/src/EntsoeAreaXmlSerializer.cpp
+++ b/extensions/entsoe/src/EntsoeAreaXmlSerializer.cpp
@@ -13,6 +13,7 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
+#include <powsybl/iidm/extensions/entsoe/EntsoeArea.hpp>
 #include <powsybl/iidm/extensions/entsoe/EntsoeGeographicalCode.hpp>
 
 #include <powsybl/stdcxx/make_unique.hpp>
@@ -32,7 +33,7 @@ EntsoeAreaXmlSerializer::EntsoeAreaXmlSerializer() :
     AbstractExtensionXmlSerializer("entsoeArea", "network", "ea", "http://www.itesla_project.eu/schema/iidm/ext/entsoe_area/1_0") {
 }
 
-EntsoeArea& EntsoeAreaXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+Extension& EntsoeAreaXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<Substation>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Substation>()));
     }

--- a/extensions/entsoe/src/EntsoeAreaXmlSerializer.cpp
+++ b/extensions/entsoe/src/EntsoeAreaXmlSerializer.cpp
@@ -13,7 +13,6 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
-#include <powsybl/iidm/extensions/entsoe/EntsoeArea.hpp>
 #include <powsybl/iidm/extensions/entsoe/EntsoeGeographicalCode.hpp>
 
 #include <powsybl/stdcxx/make_unique.hpp>
@@ -33,7 +32,7 @@ EntsoeAreaXmlSerializer::EntsoeAreaXmlSerializer() :
     AbstractExtensionXmlSerializer("entsoeArea", "network", "ea", "http://www.itesla_project.eu/schema/iidm/ext/entsoe_area/1_0") {
 }
 
-std::unique_ptr<Extension> EntsoeAreaXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+EntsoeArea& EntsoeAreaXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<Substation>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Substation>()));
     }
@@ -41,7 +40,8 @@ std::unique_ptr<Extension> EntsoeAreaXmlSerializer::read(Extendable& extendable,
 
     const auto& code = Enum::fromString<EntsoeGeographicalCode>(context.getReader().readUntilEndElement(getExtensionName()));
 
-    return stdcxx::make_unique<EntsoeArea>(substation, code);
+    extendable.addExtension(stdcxx::make_unique<EntsoeArea>(substation, code));
+    return extendable.getExtension<EntsoeArea>();
 }
 
 void EntsoeAreaXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {

--- a/extensions/entsoe/src/MergedXnodeXmlSerializer.cpp
+++ b/extensions/entsoe/src/MergedXnodeXmlSerializer.cpp
@@ -12,8 +12,6 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
-#include <powsybl/iidm/extensions/entsoe/MergedXnode.hpp>
-
 #include <powsybl/xml/XmlStreamReader.hpp>
 #include <powsybl/xml/XmlStreamWriter.hpp>
 
@@ -29,7 +27,7 @@ MergedXnodeXmlSerializer::MergedXnodeXmlSerializer() :
     AbstractExtensionXmlSerializer("mergedXnode", "network", "mxn", "http://www.itesla_project.eu/schema/iidm/ext/merged_xnode/1_0") {
 }
 
-std::unique_ptr<Extension> MergedXnodeXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+MergedXnode& MergedXnodeXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<Line>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Line>()));
     }
@@ -43,7 +41,8 @@ std::unique_ptr<Extension> MergedXnodeXmlSerializer::read(Extendable& extendable
     const auto& xnodeQ2 = context.getReader().getAttributeValue<double>("xnodeQ2");
     const auto& code = context.getReader().getAttributeValue("code");
 
-    return stdcxx::make_unique<Extension, MergedXnode>(line, rdp, xdp, xnodeP1, xnodeQ1, xnodeP2, xnodeQ2, "", "", code);
+    extendable.addExtension(stdcxx::make_unique<MergedXnode>(line, rdp, xdp, xnodeP1, xnodeQ1, xnodeP2, xnodeQ2, "", "", code));
+    return extendable.getExtension<MergedXnode>();
 }
 
 void MergedXnodeXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {

--- a/extensions/entsoe/src/MergedXnodeXmlSerializer.cpp
+++ b/extensions/entsoe/src/MergedXnodeXmlSerializer.cpp
@@ -12,6 +12,8 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
+#include <powsybl/iidm/extensions/entsoe/MergedXnode.hpp>
+
 #include <powsybl/xml/XmlStreamReader.hpp>
 #include <powsybl/xml/XmlStreamWriter.hpp>
 
@@ -27,7 +29,7 @@ MergedXnodeXmlSerializer::MergedXnodeXmlSerializer() :
     AbstractExtensionXmlSerializer("mergedXnode", "network", "mxn", "http://www.itesla_project.eu/schema/iidm/ext/merged_xnode/1_0") {
 }
 
-MergedXnode& MergedXnodeXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+Extension& MergedXnodeXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<Line>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Line>()));
     }

--- a/extensions/entsoe/src/XnodeXmlSerializer.cpp
+++ b/extensions/entsoe/src/XnodeXmlSerializer.cpp
@@ -12,6 +12,7 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
+#include <powsybl/iidm/extensions/entsoe/Xnode.hpp>
 #include <powsybl/iidm/extensions/entsoe/XnodeAdder.hpp>
 
 #include <powsybl/xml/XmlStreamReader.hpp>
@@ -29,7 +30,7 @@ XnodeXmlSerializer::XnodeXmlSerializer() :
     AbstractExtensionXmlSerializer("xnode", "network", "xn", "http://www.itesla_project.eu/schema/iidm/ext/xnode/1_0") {
 }
 
-Xnode& XnodeXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+Extension& XnodeXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     const auto& code = context.getReader().getAttributeValue("code");
     extendable.newExtension<XnodeAdder>().withCode(code).add();
     return extendable.getExtension<Xnode>();

--- a/extensions/entsoe/src/XnodeXmlSerializer.cpp
+++ b/extensions/entsoe/src/XnodeXmlSerializer.cpp
@@ -12,7 +12,6 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
-#include <powsybl/iidm/extensions/entsoe/Xnode.hpp>
 #include <powsybl/iidm/extensions/entsoe/XnodeAdder.hpp>
 
 #include <powsybl/xml/XmlStreamReader.hpp>
@@ -30,10 +29,10 @@ XnodeXmlSerializer::XnodeXmlSerializer() :
     AbstractExtensionXmlSerializer("xnode", "network", "xn", "http://www.itesla_project.eu/schema/iidm/ext/xnode/1_0") {
 }
 
-std::unique_ptr<Extension> XnodeXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+Xnode& XnodeXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     const auto& code = context.getReader().getAttributeValue("code");
     extendable.newExtension<XnodeAdder>().withCode(code).add();
-    return stdcxx::make_unique<Xnode>(extendable.getExtension<Xnode>());
+    return extendable.getExtension<Xnode>();
 }
 
 void XnodeXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/ActivePowerControlXmlSerializer.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/ActivePowerControlXmlSerializer.hpp
@@ -9,7 +9,6 @@
 #define POWSYBL_IIDM_EXTENSIONS_IIDM_ACTIVEPOWERCONTROLXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
-#include <powsybl/iidm/extensions/iidm/ActivePowerControl.hpp>
 
 namespace powsybl {
 
@@ -21,7 +20,7 @@ namespace iidm {
 
 class ActivePowerControlXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    ActivePowerControl& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/ActivePowerControlXmlSerializer.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/ActivePowerControlXmlSerializer.hpp
@@ -9,6 +9,7 @@
 #define POWSYBL_IIDM_EXTENSIONS_IIDM_ACTIVEPOWERCONTROLXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
+#include <powsybl/iidm/extensions/iidm/ActivePowerControl.hpp>
 
 namespace powsybl {
 
@@ -20,7 +21,7 @@ namespace iidm {
 
 class ActivePowerControlXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    ActivePowerControl& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/CoordinatedReactiveControlXmlSerializer.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/CoordinatedReactiveControlXmlSerializer.hpp
@@ -9,7 +9,6 @@
 #define POWSYBL_IIDM_EXTENSIONS_IIDM_COORDINATEDREACTIVECONTROLXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
-#include <powsybl/iidm/extensions/iidm/CoordinatedReactiveControl.hpp>
 
 namespace powsybl {
 
@@ -21,7 +20,7 @@ namespace iidm {
 
 class CoordinatedReactiveControlXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    CoordinatedReactiveControl& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/CoordinatedReactiveControlXmlSerializer.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/CoordinatedReactiveControlXmlSerializer.hpp
@@ -9,6 +9,7 @@
 #define POWSYBL_IIDM_EXTENSIONS_IIDM_COORDINATEDREACTIVECONTROLXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
+#include <powsybl/iidm/extensions/iidm/CoordinatedReactiveControl.hpp>
 
 namespace powsybl {
 
@@ -20,7 +21,7 @@ namespace iidm {
 
 class CoordinatedReactiveControlXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    CoordinatedReactiveControl& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.hpp
@@ -9,6 +9,7 @@
 #define POWSYBL_IIDM_EXTENSIONS_IIDM_THREEWINDINGSTRANSFORMERPHASEANGLECLOCKXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
+#include <powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp>
 
 namespace powsybl {
 
@@ -20,7 +21,7 @@ namespace iidm {
 
 class ThreeWindingsTransformerPhaseAngleClockXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    ThreeWindingsTransformerPhaseAngleClock& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.hpp
@@ -9,7 +9,6 @@
 #define POWSYBL_IIDM_EXTENSIONS_IIDM_THREEWINDINGSTRANSFORMERPHASEANGLECLOCKXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
-#include <powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp>
 
 namespace powsybl {
 
@@ -21,7 +20,7 @@ namespace iidm {
 
 class ThreeWindingsTransformerPhaseAngleClockXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    ThreeWindingsTransformerPhaseAngleClock& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClockXmlSerializer.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClockXmlSerializer.hpp
@@ -9,7 +9,6 @@
 #define POWSYBL_IIDM_EXTENSIONS_IIDM_TWOWINDINGSTRANSFORMERPHASEANGLECLOCKXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
-#include <powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp>
 
 namespace powsybl {
 
@@ -21,7 +20,7 @@ namespace iidm {
 
 class TwoWindingsTransformerPhaseAngleClockXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    TwoWindingsTransformerPhaseAngleClock& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClockXmlSerializer.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClockXmlSerializer.hpp
@@ -9,6 +9,7 @@
 #define POWSYBL_IIDM_EXTENSIONS_IIDM_TWOWINDINGSTRANSFORMERPHASEANGLECLOCKXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
+#include <powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp>
 
 namespace powsybl {
 
@@ -20,7 +21,7 @@ namespace iidm {
 
 class TwoWindingsTransformerPhaseAngleClockXmlSerializer : public converter::xml::AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
+    TwoWindingsTransformerPhaseAngleClock& read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const override;
 

--- a/extensions/iidm/src/ActivePowerControlXmlSerializer.cpp
+++ b/extensions/iidm/src/ActivePowerControlXmlSerializer.cpp
@@ -16,9 +16,8 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
+#include <powsybl/iidm/extensions/iidm/ActivePowerControl.hpp>
 #include <powsybl/iidm/extensions/iidm/ActivePowerControlAdder.hpp>
-
-#include <powsybl/stdcxx/make_unique.hpp>
 
 #include <powsybl/xml/XmlStreamReader.hpp>
 #include <powsybl/xml/XmlStreamWriter.hpp>
@@ -35,7 +34,7 @@ ActivePowerControlXmlSerializer::ActivePowerControlXmlSerializer() :
     AbstractExtensionXmlSerializer("activePowerControl", "network", "apc", "http://www.itesla_project.eu/schema/iidm/ext/active_power_control/1_0") {
 }
 
-ActivePowerControl& ActivePowerControlXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+Extension& ActivePowerControlXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     const auto& participate = context.getReader().getAttributeValue<bool>("participate");
     const auto& droop = context.getReader().getAttributeValue<double>("droop");
 

--- a/extensions/iidm/src/ActivePowerControlXmlSerializer.cpp
+++ b/extensions/iidm/src/ActivePowerControlXmlSerializer.cpp
@@ -16,7 +16,6 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
-#include <powsybl/iidm/extensions/iidm/ActivePowerControl.hpp>
 #include <powsybl/iidm/extensions/iidm/ActivePowerControlAdder.hpp>
 
 #include <powsybl/stdcxx/make_unique.hpp>
@@ -36,12 +35,12 @@ ActivePowerControlXmlSerializer::ActivePowerControlXmlSerializer() :
     AbstractExtensionXmlSerializer("activePowerControl", "network", "apc", "http://www.itesla_project.eu/schema/iidm/ext/active_power_control/1_0") {
 }
 
-std::unique_ptr<Extension> ActivePowerControlXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+ActivePowerControl& ActivePowerControlXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     const auto& participate = context.getReader().getAttributeValue<bool>("participate");
     const auto& droop = context.getReader().getAttributeValue<double>("droop");
 
     extendable.newExtension<ActivePowerControlAdder>().withParticipate(participate).withDroop(droop).add();
-    return stdcxx::make_unique<ActivePowerControl>(extendable.getExtension<ActivePowerControl>());
+    return extendable.getExtension<ActivePowerControl>();
 }
 
 void ActivePowerControlXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {

--- a/extensions/iidm/src/CoordinatedReactiveControlXmlSerializer.cpp
+++ b/extensions/iidm/src/CoordinatedReactiveControlXmlSerializer.cpp
@@ -14,8 +14,6 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
-#include <powsybl/iidm/extensions/iidm/CoordinatedReactiveControl.hpp>
-
 #include <powsybl/stdcxx/make_unique.hpp>
 
 #include <powsybl/xml/XmlStreamReader.hpp>
@@ -33,7 +31,7 @@ CoordinatedReactiveControlXmlSerializer::CoordinatedReactiveControlXmlSerializer
     AbstractExtensionXmlSerializer("coordinatedReactiveControl", "network", "crc", "http://www.powsybl.org/schema/iidm/ext/coordinated_reactive_control/1_0") {
 }
 
-std::unique_ptr<Extension> CoordinatedReactiveControlXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+CoordinatedReactiveControl& CoordinatedReactiveControlXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<Generator>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Generator>()));
     }
@@ -41,7 +39,8 @@ std::unique_ptr<Extension> CoordinatedReactiveControlXmlSerializer::read(Extenda
 
     const auto& qPercent = context.getReader().getAttributeValue<double>("qPercent");
 
-    return stdcxx::make_unique<Extension, CoordinatedReactiveControl>(generator, qPercent);
+    extendable.addExtension(stdcxx::make_unique<CoordinatedReactiveControl>(generator, qPercent));
+    return extendable.getExtension<CoordinatedReactiveControl>();
 }
 
 void CoordinatedReactiveControlXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {

--- a/extensions/iidm/src/CoordinatedReactiveControlXmlSerializer.cpp
+++ b/extensions/iidm/src/CoordinatedReactiveControlXmlSerializer.cpp
@@ -14,6 +14,8 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
+#include <powsybl/iidm/extensions/iidm/CoordinatedReactiveControl.hpp>
+
 #include <powsybl/stdcxx/make_unique.hpp>
 
 #include <powsybl/xml/XmlStreamReader.hpp>
@@ -31,7 +33,7 @@ CoordinatedReactiveControlXmlSerializer::CoordinatedReactiveControlXmlSerializer
     AbstractExtensionXmlSerializer("coordinatedReactiveControl", "network", "crc", "http://www.powsybl.org/schema/iidm/ext/coordinated_reactive_control/1_0") {
 }
 
-CoordinatedReactiveControl& CoordinatedReactiveControlXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+Extension& CoordinatedReactiveControlXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<Generator>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Generator>()));
     }

--- a/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.cpp
+++ b/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.cpp
@@ -14,6 +14,8 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
+#include <powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp>
+
 #include <powsybl/stdcxx/make_unique.hpp>
 
 #include <powsybl/xml/XmlStreamReader.hpp>
@@ -31,7 +33,7 @@ ThreeWindingsTransformerPhaseAngleClockXmlSerializer::ThreeWindingsTransformerPh
     AbstractExtensionXmlSerializer("threeWindingsTransformerPhaseAngleClock", "network", "threewtpac", "http://www.powsybl.org/schema/iidm/ext/three_windings_transformer_phase_angle_clock/1_0") {
 }
 
-ThreeWindingsTransformerPhaseAngleClock& ThreeWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+Extension& ThreeWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<ThreeWindingsTransformer>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<ThreeWindingsTransformer>()));
     }
@@ -44,12 +46,12 @@ ThreeWindingsTransformerPhaseAngleClock& ThreeWindingsTransformerPhaseAngleClock
     return extendable.getExtension<ThreeWindingsTransformerPhaseAngleClock>();
 }
 
-void ThreeWindingsTransformerPhaseAngleClockXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {
-    const auto& ext = safeCast<ThreeWindingsTransformerPhaseAngleClock>(extension);
+    void ThreeWindingsTransformerPhaseAngleClockXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {
+        const auto& ext = safeCast<ThreeWindingsTransformerPhaseAngleClock>(extension);
 
-    context.getExtensionsWriter().writeOptionalAttribute("phaseAngleClockLeg2", ext.getPhaseAngleClockLeg2(), 0UL);
-    context.getExtensionsWriter().writeOptionalAttribute("phaseAngleClockLeg3", ext.getPhaseAngleClockLeg3(), 0UL);
-}
+        context.getExtensionsWriter().writeOptionalAttribute("phaseAngleClockLeg2", ext.getPhaseAngleClockLeg2(), 0UL);
+        context.getExtensionsWriter().writeOptionalAttribute("phaseAngleClockLeg3", ext.getPhaseAngleClockLeg3(), 0UL);
+    }
 
 }  // namespace iidm
 
@@ -58,3 +60,4 @@ void ThreeWindingsTransformerPhaseAngleClockXmlSerializer::write(const Extension
 }  // namespace iidm
 
 }  // namespace powsybl
+

--- a/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.cpp
+++ b/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClockXmlSerializer.cpp
@@ -14,8 +14,6 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
-#include <powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp>
-
 #include <powsybl/stdcxx/make_unique.hpp>
 
 #include <powsybl/xml/XmlStreamReader.hpp>
@@ -33,7 +31,7 @@ ThreeWindingsTransformerPhaseAngleClockXmlSerializer::ThreeWindingsTransformerPh
     AbstractExtensionXmlSerializer("threeWindingsTransformerPhaseAngleClock", "network", "threewtpac", "http://www.powsybl.org/schema/iidm/ext/three_windings_transformer_phase_angle_clock/1_0") {
 }
 
-std::unique_ptr<Extension> ThreeWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+ThreeWindingsTransformerPhaseAngleClock& ThreeWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<ThreeWindingsTransformer>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<ThreeWindingsTransformer>()));
     }
@@ -42,7 +40,8 @@ std::unique_ptr<Extension> ThreeWindingsTransformerPhaseAngleClockXmlSerializer:
     const auto& phaseAngleClockLeg2 = context.getReader().getOptionalAttributeValue("phaseAngleClockLeg2", 0UL);
     const auto& phaseAngleClockLeg3 = context.getReader().getOptionalAttributeValue("phaseAngleClockLeg3", 0UL);
 
-    return stdcxx::make_unique<Extension, ThreeWindingsTransformerPhaseAngleClock>(transformer, phaseAngleClockLeg2, phaseAngleClockLeg3);
+    extendable.addExtension(stdcxx::make_unique<ThreeWindingsTransformerPhaseAngleClock>(transformer, phaseAngleClockLeg2, phaseAngleClockLeg3));
+    return extendable.getExtension<ThreeWindingsTransformerPhaseAngleClock>();
 }
 
 void ThreeWindingsTransformerPhaseAngleClockXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {

--- a/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClockXmlSerializer.cpp
+++ b/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClockXmlSerializer.cpp
@@ -12,6 +12,8 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
+#include <powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp>
+
 #include <powsybl/stdcxx/make_unique.hpp>
 
 #include <powsybl/xml/XmlStreamReader.hpp>
@@ -29,7 +31,7 @@ TwoWindingsTransformerPhaseAngleClockXmlSerializer::TwoWindingsTransformerPhaseA
     AbstractExtensionXmlSerializer("twoWindingsTransformerPhaseAngleClock", "network", "twowtpac", "http://www.powsybl.org/schema/iidm/ext/two_windings_transformer_phase_angle_clock/1_0") {
 }
 
-TwoWindingsTransformerPhaseAngleClock& TwoWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+Extension& TwoWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<TwoWindingsTransformer>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<TwoWindingsTransformer>()));
     }
@@ -54,3 +56,4 @@ void TwoWindingsTransformerPhaseAngleClockXmlSerializer::write(const Extension& 
 }  // namespace iidm
 
 }  // namespace powsybl
+

--- a/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClockXmlSerializer.cpp
+++ b/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClockXmlSerializer.cpp
@@ -12,8 +12,6 @@
 #include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
 #include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
 
-#include <powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp>
-
 #include <powsybl/stdcxx/make_unique.hpp>
 
 #include <powsybl/xml/XmlStreamReader.hpp>
@@ -31,7 +29,7 @@ TwoWindingsTransformerPhaseAngleClockXmlSerializer::TwoWindingsTransformerPhaseA
     AbstractExtensionXmlSerializer("twoWindingsTransformerPhaseAngleClock", "network", "twowtpac", "http://www.powsybl.org/schema/iidm/ext/two_windings_transformer_phase_angle_clock/1_0") {
 }
 
-std::unique_ptr<Extension> TwoWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
+TwoWindingsTransformerPhaseAngleClock& TwoWindingsTransformerPhaseAngleClockXmlSerializer::read(Extendable& extendable, converter::xml::NetworkXmlReaderContext& context) const {
     if (!stdcxx::isInstanceOf<TwoWindingsTransformer>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<TwoWindingsTransformer>()));
     }
@@ -39,7 +37,8 @@ std::unique_ptr<Extension> TwoWindingsTransformerPhaseAngleClockXmlSerializer::r
 
     const auto& phaseAngleClock = context.getReader().getOptionalAttributeValue("phaseAngleClock", 0UL);
 
-    return stdcxx::make_unique<Extension, TwoWindingsTransformerPhaseAngleClock>(transformer, phaseAngleClock);
+    extendable.addExtension(stdcxx::make_unique<TwoWindingsTransformerPhaseAngleClock>(transformer, phaseAngleClock));
+    return extendable.getExtension<TwoWindingsTransformerPhaseAngleClock>();
 }
 
 void TwoWindingsTransformerPhaseAngleClockXmlSerializer::write(const Extension& extension, converter::xml::NetworkXmlWriterContext& context) const {

--- a/include/powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp
+++ b/include/powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp
@@ -101,11 +101,11 @@ public:
      * @param extendable The holder of the new extension
      * @param context The current XML context
      *
-     * @return An extension
+     * @return The added extension
      *
      * @throw An {@link AssertionError} if the extension is not compatible with the extendable type
      */
-    virtual std::unique_ptr<Extension> read(Extendable& extendable, NetworkXmlReaderContext& context) const = 0;
+    virtual Extension& read(Extendable& extendable, NetworkXmlReaderContext& context) const = 0;
 
     /**
      * Write an extension in XML

--- a/src/iidm/converter/xml/NetworkXml.cpp
+++ b/src/iidm/converter/xml/NetworkXml.cpp
@@ -117,8 +117,7 @@ void readExtensions(Identifiable& identifiable, NetworkXmlReaderContext& context
 
         stdcxx::CReference<ExtensionXmlSerializer> serializer = extensionProviders.findProvider(extensionName);
         if (serializer) {
-            std::unique_ptr<Extension> extension = serializer.get().read(identifiable, context);
-            identifiable.addExtension(std::move(extension));
+            serializer.get().read(identifiable, context);
         } else {
             extensionsNotFound.insert(extensionName);
             context.getReader().readUntilEndElement(extensionName, []() {});

--- a/test/iidm/converter/xml/extensions/LoadBarXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadBarXmlSerializer.cpp
@@ -8,7 +8,6 @@
 #include "LoadBarXmlSerializer.hpp"
 
 #include <powsybl/iidm/Load.hpp>
-#include <powsybl/network/LoadBarExt.hpp>
 
 namespace powsybl {
 
@@ -24,13 +23,14 @@ LoadBarXmlSerializer::LoadBarXmlSerializer() :
     AbstractExtensionXmlSerializer("loadBar", "network", "bar", "http://www.itesla_project.eu/schema/iidm/ext/loadbar/1_0") {
 }
 
-std::unique_ptr<Extension> LoadBarXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& /*context*/) const {
+network::LoadBarExt& LoadBarXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& /*context*/) const {
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
     }
     auto& load = dynamic_cast<Load&>(extendable);
 
-    return stdcxx::make_unique<network::LoadBarExt>(load);
+    extendable.addExtension(stdcxx::make_unique<network::LoadBarExt>(load));
+    return extendable.getExtension<network::LoadBarExt>();
 }
 
 void LoadBarXmlSerializer::write(const Extension& /*extension*/, NetworkXmlWriterContext& /*context*/) const {

--- a/test/iidm/converter/xml/extensions/LoadBarXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadBarXmlSerializer.cpp
@@ -8,6 +8,7 @@
 #include "LoadBarXmlSerializer.hpp"
 
 #include <powsybl/iidm/Load.hpp>
+#include <powsybl/network/LoadBarExt.hpp>
 
 namespace powsybl {
 
@@ -23,7 +24,7 @@ LoadBarXmlSerializer::LoadBarXmlSerializer() :
     AbstractExtensionXmlSerializer("loadBar", "network", "bar", "http://www.itesla_project.eu/schema/iidm/ext/loadbar/1_0") {
 }
 
-network::LoadBarExt& LoadBarXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& /*context*/) const {
+Extension& LoadBarXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& /*context*/) const {
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
     }

--- a/test/iidm/converter/xml/extensions/LoadBarXmlSerializer.hpp
+++ b/test/iidm/converter/xml/extensions/LoadBarXmlSerializer.hpp
@@ -9,6 +9,7 @@
 #define POWSYBL_IIDM_CONVERTER_XML_EXTENSIONS_LOADBARXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
+#include <powsybl/network/LoadBarExt.hpp>
 
 namespace powsybl {
 
@@ -24,7 +25,7 @@ namespace extensions {
 
 class LoadBarXmlSerializer : public AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
+    network::LoadBarExt& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, NetworkXmlWriterContext& context) const override;
 

--- a/test/iidm/converter/xml/extensions/LoadBarXmlSerializer.hpp
+++ b/test/iidm/converter/xml/extensions/LoadBarXmlSerializer.hpp
@@ -9,7 +9,6 @@
 #define POWSYBL_IIDM_CONVERTER_XML_EXTENSIONS_LOADBARXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
-#include <powsybl/network/LoadBarExt.hpp>
 
 namespace powsybl {
 
@@ -25,7 +24,7 @@ namespace extensions {
 
 class LoadBarXmlSerializer : public AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    network::LoadBarExt& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, NetworkXmlWriterContext& context) const override;
 

--- a/test/iidm/converter/xml/extensions/LoadFooXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadFooXmlSerializer.cpp
@@ -8,7 +8,6 @@
 #include "LoadFooXmlSerializer.hpp"
 
 #include <powsybl/iidm/Load.hpp>
-#include <powsybl/network/LoadFooExt.hpp>
 
 namespace powsybl {
 
@@ -24,13 +23,14 @@ LoadFooXmlSerializer::LoadFooXmlSerializer() :
     AbstractExtensionXmlSerializer("loadFoo", "network", "foo", "http://www.itesla_project.eu/schema/iidm/ext/loadfoo/1_0") {
 }
 
-std::unique_ptr<Extension> LoadFooXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& /*context*/) const {
+network::LoadFooExt& LoadFooXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& /*context*/) const {
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
     }
     auto& load = dynamic_cast<Load&>(extendable);
 
-    return stdcxx::make_unique<network::LoadFooExt>(load);
+    extendable.addExtension(stdcxx::make_unique<network::LoadFooExt>(load));
+    return extendable.getExtension<network::LoadFooExt>();
 }
 
 void LoadFooXmlSerializer::write(const Extension& /*extension*/, NetworkXmlWriterContext& /*context*/) const {

--- a/test/iidm/converter/xml/extensions/LoadFooXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadFooXmlSerializer.cpp
@@ -8,6 +8,7 @@
 #include "LoadFooXmlSerializer.hpp"
 
 #include <powsybl/iidm/Load.hpp>
+#include <powsybl/network/LoadFooExt.hpp>
 
 namespace powsybl {
 
@@ -23,7 +24,7 @@ LoadFooXmlSerializer::LoadFooXmlSerializer() :
     AbstractExtensionXmlSerializer("loadFoo", "network", "foo", "http://www.itesla_project.eu/schema/iidm/ext/loadfoo/1_0") {
 }
 
-network::LoadFooExt& LoadFooXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& /*context*/) const {
+Extension& LoadFooXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& /*context*/) const {
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
         throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Load>()));
     }

--- a/test/iidm/converter/xml/extensions/LoadFooXmlSerializer.hpp
+++ b/test/iidm/converter/xml/extensions/LoadFooXmlSerializer.hpp
@@ -9,7 +9,6 @@
 #define POWSYBL_IIDM_CONVERTER_XML_EXTENSIONS_LOADFOOXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
-#include <powsybl/network/LoadFooExt.hpp>
 
 namespace powsybl {
 
@@ -25,7 +24,7 @@ namespace extensions {
 
 class LoadFooXmlSerializer : public AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    network::LoadFooExt& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, NetworkXmlWriterContext& context) const override;
 

--- a/test/iidm/converter/xml/extensions/LoadFooXmlSerializer.hpp
+++ b/test/iidm/converter/xml/extensions/LoadFooXmlSerializer.hpp
@@ -9,6 +9,7 @@
 #define POWSYBL_IIDM_CONVERTER_XML_EXTENSIONS_LOADFOOXMLSERIALIZER_HPP
 
 #include <powsybl/iidm/converter/xml/AbstractExtensionXmlSerializer.hpp>
+#include <powsybl/network/LoadFooExt.hpp>
 
 namespace powsybl {
 
@@ -24,7 +25,7 @@ namespace extensions {
 
 class LoadFooXmlSerializer : public AbstractExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
+    network::LoadFooExt& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, NetworkXmlWriterContext& context) const override;
 

--- a/test/iidm/converter/xml/extensions/LoadMockExtXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadMockExtXmlSerializer.cpp
@@ -12,8 +12,6 @@
 #include <powsybl/iidm/converter/xml/VersionsCompatibity.hpp>
 #include <powsybl/stdcxx/map.hpp>
 
-#include "LoadMockExt.hpp"
-
 namespace powsybl {
 
 namespace iidm {
@@ -37,7 +35,7 @@ LoadMockExtXmlSerializer::LoadMockExtXmlSerializer() :
             .build()) {
 }
 
-std::unique_ptr<Extension> LoadMockExtXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
+LoadMockExt& LoadMockExtXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
     checkReadingCompatibility(context);
 
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
@@ -45,7 +43,8 @@ std::unique_ptr<Extension> LoadMockExtXmlSerializer::read(Extendable& extendable
     }
     auto& load = dynamic_cast<Load&>(extendable);
 
-    return stdcxx::make_unique<LoadMockExt>(load);
+    extendable.addExtension(stdcxx::make_unique<LoadMockExt>(load));
+    return extendable.getExtension<LoadMockExt>();
 }
 
 void LoadMockExtXmlSerializer::write(const Extension& /*extension*/, NetworkXmlWriterContext& /*context*/) const {

--- a/test/iidm/converter/xml/extensions/LoadMockExtXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadMockExtXmlSerializer.cpp
@@ -12,6 +12,8 @@
 #include <powsybl/iidm/converter/xml/VersionsCompatibity.hpp>
 #include <powsybl/stdcxx/map.hpp>
 
+#include "LoadMockExt.hpp"
+
 namespace powsybl {
 
 namespace iidm {
@@ -35,7 +37,7 @@ LoadMockExtXmlSerializer::LoadMockExtXmlSerializer() :
             .build()) {
 }
 
-LoadMockExt& LoadMockExtXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
+Extension& LoadMockExtXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
     checkReadingCompatibility(context);
 
     if (!stdcxx::isInstanceOf<Load>(extendable)) {

--- a/test/iidm/converter/xml/extensions/LoadMockExtXmlSerializer.hpp
+++ b/test/iidm/converter/xml/extensions/LoadMockExtXmlSerializer.hpp
@@ -10,8 +10,6 @@
 
 #include <powsybl/iidm/converter/xml/AbstractVersionableExtensionXmlSerializer.hpp>
 
-#include "LoadMockExt.hpp"
-
 namespace powsybl {
 
 namespace iidm {
@@ -26,7 +24,7 @@ namespace extensions {
 
 class LoadMockExtXmlSerializer : public AbstractVersionableExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    LoadMockExt& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, NetworkXmlWriterContext& context) const override;
 

--- a/test/iidm/converter/xml/extensions/LoadMockExtXmlSerializer.hpp
+++ b/test/iidm/converter/xml/extensions/LoadMockExtXmlSerializer.hpp
@@ -10,6 +10,8 @@
 
 #include <powsybl/iidm/converter/xml/AbstractVersionableExtensionXmlSerializer.hpp>
 
+#include "LoadMockExt.hpp"
+
 namespace powsybl {
 
 namespace iidm {
@@ -24,7 +26,7 @@ namespace extensions {
 
 class LoadMockExtXmlSerializer : public AbstractVersionableExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
+    LoadMockExt& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, NetworkXmlWriterContext& context) const override;
 

--- a/test/iidm/converter/xml/extensions/LoadQuxXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadQuxXmlSerializer.cpp
@@ -12,8 +12,6 @@
 #include <powsybl/iidm/converter/xml/VersionsCompatibity.hpp>
 #include <powsybl/stdcxx/map.hpp>
 
-#include "LoadQuxExt.hpp"
-
 namespace powsybl {
 
 namespace iidm {
@@ -34,7 +32,7 @@ LoadQuxXmlSerializer::LoadQuxXmlSerializer() :
             .build()) {
 }
 
-std::unique_ptr<Extension> LoadQuxXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
+LoadQuxExt& LoadQuxXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
     checkReadingCompatibility(context);
 
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
@@ -42,7 +40,8 @@ std::unique_ptr<Extension> LoadQuxXmlSerializer::read(Extendable& extendable, Ne
     }
     auto& load = dynamic_cast<Load&>(extendable);
 
-    return stdcxx::make_unique<LoadQuxExt>(load);
+    extendable.addExtension(stdcxx::make_unique<LoadQuxExt>(load));
+    return extendable.getExtension<LoadQuxExt>();
 }
 
 void LoadQuxXmlSerializer::write(const Extension& /*extension*/, NetworkXmlWriterContext& /*context*/) const {

--- a/test/iidm/converter/xml/extensions/LoadQuxXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/LoadQuxXmlSerializer.cpp
@@ -12,6 +12,8 @@
 #include <powsybl/iidm/converter/xml/VersionsCompatibity.hpp>
 #include <powsybl/stdcxx/map.hpp>
 
+#include "LoadQuxExt.hpp"
+
 namespace powsybl {
 
 namespace iidm {
@@ -32,7 +34,7 @@ LoadQuxXmlSerializer::LoadQuxXmlSerializer() :
             .build()) {
 }
 
-LoadQuxExt& LoadQuxXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
+Extension& LoadQuxXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
     checkReadingCompatibility(context);
 
     if (!stdcxx::isInstanceOf<Load>(extendable)) {

--- a/test/iidm/converter/xml/extensions/LoadQuxXmlSerializer.hpp
+++ b/test/iidm/converter/xml/extensions/LoadQuxXmlSerializer.hpp
@@ -10,8 +10,6 @@
 
 #include <powsybl/iidm/converter/xml/AbstractVersionableExtensionXmlSerializer.hpp>
 
-#include "LoadQuxExt.hpp"
-
 namespace powsybl {
 
 namespace iidm {
@@ -26,7 +24,7 @@ namespace extensions {
 
 class LoadQuxXmlSerializer : public AbstractVersionableExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    LoadQuxExt& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, NetworkXmlWriterContext& context) const override;
 

--- a/test/iidm/converter/xml/extensions/LoadQuxXmlSerializer.hpp
+++ b/test/iidm/converter/xml/extensions/LoadQuxXmlSerializer.hpp
@@ -10,6 +10,8 @@
 
 #include <powsybl/iidm/converter/xml/AbstractVersionableExtensionXmlSerializer.hpp>
 
+#include "LoadQuxExt.hpp"
+
 namespace powsybl {
 
 namespace iidm {
@@ -24,7 +26,7 @@ namespace extensions {
 
 class LoadQuxXmlSerializer : public AbstractVersionableExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
+    LoadQuxExt& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, NetworkXmlWriterContext& context) const override;
 

--- a/test/iidm/converter/xml/extensions/TerminalMockXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/TerminalMockXmlSerializer.cpp
@@ -18,8 +18,6 @@
 #include <powsybl/stdcxx/map.hpp>
 #include <powsybl/xml/XmlStreamReader.hpp>
 
-#include "TerminalMockExt.hpp"
-
 namespace powsybl {
 
 namespace iidm {
@@ -42,7 +40,7 @@ TerminalMockXmlSerializer::TerminalMockXmlSerializer() :
             .build()) {
 }
 
-std::unique_ptr<Extension> TerminalMockXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
+TerminalMockExt& TerminalMockXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
     checkReadingCompatibility(context);
 
     if (!stdcxx::isInstanceOf<Load>(extendable)) {
@@ -62,7 +60,8 @@ std::unique_ptr<Extension> TerminalMockXmlSerializer::read(Extendable& extendabl
         }
     });
 
-    return std::move(terminalMockExt);
+    extendable.addExtension(std::move(terminalMockExt));
+    return extendable.getExtension<TerminalMockExt>();
 }
 
 void TerminalMockXmlSerializer::write(const Extension& extension, NetworkXmlWriterContext& context) const {

--- a/test/iidm/converter/xml/extensions/TerminalMockXmlSerializer.cpp
+++ b/test/iidm/converter/xml/extensions/TerminalMockXmlSerializer.cpp
@@ -18,6 +18,8 @@
 #include <powsybl/stdcxx/map.hpp>
 #include <powsybl/xml/XmlStreamReader.hpp>
 
+#include "TerminalMockExt.hpp"
+
 namespace powsybl {
 
 namespace iidm {
@@ -40,7 +42,7 @@ TerminalMockXmlSerializer::TerminalMockXmlSerializer() :
             .build()) {
 }
 
-TerminalMockExt& TerminalMockXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
+Extension& TerminalMockXmlSerializer::read(Extendable& extendable, NetworkXmlReaderContext& context) const {
     checkReadingCompatibility(context);
 
     if (!stdcxx::isInstanceOf<Load>(extendable)) {

--- a/test/iidm/converter/xml/extensions/TerminalMockXmlSerializer.hpp
+++ b/test/iidm/converter/xml/extensions/TerminalMockXmlSerializer.hpp
@@ -10,6 +10,8 @@
 
 #include <powsybl/iidm/converter/xml/AbstractVersionableExtensionXmlSerializer.hpp>
 
+#include "TerminalMockExt.hpp"
+
 namespace powsybl {
 
 namespace iidm {
@@ -24,7 +26,7 @@ namespace extensions {
 
 class TerminalMockXmlSerializer : public AbstractVersionableExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    std::unique_ptr<Extension> read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
+    TerminalMockExt& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, NetworkXmlWriterContext& context) const override;
 

--- a/test/iidm/converter/xml/extensions/TerminalMockXmlSerializer.hpp
+++ b/test/iidm/converter/xml/extensions/TerminalMockXmlSerializer.hpp
@@ -10,8 +10,6 @@
 
 #include <powsybl/iidm/converter/xml/AbstractVersionableExtensionXmlSerializer.hpp>
 
-#include "TerminalMockExt.hpp"
-
 namespace powsybl {
 
 namespace iidm {
@@ -26,7 +24,7 @@ namespace extensions {
 
 class TerminalMockXmlSerializer : public AbstractVersionableExtensionXmlSerializer {
 public:  // ExtensionXmlSerializer
-    TerminalMockExt& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
+    Extension& read(Extendable& extendable, NetworkXmlReaderContext& context) const override;
 
     void write(const Extension& extension, NetworkXmlWriterContext& context) const override;
 


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
While reading an extension from an XML, the extension is added after it was read (i.e that `ExtensionProvider::read` was called).
For extensions which have an adder, it is added twice by returning a copy (the second call to addExtension does nothing ; extensions are stores by name in the extendable)


**What is the new behavior (if this is a feature change)?**
The addExtension is done once in `read` implementation and the added extension is returned by address.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
