### PR TITLE
Fix ExtensionProvider

### DIFF
--- a/examples/example1/example1.cpp
+++ b/examples/example1/example1.cpp
@@ -9,6 +9,8 @@
 
 #include <iostream>
 
+#include <libxml/parser.h>
+
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/Network.hpp>
 
@@ -23,11 +25,15 @@ int main(int argc, char** argv) {
     }
 
     try {
+        xmlInitParser();
+
         std::ifstream inputStream(argv[1]);
         powsybl::iidm::Network network = powsybl::iidm::Network::readXml(inputStream);
 
         std::ofstream outputStream(argv[2]);
         powsybl::iidm::Network::writeXml(outputStream, network);
+
+        xmlCleanupParser();
 
     } catch (const powsybl::PowsyblException& e) {
         std::cout << e.what() << std::endl;

--- a/include/powsybl/iidm/ExtensionProviders.hpp
+++ b/include/powsybl/iidm/ExtensionProviders.hpp
@@ -11,10 +11,10 @@
 #include <map>
 #include <memory>
 #include <regex>
-#include <set>
 #include <string>
 #include <type_traits>
 
+#include <boost/dll/shared_library.hpp>
 #include <boost/filesystem.hpp>
 
 #include <powsybl/iidm/ExtensionProvider.hpp>
@@ -57,7 +57,7 @@ private:
     void loadLibrary(const boost::filesystem::path& libraryPath);
 
 private:
-    std::set<boost::filesystem::path> m_loadedLibraries;
+    std::map<boost::filesystem::path, boost::dll::shared_library> m_loadedLibraries;
 
     std::map<std::string, std::unique_ptr<T>> m_providers;
 };

--- a/include/powsybl/logging/ConsoleLogger.hpp
+++ b/include/powsybl/logging/ConsoleLogger.hpp
@@ -30,12 +30,17 @@ public: // Logger
     bool isWarnEnabled() const override;
 
 public:
-    ConsoleLogger() = default;
+    ConsoleLogger();
+
+    explicit ConsoleLogger(const Level& level);
 
     ~ConsoleLogger() noexcept override = default;
 
 private: // Logger
     void log(const Level& level, const std::string& message) override;
+
+private:
+    Level m_level;
 };
 
 }  // namespace logging

--- a/src/iidm/ExtensionProviders.cpp
+++ b/src/iidm/ExtensionProviders.cpp
@@ -8,7 +8,6 @@
 #include <powsybl/iidm/ExtensionProviders.hpp>
 
 #include <boost/dll/import.hpp>
-#include <boost/dll/shared_library.hpp>
 #include <boost/range/adaptor/indirected.hpp>
 #include <boost/range/adaptor/map.hpp>
 
@@ -95,7 +94,7 @@ void ExtensionProviders<T, Dummy>::loadLibrary(const boost::filesystem::path& li
                     }
                     logger.debug(stdcxx::format("Extension %1% has been loaded from %2%", extensionName, libraryPath));
                 }
-                m_loadedLibraries.insert(libraryPath);
+                m_loadedLibraries.insert(std::make_pair(libraryPath, library));
             }
         } catch (const boost::system::system_error& err) {
             logger.info(stdcxx::format("Unable to load file %1%: %2%", libraryPath, err.what()));

--- a/src/logging/ConsoleLogger.cpp
+++ b/src/logging/ConsoleLogger.cpp
@@ -15,24 +15,32 @@ namespace powsybl {
 
 namespace logging {
 
+ConsoleLogger::ConsoleLogger() :
+    ConsoleLogger(Level::INFO) {
+}
+
+ConsoleLogger::ConsoleLogger(const Level &level) :
+    m_level(level) {
+}
+
 bool ConsoleLogger::isDebugEnabled() const {
-    return true;
+    return m_level <= Level::DEBUG;
 }
 
 bool ConsoleLogger::isErrorEnabled() const {
-    return true;
+    return m_level <= Level::ERROR;
 }
 
 bool ConsoleLogger::isInfoEnabled() const {
-    return true;
+    return m_level <= Level::INFO;
 }
 
 bool ConsoleLogger::isTraceEnabled() const {
-    return true;
+    return m_level <= Level::TRACE;
 }
 
 bool ConsoleLogger::isWarnEnabled() const {
-    return true;
+    return m_level <= Level::WARN;
 }
 
 void ConsoleLogger::log(const Level& level, const std::string& message) {

--- a/test/logging/ConsoleLoggerTest.cpp
+++ b/test/logging/ConsoleLoggerTest.cpp
@@ -19,11 +19,11 @@ BOOST_AUTO_TEST_SUITE(ConsoleLoggerTestSuite)
 
 BOOST_AUTO_TEST_CASE(level) {
     ConsoleLogger logger;
-    BOOST_TEST(logger.isTraceEnabled());
-    BOOST_TEST(logger.isDebugEnabled());
-    BOOST_TEST(logger.isInfoEnabled());
-    BOOST_TEST(logger.isWarnEnabled());
-    BOOST_TEST(logger.isErrorEnabled());
+    BOOST_CHECK_EQUAL(false, logger.isTraceEnabled());
+    BOOST_CHECK_EQUAL(false, logger.isDebugEnabled());
+    BOOST_CHECK_EQUAL(true, logger.isInfoEnabled());
+    BOOST_CHECK_EQUAL(true, logger.isWarnEnabled());
+    BOOST_CHECK_EQUAL(true, logger.isErrorEnabled());
 }
 
 BOOST_AUTO_TEST_CASE(logMessage) {

--- a/test/logging/LoggerFactoryTest.cpp
+++ b/test/logging/LoggerFactoryTest.cpp
@@ -32,14 +32,14 @@ BOOST_AUTO_TEST_CASE(test) {
 
     LoggerFactory::getInstance().addLogger("console", stdcxx::make_unique<ConsoleLogger>());
     Logger& consoleLogger = LoggerFactory::getLogger("console");
-    BOOST_TEST(stdcxx::areSame(typeid(ConsoleLogger), typeid(consoleLogger)));
+    BOOST_CHECK_EQUAL(typeid(ConsoleLogger), typeid(consoleLogger));
     LoggerFactory::getInstance().removeLogger("console");
     Logger& consoleLogger2 = LoggerFactory::getLogger("console");
     BOOST_CHECK_EQUAL(typeid(NoopLogger), typeid(consoleLogger2));
 
     LoggerFactory::getInstance().addLogger<LoggerFactory>(stdcxx::make_unique<NoopLogger>());
     Logger& noopLogger = LoggerFactory::getLogger<LoggerFactory>();
-    BOOST_TEST(stdcxx::areSame(typeid(NoopLogger), typeid(noopLogger)));
+    BOOST_CHECK_EQUAL(typeid(NoopLogger), typeid(noopLogger));
     BOOST_TEST(!stdcxx::areSame(unknown3, noopLogger));
 
     LoggerFactory::getInstance().addLogger("powsybl", stdcxx::make_unique<NoopLogger>());

--- a/tools/benchmark/Benchmark.cpp
+++ b/tools/benchmark/Benchmark.cpp
@@ -5,27 +5,77 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <regex>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/dll/runtime_symbol_info.hpp>
+#include <boost/dll/shared_library.hpp>
 #include <boost/program_options.hpp>
 
+#include <libxml/parser.h>
+
+#include <powsybl/iidm/ExtensionProviders.hpp>
 #include <powsybl/iidm/Network.hpp>
+#include <powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp>
 #include <powsybl/logging/ConsoleLogger.hpp>
 #include <powsybl/logging/LoggerFactory.hpp>
 #include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/make_unique.hpp>
 
+/**
+ * Helper class to load/unload properly LibXml2
+ */
+class LibXml2 {
+public:
+    LibXml2() {
+        xmlInitParser();
+    }
+
+    ~LibXml2() {
+        xmlCleanupParser();
+    }
+};
+
+void loadExtensions(const std::string& strPaths) {
+    std::regex fileRegex(stdcxx::format(".*\\%1%.*", boost::dll::shared_library::suffix().string()));
+
+    // Load extensions from libraries found in the same directory that this binary
+    powsybl::iidm::ExtensionProviders<powsybl::iidm::converter::xml::ExtensionXmlSerializer>::getInstance().loadExtensions(boost::dll::program_location().parent_path().string(), fileRegex);
+
+    if (!strPaths.empty()) {
+        std::vector<std::string> paths;
+        boost::algorithm::split(paths, strPaths, [](char c) { return c == boost::filesystem::path::separator; });
+        for (const auto& path : paths) {
+            powsybl::iidm::ExtensionProviders<powsybl::iidm::converter::xml::ExtensionXmlSerializer>::getInstance().loadExtensions(path, fileRegex);
+        }
+    }
+}
+
 int main(int argc, char** argv) {
     const char* const INPUT_FILE = "input-file";
     const char* const OUTPUT_FILE = "output-file";
+    const char* const EXT_PATH = "ext-path";
 
     boost::program_options::options_description desc("Options");
     desc.add_options()
         (INPUT_FILE, boost::program_options::value<std::string>()->required())
-        (OUTPUT_FILE, boost::program_options::value<std::string>()->required());
+        (OUTPUT_FILE, boost::program_options::value<std::string>()->required())
+        (EXT_PATH, boost::program_options::value<std::string>()->default_value(""));
 
     try {
+        // Use the RAII to load/unload LibXml2
+        LibXml2 libxml2;
+
         boost::program_options::variables_map vm;
         boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
         boost::program_options::notify(vm);
+
+        // Setup the logger
+        auto logger = stdcxx::make_unique<powsybl::logging::ConsoleLogger>(powsybl::logging::Level::DEBUG);
+        powsybl::logging::LoggerFactory::getInstance().addLogger("powsybl::iidm::converter::xml::NetworkXml", std::move(logger));
+
+        // Load the XIIDM extensions
+        loadExtensions(vm[EXT_PATH].as<std::string>());
 
         const auto& inputFile = vm[INPUT_FILE].as<std::string>();
         std::ifstream inputStream(inputFile);
@@ -40,9 +90,6 @@ int main(int argc, char** argv) {
             std::cerr << stdcxx::format("Unable to open file '%1%' for writing", outputFile) << std::endl;
             return EXIT_FAILURE;
         }
-
-        auto logger = stdcxx::make_unique<powsybl::logging::ConsoleLogger>();
-        powsybl::logging::LoggerFactory::getInstance().addLogger("powsybl::iidm::converter::xml::NetworkXml", std::move(logger));
 
         const powsybl::iidm::Network& network = powsybl::iidm::Network::readXml(inputStream);
         powsybl::iidm::Network::writeXml(outputStream, network);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The iidm-benchmark tool crash when there are extensions in the XIIDM files. The shared_library are unloaded before used, so we have to store them in the ExtensionProviders singleton.

**What is the new behavior (if this is a feature change)?**
There is no crash anymore. We also add a new `ext-path` extension to set the path where the extensions are located.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
