### PR TITLE
Add getNameOrId() and getOptionalName() into Identifiable

### DIFF
--- a/include/powsybl/iidm/Identifiable.hpp
+++ b/include/powsybl/iidm/Identifiable.hpp
@@ -39,11 +39,13 @@ public:
 
     const std::string& getId() const;
 
-    const std::string& getName() const;
+    const std::string& getNameOrId() const;
 
     virtual const Network& getNetwork() const = 0;
 
     virtual Network& getNetwork() = 0;
+
+    boost::optional<std::string> getOptionalName() const;
 
     bool hasProperty() const;
 

--- a/src/iidm/BusBreakerVoltageLevelTopology.cpp
+++ b/src/iidm/BusBreakerVoltageLevelTopology.cpp
@@ -29,7 +29,8 @@ CalculatedBusTopology::CalculatedBusTopology(BusBreakerVoltageLevel& voltageLeve
 
 std::unique_ptr<MergedBus> CalculatedBusTopology::createMergedBus(unsigned long busCount, const MergedBus::BusSet& busSet) const {
     const std::string& mergedBusId = stdcxx::format("%1%_%2%", m_voltageLevel.getId(), busCount);
-    const std::string& mergedBusName = m_voltageLevel.getName().empty() ? "" : stdcxx::format("%1%_%2%", m_voltageLevel.getName(), busCount);
+    const auto& optionalName = m_voltageLevel.getOptionalName();
+    const std::string& mergedBusName = optionalName ? stdcxx::format("%1%_%2%", *optionalName, busCount) : "";
 
     return stdcxx::make_unique<MergedBus>(mergedBusId, mergedBusName, busSet);
 }

--- a/src/iidm/Identifiable.cpp
+++ b/src/iidm/Identifiable.cpp
@@ -44,8 +44,12 @@ std::string Identifiable::getMessageHeader() const {
     return getTypeDescription() + " '" + m_id + "': ";
 }
 
-const std::string& Identifiable::getName() const {
+const std::string& Identifiable::getNameOrId() const {
     return m_name.empty() ? m_id : m_name;
+}
+
+boost::optional<std::string> Identifiable::getOptionalName() const {
+    return m_name.empty() ? boost::optional<std::string>() : boost::optional<std::string>(m_name);
 }
 
 const std::string& Identifiable::getProperty(const std::string& key) const {

--- a/src/iidm/NodeBreakerVoltageLevelBusNamingStrategy.cpp
+++ b/src/iidm/NodeBreakerVoltageLevelBusNamingStrategy.cpp
@@ -27,9 +27,9 @@ std::string BusNamingStrategy::getId(const std::vector<unsigned long>& nodes) {
 }
 
 std::string BusNamingStrategy::getName(const std::vector<unsigned long>& nodes) {
-    if (!m_voltageLevel.getName().empty()) {
+    if (m_voltageLevel.getOptionalName()) {
         const auto& iter = std::min_element(nodes.cbegin(), nodes.cend());
-        return stdcxx::format("%1%_%2%", m_voltageLevel.getName(), *iter);
+        return stdcxx::format("%1%_%2%", *m_voltageLevel.getOptionalName(), *iter);
     }
 
     return "";

--- a/src/iidm/converter/xml/AbstractIdentifiableXml.hxx
+++ b/src/iidm/converter/xml/AbstractIdentifiableXml.hxx
@@ -50,8 +50,9 @@ void AbstractIdentifiableXml<Added, Adder, Parent>::write(const Added& identifia
     context.getWriter().writeStartElement(context.getVersion().getPrefix(), getRootElementName());
 
     context.getWriter().writeAttribute(ID, context.getAnonymizer().anonymizeString(identifiable.getId()));
-    if (identifiable.getId() != identifiable.getName()) {
-        context.getWriter().writeAttribute(NAME, context.getAnonymizer().anonymizeString(identifiable.getName()));
+    const auto& name = identifiable.getOptionalName();
+    if (name) {
+        context.getWriter().writeAttribute(NAME, context.getAnonymizer().anonymizeString(*name));
     }
     writeRootElementAttributes(identifiable, parent, context);
 

--- a/test/iidm/BatteryTest.cpp
+++ b/test/iidm/BatteryTest.cpp
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
     const Battery& battery = network.getBattery("BAT1");
 
     BOOST_CHECK_EQUAL("BAT1", battery.getId());
-    BOOST_CHECK_EQUAL("BAT1_NAME", battery.getName());
+    BOOST_CHECK_EQUAL("BAT1_NAME", *battery.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::BATTERY, battery.getType());
     std::ostringstream oss;
     oss << battery.getType();

--- a/test/iidm/BusBreakerVoltageLevelTest.cpp
+++ b/test/iidm/BusBreakerVoltageLevelTest.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(BusTest) {
     const auto& cBus = bus;
 
     BOOST_CHECK_EQUAL("BUS", bus.getId());
-    BOOST_CHECK_EQUAL("BUS_NAME", bus.getName());
+    BOOST_CHECK_EQUAL("BUS_NAME", *bus.getOptionalName());
     BOOST_TEST(stdcxx::areSame(voltageLevel, bus.getVoltageLevel()));
     BOOST_TEST(stdcxx::areSame(voltageLevel, cBus.getVoltageLevel()));
     BOOST_CHECK_EQUAL(0UL, bus.getConnectedTerminalCount());
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(SwitchTest) {
     swAdder.setBus2("BUS2");
     Switch& aSwitch = swAdder.add();
     BOOST_CHECK_EQUAL("SW", aSwitch.getId());
-    BOOST_CHECK_EQUAL("SW_NAME", aSwitch.getName());
+    BOOST_CHECK_EQUAL("SW_NAME", *aSwitch.getOptionalName());
     BOOST_TEST(stdcxx::areSame(voltageLevel, aSwitch.getVoltageLevel()));
     BOOST_TEST(!aSwitch.isFictitious());
     BOOST_TEST(!aSwitch.isOpen());
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE(CalculatedBusTopologyTest) {
     stdcxx::Reference<Bus> mergedBus2 = vl.getBusView().getMergedBus("BUS2");
     BOOST_TEST(stdcxx::areSame(mergedBus1.get(), mergedBus2.get()));
     BOOST_CHECK_EQUAL("VL_0", mergedBus1.get().getId());
-    BOOST_CHECK_EQUAL("VL_0", mergedBus1.get().getName());
+    BOOST_CHECK(!mergedBus1.get().getOptionalName());
 
     sw.setOpen(true);
     VoltageLevel& vlTest = vl;
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
     busBreakerView.setConnectableBus("BUS1");
     const auto& configuredBus = busBreakerView.getBus().get();
     BOOST_CHECK_EQUAL("BUS1", configuredBus.getId());
-    BOOST_CHECK_EQUAL("BUS1_NAME", configuredBus.getName());
+    BOOST_CHECK_EQUAL("BUS1_NAME", *configuredBus.getOptionalName());
     const auto& cConfiguredBus = cBusBreakerView.getBus().get();
     BOOST_TEST(stdcxx::areSame(configuredBus, cConfiguredBus));
 
@@ -479,7 +479,7 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
     POWSYBL_ASSERT_REF_TRUE(cTerminal.getBusView().getBus());
     const auto& mergedBus = terminal.getBusView().getBus().get();
     BOOST_CHECK_EQUAL("VL_0", mergedBus.getId());
-    BOOST_CHECK_EQUAL("VL_0", mergedBus.getName());
+    BOOST_CHECK(!mergedBus.getOptionalName());
 
     POWSYBL_ASSERT_THROW(terminal.getNodeBreakerView(), AssertionError, "Not implemented");
     POWSYBL_ASSERT_THROW(cTerminal.getNodeBreakerView(), AssertionError, "Not implemented");

--- a/test/iidm/DanglingLineTest.cpp
+++ b/test/iidm/DanglingLineTest.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     const DanglingLine& danglingLine = network.getDanglingLine("DL1");
     BOOST_CHECK_EQUAL("DL1", danglingLine.getId());
-    BOOST_CHECK_EQUAL("DL1_NAME", danglingLine.getName());
+    BOOST_CHECK_EQUAL("DL1_NAME", *danglingLine.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::DANGLING_LINE, danglingLine.getType());
     std::ostringstream oss;
     oss << danglingLine.getType();
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant("s1");
     BOOST_CHECK_EQUAL("DL1", danglingLine.getId());
-    BOOST_CHECK_EQUAL("DL1_NAME", danglingLine.getName());
+    BOOST_CHECK_EQUAL("DL1_NAME", *danglingLine.getOptionalName());
     BOOST_CHECK_CLOSE(1.0, danglingLine.getB(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(2.0, danglingLine.getG(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(3.0, danglingLine.getP0(), std::numeric_limits<double>::epsilon());
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     danglingLine.setB(100.0).setG(200.0).setP0(300.0).setQ0(400).setR(500.0).setX(600.0);
 
     BOOST_CHECK_EQUAL("DL1", danglingLine.getId());
-    BOOST_CHECK_EQUAL("DL1_NAME", danglingLine.getName());
+    BOOST_CHECK_EQUAL("DL1_NAME", *danglingLine.getOptionalName());
     BOOST_CHECK_CLOSE(100.0, danglingLine.getB(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(200.0, danglingLine.getG(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(300.0, danglingLine.getP0(), std::numeric_limits<double>::epsilon());
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant("s2");
     BOOST_CHECK_EQUAL("DL1", danglingLine.getId());
-    BOOST_CHECK_EQUAL("DL1_NAME", danglingLine.getName());
+    BOOST_CHECK_EQUAL("DL1_NAME", *danglingLine.getOptionalName());
     BOOST_CHECK_CLOSE(100.0, danglingLine.getB(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(200.0, danglingLine.getG(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(3.0, danglingLine.getP0(), std::numeric_limits<double>::epsilon());
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     danglingLine.setB(150.0).setG(250.0).setP0(350.0).setQ0(450).setR(550.0).setX(650.0);
 
     BOOST_CHECK_EQUAL("DL1", danglingLine.getId());
-    BOOST_CHECK_EQUAL("DL1_NAME", danglingLine.getName());
+    BOOST_CHECK_EQUAL("DL1_NAME", *danglingLine.getOptionalName());
     BOOST_CHECK_CLOSE(150.0, danglingLine.getB(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(250.0, danglingLine.getG(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(350.0, danglingLine.getP0(), std::numeric_limits<double>::epsilon());
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant(VariantManager::getInitialVariantId());
     BOOST_CHECK_EQUAL("DL1", danglingLine.getId());
-    BOOST_CHECK_EQUAL("DL1_NAME", danglingLine.getName());
+    BOOST_CHECK_EQUAL("DL1_NAME", *danglingLine.getOptionalName());
     BOOST_CHECK_CLOSE(150.0, danglingLine.getB(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(250.0, danglingLine.getG(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(3.0, danglingLine.getP0(), std::numeric_limits<double>::epsilon());
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     network.getVariantManager().cloneVariant("s2", "s3");
     network.getVariantManager().setWorkingVariant("s3");
     BOOST_CHECK_EQUAL("DL1", danglingLine.getId());
-    BOOST_CHECK_EQUAL("DL1_NAME", danglingLine.getName());
+    BOOST_CHECK_EQUAL("DL1_NAME", *danglingLine.getOptionalName());
     BOOST_CHECK_CLOSE(150.0, danglingLine.getB(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(250.0, danglingLine.getG(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(350.0, danglingLine.getP0(), std::numeric_limits<double>::epsilon());

--- a/test/iidm/GeneratorTest.cpp
+++ b/test/iidm/GeneratorTest.cpp
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(integrity) {
 
     Generator& gen = network.getGenerator("GEN1");
     BOOST_CHECK_EQUAL("GEN1", gen.getId());
-    BOOST_CHECK_EQUAL("GEN1_NAME", gen.getName());
+    BOOST_CHECK_EQUAL("GEN1_NAME", *gen.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::GENERATOR, gen.getType());
     std::ostringstream oss;
     oss << gen.getType();
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant("s1");
     BOOST_CHECK_EQUAL("GEN1", gen.getId());
-    BOOST_CHECK_EQUAL("GEN1_NAME", gen.getName());
+    BOOST_CHECK_EQUAL("GEN1_NAME", *gen.getOptionalName());
     BOOST_CHECK_CLOSE(45, gen.getActivePowerSetpoint(), std::numeric_limits<double>::epsilon());
     POWSYBL_ASSERT_ENUM_EQ(EnergySource::WIND, gen.getEnergySource());
     BOOST_CHECK_CLOSE(50.0, gen.getMaxP(), std::numeric_limits<double>::epsilon());

--- a/test/iidm/HvdcLineTest.cpp
+++ b/test/iidm/HvdcLineTest.cpp
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     const HvdcLine& hvdc = network.getHvdcLine("HVDC1");
     BOOST_CHECK_EQUAL("HVDC1", hvdc.getId());
-    BOOST_CHECK_EQUAL("HVDC1_NAME", hvdc.getName());
+    BOOST_CHECK_EQUAL("HVDC1_NAME", *hvdc.getOptionalName());
     BOOST_CHECK_CLOSE(11.0, hvdc.getActivePowerSetpoint(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(HvdcLine::ConvertersMode::SIDE_1_RECTIFIER_SIDE_2_INVERTER, hvdc.getConvertersMode());
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant("s1");
     BOOST_CHECK_EQUAL("HVDC1", hvdc.getId());
-    BOOST_CHECK_EQUAL("HVDC1_NAME", hvdc.getName());
+    BOOST_CHECK_EQUAL("HVDC1_NAME", *hvdc.getOptionalName());
     BOOST_CHECK_CLOSE(11.0, hvdc.getActivePowerSetpoint(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(HvdcLine::ConvertersMode::SIDE_1_RECTIFIER_SIDE_2_INVERTER, hvdc.getConvertersMode());
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     hvdc.setActivePowerSetpoint(100.0).setR(200.0).setMaxP(300.0).setConvertersMode(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER).setNominalVoltage(400.0);
 
     BOOST_CHECK_EQUAL("HVDC1", hvdc.getId());
-    BOOST_CHECK_EQUAL("HVDC1_NAME", hvdc.getName());
+    BOOST_CHECK_EQUAL("HVDC1_NAME", *hvdc.getOptionalName());
     BOOST_CHECK_CLOSE(100.0, hvdc.getActivePowerSetpoint(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER, hvdc.getConvertersMode());
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant("s2");
     BOOST_CHECK_EQUAL("HVDC1", hvdc.getId());
-    BOOST_CHECK_EQUAL("HVDC1_NAME", hvdc.getName());
+    BOOST_CHECK_EQUAL("HVDC1_NAME", *hvdc.getOptionalName());
     BOOST_CHECK_CLOSE(11.0, hvdc.getActivePowerSetpoint(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(HvdcLine::ConvertersMode::SIDE_1_RECTIFIER_SIDE_2_INVERTER, hvdc.getConvertersMode());
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     hvdc.setActivePowerSetpoint(150.0).setR(250.0).setMaxP(350.0).setConvertersMode(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER).setNominalVoltage(450.0);
 
     BOOST_CHECK_EQUAL("HVDC1", hvdc.getId());
-    BOOST_CHECK_EQUAL("HVDC1_NAME", hvdc.getName());
+    BOOST_CHECK_EQUAL("HVDC1_NAME", *hvdc.getOptionalName());
     BOOST_CHECK_CLOSE(150.0, hvdc.getActivePowerSetpoint(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER, hvdc.getConvertersMode());
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
@@ -290,7 +290,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant(VariantManager::getInitialVariantId());
     BOOST_CHECK_EQUAL("HVDC1", hvdc.getId());
-    BOOST_CHECK_EQUAL("HVDC1_NAME", hvdc.getName());
+    BOOST_CHECK_EQUAL("HVDC1_NAME", *hvdc.getOptionalName());
     BOOST_CHECK_CLOSE(11.0, hvdc.getActivePowerSetpoint(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(HvdcLine::ConvertersMode::SIDE_1_RECTIFIER_SIDE_2_INVERTER, hvdc.getConvertersMode());
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     network.getVariantManager().cloneVariant("s2", "s3");
     network.getVariantManager().setWorkingVariant("s3");
     BOOST_CHECK_EQUAL("HVDC1", hvdc.getId());
-    BOOST_CHECK_EQUAL("HVDC1_NAME", hvdc.getName());
+    BOOST_CHECK_EQUAL("HVDC1_NAME", *hvdc.getOptionalName());
     BOOST_CHECK_CLOSE(150.0, hvdc.getActivePowerSetpoint(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER, hvdc.getConvertersMode());
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());

--- a/test/iidm/LccConverterStationTest.cpp
+++ b/test/iidm/LccConverterStationTest.cpp
@@ -57,8 +57,8 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_TEST(stdcxx::areSame(lcc, hvdc));
     BOOST_CHECK_EQUAL("LCC1", lcc.getId());
     BOOST_CHECK_EQUAL(lcc.getId(), hvdc.getId());
-    BOOST_CHECK_EQUAL("LCC1_NAME", lcc.getName());
-    BOOST_CHECK_EQUAL(lcc.getName(), hvdc.getName());
+    BOOST_CHECK_EQUAL("LCC1_NAME", *lcc.getOptionalName());
+    BOOST_CHECK_EQUAL(*lcc.getOptionalName(), *hvdc.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::HVDC_CONVERTER_STATION, lcc.getType());
     std::ostringstream oss;
     oss << lcc.getType();

--- a/test/iidm/LineTest.cpp
+++ b/test/iidm/LineTest.cpp
@@ -120,7 +120,8 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     const Line& line = network.getLine("VL1_VL3");
     BOOST_CHECK_EQUAL("VL1_VL3", line.getId());
-    BOOST_CHECK_EQUAL("VL1_VL3", line.getName());
+    BOOST_CHECK(!line.getOptionalName());
+    BOOST_CHECK_EQUAL("VL1_VL3", line.getNameOrId());
     BOOST_CHECK_EQUAL(ConnectableType::LINE, line.getType());
     std::ostringstream oss;
     oss << line.getType();

--- a/test/iidm/LoadTest.cpp
+++ b/test/iidm/LoadTest.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     Load& load = network.getLoad("LOAD1");
     BOOST_CHECK_EQUAL("LOAD1", load.getId());
-    BOOST_CHECK_EQUAL("LOAD1_NAME", load.getName());
+    BOOST_CHECK_EQUAL("LOAD1_NAME", *load.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::LOAD, load.getType());
     std::ostringstream oss;
     oss << load.getType();

--- a/test/iidm/NetworkTest.cpp
+++ b/test/iidm/NetworkTest.cpp
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     Network network("id", "sourceFormat");
     BOOST_CHECK_EQUAL("id", network.getId());
-    BOOST_CHECK_EQUAL("id", network.getName());
+    BOOST_CHECK_EQUAL("id", *network.getOptionalName());
     BOOST_CHECK_EQUAL("sourceFormat", network.getSourceFormat());
     BOOST_CHECK_EQUAL(0, network.getForecastDistance());
 

--- a/test/iidm/NodeBreakerVoltageLevelTest.cpp
+++ b/test/iidm/NodeBreakerVoltageLevelTest.cpp
@@ -197,7 +197,8 @@ BOOST_AUTO_TEST_CASE(busbarSection) {
         .add();
 
     BOOST_CHECK_EQUAL("BBS", bbs.getId());
-    BOOST_CHECK_EQUAL("BBS_NAME", bbs.getName());
+    BOOST_CHECK( bbs.getOptionalName());
+    BOOST_CHECK_EQUAL("BBS_NAME", *bbs.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::BUSBAR_SECTION, bbs.getType());
     std::ostringstream oss;
     oss << bbs.getType();
@@ -254,7 +255,8 @@ BOOST_AUTO_TEST_CASE(switches) {
         .add();
 
     BOOST_CHECK_EQUAL("BK", breaker.getId());
-    BOOST_CHECK_EQUAL("BK_NAME", breaker.getName());
+    BOOST_CHECK(breaker.getOptionalName());
+    BOOST_CHECK_EQUAL("BK_NAME",* breaker.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(SwitchKind::BREAKER, breaker.getKind());
     BOOST_TEST(!breaker.isOpen());
     BOOST_TEST(breaker.isRetained());
@@ -542,7 +544,8 @@ BOOST_AUTO_TEST_CASE(calculatedBusBreakerTopology) {
     auto& testBus = busBreakerView.getBus("VL_0").get();
     const auto& cTestBus = testBus;
     BOOST_CHECK_EQUAL("VL_0", testBus.getId());
-    BOOST_CHECK_EQUAL("VL_0", testBus.getName());
+    BOOST_CHECK(!testBus.getOptionalName());
+    BOOST_CHECK_EQUAL("VL_0", testBus.getNameOrId());
     BOOST_CHECK_CLOSE(7.7, testBus.setAngle(7.7).setV(8.8).getAngle(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(8.8, testBus.getV(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(2UL, testBus.getConnectedTerminalCount());
@@ -700,7 +703,7 @@ BOOST_AUTO_TEST_CASE(CalculatedBusTopology) {
     POWSYBL_ASSERT_REF_TRUE(cBusView.getMergedBus("BBS"));
     const auto& calculatedBus = busView.getBus("VL_0").get();
     BOOST_CHECK_EQUAL("VL_0", calculatedBus.getId());
-    BOOST_CHECK_EQUAL("VL_0", calculatedBus.getName());
+    BOOST_CHECK(!calculatedBus.getOptionalName());
 
     sw.setOpen(true);
     BOOST_CHECK_EQUAL(2UL, boost::size(busView.getBuses()));
@@ -1009,7 +1012,9 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
     BOOST_TEST(stdcxx::areSame(cBusBreakerView.getBus().get(), cBusBreakerView.getConnectableBus().get()));
     const auto& calculatedBus = busBreakerView.getBus().get();
     BOOST_CHECK_EQUAL("VL_0", calculatedBus.getId());
-    BOOST_CHECK_EQUAL("VL_name_0", calculatedBus.getName());
+    BOOST_CHECK(calculatedBus.getOptionalName());
+    BOOST_CHECK_EQUAL("VL_name_0", *calculatedBus.getOptionalName());
+    BOOST_CHECK_EQUAL("VL_name_0", calculatedBus.getNameOrId());
 
 
     POWSYBL_ASSERT_THROW(busBreakerView.setConnectableBus("BUS1"), AssertionError, "Not implemented");
@@ -1021,7 +1026,9 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
     BOOST_TEST(stdcxx::areSame(cBusView.getBus().get(), cBusView.getConnectableBus().get()));
     const auto& calculatedBus2 = busView.getBus().get();
     BOOST_CHECK_EQUAL("VL_0", calculatedBus2.getId());
-    BOOST_CHECK_EQUAL("VL_name_0", calculatedBus2.getName());
+    BOOST_CHECK(calculatedBus2.getOptionalName());
+    BOOST_CHECK_EQUAL("VL_name_0", *calculatedBus2.getOptionalName());
+    BOOST_CHECK_EQUAL("VL_name_0", calculatedBus.getNameOrId());
 
     BOOST_TEST(stdcxx::areSame(terminal.getNodeBreakerView(), cTerminal.getNodeBreakerView()));
     BOOST_CHECK_EQUAL(2UL, terminal.getNodeBreakerView().getNode());

--- a/test/iidm/ShuntCompensatorTest.cpp
+++ b/test/iidm/ShuntCompensatorTest.cpp
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     ShuntCompensator& shunt = network.getShuntCompensator("SHUNT1");
     BOOST_CHECK_EQUAL("SHUNT1", shunt.getId());
-    BOOST_CHECK_EQUAL("SHUNT1_NAME", shunt.getName());
+    BOOST_CHECK_EQUAL("SHUNT1_NAME", *shunt.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::SHUNT_COMPENSATOR, shunt.getType());
     std::ostringstream oss;
     oss << shunt.getType();
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant("s1");
     BOOST_CHECK_EQUAL("SHUNT1", shunt.getId());
-    BOOST_CHECK_EQUAL("SHUNT1_NAME", shunt.getName());
+    BOOST_CHECK_EQUAL("SHUNT1_NAME", *shunt.getOptionalName());
     BOOST_CHECK_CLOSE(12.0, shunt.getbPerSection(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(2UL, shunt.getCurrentSectionCount());
     BOOST_CHECK_EQUAL(3UL, shunt.getMaximumSectionCount());
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     shunt.setbPerSection(100.0).setMaximumSectionCount(300UL).setCurrentSectionCount(200UL);
 
     BOOST_CHECK_EQUAL("SHUNT1", shunt.getId());
-    BOOST_CHECK_EQUAL("SHUNT1_NAME", shunt.getName());
+    BOOST_CHECK_EQUAL("SHUNT1_NAME", *shunt.getOptionalName());
     BOOST_CHECK_CLOSE(100.0, shunt.getbPerSection(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(200UL, shunt.getCurrentSectionCount());
     BOOST_CHECK_EQUAL(300UL, shunt.getMaximumSectionCount());
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant("s2");
     BOOST_CHECK_EQUAL("SHUNT1", shunt.getId());
-    BOOST_CHECK_EQUAL("SHUNT1_NAME", shunt.getName());
+    BOOST_CHECK_EQUAL("SHUNT1_NAME", *shunt.getOptionalName());
     BOOST_CHECK_CLOSE(100.0, shunt.getbPerSection(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(2UL, shunt.getCurrentSectionCount());
     BOOST_CHECK_EQUAL(300UL, shunt.getMaximumSectionCount());
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     shunt.setbPerSection(150.0).setMaximumSectionCount(350UL).setCurrentSectionCount(250UL);
 
     BOOST_CHECK_EQUAL("SHUNT1", shunt.getId());
-    BOOST_CHECK_EQUAL("SHUNT1_NAME", shunt.getName());
+    BOOST_CHECK_EQUAL("SHUNT1_NAME", *shunt.getOptionalName());
     BOOST_CHECK_CLOSE(150.0, shunt.getbPerSection(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(250UL, shunt.getCurrentSectionCount());
     BOOST_CHECK_EQUAL(350UL, shunt.getMaximumSectionCount());
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant(VariantManager::getInitialVariantId());
     BOOST_CHECK_EQUAL("SHUNT1", shunt.getId());
-    BOOST_CHECK_EQUAL("SHUNT1_NAME", shunt.getName());
+    BOOST_CHECK_EQUAL("SHUNT1_NAME", *shunt.getOptionalName());
     BOOST_CHECK_CLOSE(150.0, shunt.getbPerSection(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(2UL, shunt.getCurrentSectionCount());
     BOOST_CHECK_EQUAL(350UL, shunt.getMaximumSectionCount());
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     network.getVariantManager().cloneVariant("s2", "s3");
     network.getVariantManager().setWorkingVariant("s3");
     BOOST_CHECK_EQUAL("SHUNT1", shunt.getId());
-    BOOST_CHECK_EQUAL("SHUNT1_NAME", shunt.getName());
+    BOOST_CHECK_EQUAL("SHUNT1_NAME", *shunt.getOptionalName());
     BOOST_CHECK_CLOSE(150.0, shunt.getbPerSection(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(250UL, shunt.getCurrentSectionCount());
     BOOST_CHECK_EQUAL(350UL, shunt.getMaximumSectionCount());

--- a/test/iidm/StaticVarCompensatorTest.cpp
+++ b/test/iidm/StaticVarCompensatorTest.cpp
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     const StaticVarCompensator& svc = network.getStaticVarCompensator("SVC1");
     BOOST_CHECK_EQUAL("SVC1", svc.getId());
-    BOOST_CHECK_EQUAL("SVC1_NAME", svc.getName());
+    BOOST_CHECK_EQUAL("SVC1_NAME", *svc.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::STATIC_VAR_COMPENSATOR, svc.getType());
     std::ostringstream oss;
     oss << svc.getType();

--- a/test/iidm/SubstationTest.cpp
+++ b/test/iidm/SubstationTest.cpp
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     const Substation& substation = network.getSubstation("S1");
     BOOST_CHECK_EQUAL("S1", substation.getId());
-    BOOST_CHECK_EQUAL("S1_NAME", substation.getName());
+    BOOST_CHECK_EQUAL("S1_NAME", *substation.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(Country::FR, *substation.getCountry());
     BOOST_CHECK_EQUAL("TSO", substation.getTso());
 }

--- a/test/iidm/ThreeWindingsTransformerTest.cpp
+++ b/test/iidm/ThreeWindingsTransformerTest.cpp
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_TEST(stdcxx::areSame(cTransformer, transformer));
 
     BOOST_CHECK_EQUAL("3WT_VL1_VL2_VL3", transformer.getId());
-    BOOST_CHECK_EQUAL("3WT_VL1_VL2_VL3_NAME", transformer.getName());
+    BOOST_CHECK_EQUAL("3WT_VL1_VL2_VL3_NAME", *transformer.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::THREE_WINDINGS_TRANSFORMER, transformer.getType());
     std::ostringstream oss;
     oss << transformer.getType();

--- a/test/iidm/TieLineTest.cpp
+++ b/test/iidm/TieLineTest.cpp
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     const TieLine& tieLine = dynamic_cast<const TieLine&>(network.getLine("TL_VL1_VL3"));
     BOOST_CHECK_EQUAL("TL_VL1_VL3", tieLine.getId());
-    BOOST_CHECK_EQUAL("TL_VL1_VL3", tieLine.getName());
+    BOOST_CHECK(!tieLine.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::LINE, tieLine.getType());
     std::ostringstream oss;
     oss << tieLine.getType();

--- a/test/iidm/TwoWindingsTransformerTest.cpp
+++ b/test/iidm/TwoWindingsTransformerTest.cpp
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     TwoWindingsTransformer& transformer = network.getTwoWindingsTransformer("2WT_VL1_VL2");
     BOOST_CHECK_EQUAL("2WT_VL1_VL2", transformer.getId());
-    BOOST_CHECK_EQUAL("2WT_VL1_VL2", transformer.getName());
+    BOOST_CHECK(!transformer.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::TWO_WINDINGS_TRANSFORMER, transformer.getType());
     std::ostringstream oss;
     oss << transformer.getType();

--- a/test/iidm/VoltageLevelTest.cpp
+++ b/test/iidm/VoltageLevelTest.cpp
@@ -34,7 +34,8 @@ BOOST_AUTO_TEST_CASE(constructor) {
 
     VoltageLevel& vl1 = network.getVoltageLevel("VL1");
     BOOST_CHECK_EQUAL("VL1", vl1.getId());
-    BOOST_CHECK_EQUAL("VL1_NAME", vl1.getName());
+    BOOST_CHECK(vl1.getOptionalName());
+    BOOST_CHECK_EQUAL("VL1_NAME", *vl1.getOptionalName());
     BOOST_CHECK_EQUAL(TopologyKind::BUS_BREAKER, vl1.getTopologyKind());
     BOOST_CHECK_CLOSE(340, vl1.getLowVoltageLimit(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(420, vl1.getHighVoltageLimit(), std::numeric_limits<double>::epsilon());

--- a/test/iidm/VscConverterStationTest.cpp
+++ b/test/iidm/VscConverterStationTest.cpp
@@ -70,8 +70,8 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_TEST(stdcxx::areSame(vsc, hvdc));
     BOOST_CHECK_EQUAL("VSC1", vsc.getId());
     BOOST_CHECK_EQUAL(vsc.getId(), hvdc.getId());
-    BOOST_CHECK_EQUAL("VSC1_NAME", vsc.getName());
-    BOOST_CHECK_EQUAL(vsc.getName(), hvdc.getName());
+    BOOST_CHECK_EQUAL("VSC1_NAME", *vsc.getOptionalName());
+    BOOST_CHECK_EQUAL(*vsc.getOptionalName(), *hvdc.getOptionalName());
     BOOST_CHECK_EQUAL(ConnectableType::HVDC_CONVERTER_STATION, vsc.getType());
     std::ostringstream oss;
     oss << vsc.getType();
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant("s1");
     BOOST_CHECK_EQUAL("VSC1", vsc.getId());
-    BOOST_CHECK_EQUAL("VSC1_NAME", vsc.getName());
+    BOOST_CHECK_EQUAL("VSC1_NAME", *vsc.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(HvdcConverterStation::HvdcType::VSC, vsc.getHvdcType());
     BOOST_CHECK_CLOSE(3.0, vsc.getLossFactor(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(4.0, vsc.getVoltageSetpoint(), std::numeric_limits<double>::epsilon());
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     vsc.setLossFactor(100.0).setVoltageSetpoint(200.0).setReactivePowerSetpoint(300.0).setVoltageRegulatorOn(false);
 
     BOOST_CHECK_EQUAL("VSC1", vsc.getId());
-    BOOST_CHECK_EQUAL("VSC1_NAME", vsc.getName());
+    BOOST_CHECK_EQUAL("VSC1_NAME", *vsc.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(HvdcConverterStation::HvdcType::VSC, vsc.getHvdcType());
     BOOST_CHECK_CLOSE(100.0, vsc.getLossFactor(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(200.0, vsc.getVoltageSetpoint(), std::numeric_limits<double>::epsilon());
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant("s2");
     BOOST_CHECK_EQUAL("VSC1", vsc.getId());
-    BOOST_CHECK_EQUAL("VSC1_NAME", vsc.getName());
+    BOOST_CHECK_EQUAL("VSC1_NAME", *vsc.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(HvdcConverterStation::HvdcType::VSC, vsc.getHvdcType());
     BOOST_CHECK_CLOSE(100.0, vsc.getLossFactor(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(4.0, vsc.getVoltageSetpoint(), std::numeric_limits<double>::epsilon());
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     vsc.setLossFactor(150.0).setVoltageSetpoint(250.0).setReactivePowerSetpoint(350.0).setVoltageRegulatorOn(false);
 
     BOOST_CHECK_EQUAL("VSC1", vsc.getId());
-    BOOST_CHECK_EQUAL("VSC1_NAME", vsc.getName());
+    BOOST_CHECK_EQUAL("VSC1_NAME", *vsc.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(HvdcConverterStation::HvdcType::VSC, vsc.getHvdcType());
     BOOST_CHECK_CLOSE(150.0, vsc.getLossFactor(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(250.0, vsc.getVoltageSetpoint(), std::numeric_limits<double>::epsilon());
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
 
     network.getVariantManager().setWorkingVariant(VariantManager::getInitialVariantId());
     BOOST_CHECK_EQUAL("VSC1", vsc.getId());
-    BOOST_CHECK_EQUAL("VSC1_NAME", vsc.getName());
+    BOOST_CHECK_EQUAL("VSC1_NAME", *vsc.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(HvdcConverterStation::HvdcType::VSC, vsc.getHvdcType());
     BOOST_CHECK_CLOSE(150.0, vsc.getLossFactor(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(4.0, vsc.getVoltageSetpoint(), std::numeric_limits<double>::epsilon());
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     network.getVariantManager().cloneVariant("s2", "s3");
     network.getVariantManager().setWorkingVariant("s3");
     BOOST_CHECK_EQUAL("VSC1", vsc.getId());
-    BOOST_CHECK_EQUAL("VSC1_NAME", vsc.getName());
+    BOOST_CHECK_EQUAL("VSC1_NAME", *vsc.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(HvdcConverterStation::HvdcType::VSC, vsc.getHvdcType());
     BOOST_CHECK_CLOSE(150.0, vsc.getLossFactor(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(250.0, vsc.getVoltageSetpoint(), std::numeric_limits<double>::epsilon());

--- a/test/network/EurostagFactoryTest.cpp
+++ b/test/network/EurostagFactoryTest.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_SUITE(EurostagFactoryTestSuite)
 BOOST_AUTO_TEST_CASE(createTutorial1NetworkTest) {
     const iidm::Network& network = EurostagFactory::createTutorial1Network();
     BOOST_CHECK_EQUAL("sim1", network.getId());
-    BOOST_CHECK_EQUAL("sim1", network.getName());
+    BOOST_CHECK_EQUAL("sim1", *network.getOptionalName());
     BOOST_CHECK_EQUAL("test", network.getSourceFormat());
     BOOST_CHECK_EQUAL(0, network.getForecastDistance());
 
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(createTutorial1NetworkTest) {
     BOOST_TEST(std::isnan(nload.getV()));
 
     const auto& line1 = network.getLine("NHV1_NHV2_1");
-    BOOST_CHECK_EQUAL("NHV1_NHV2_1", line1.getName());
+    BOOST_CHECK(!line1.getOptionalName());
     BOOST_TEST(!line1.isTieLine());
     BOOST_CHECK_CLOSE(3.0, line1.getR(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(33.0, line1.getX(), std::numeric_limits<double>::epsilon());
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(createTutorial1NetworkTest) {
     BOOST_TEST(!line1.isOverloaded());
 
     const auto& line2 = network.getLine("NHV1_NHV2_2");
-    BOOST_CHECK_EQUAL("NHV1_NHV2_2", line2.getName());
+    BOOST_CHECK(!line2.getOptionalName());
     BOOST_TEST(!line2.isTieLine());
     BOOST_CHECK_CLOSE(3.0, line2.getR(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(33.0, line2.getX(), std::numeric_limits<double>::epsilon());
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(createTutorial1NetworkTest) {
     BOOST_TEST(!line2.isOverloaded());
 
     const auto& transfo1 = network.getTwoWindingsTransformer("NGEN_NHV1");
-    BOOST_CHECK_EQUAL("NGEN_NHV1", transfo1.getName());
+    BOOST_CHECK(!transfo1.getOptionalName());
     BOOST_CHECK_CLOSE(24.0, transfo1.getRatedU1(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(400.0, transfo1.getRatedU2(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(0.24 / 1300.0 * (380.0 * 380.0 / 100.0), transfo1.getR(), std::numeric_limits<double>::epsilon());
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(createTutorial1NetworkTest) {
     BOOST_TEST(!transfo1.isOverloaded());
 
     const auto& transfo2 = network.getTwoWindingsTransformer("NHV2_NLOAD");
-    BOOST_CHECK_EQUAL("NHV2_NLOAD", transfo2.getName());
+    BOOST_CHECK(!transfo2.getOptionalName());
     BOOST_CHECK_CLOSE(400.0, transfo2.getRatedU1(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(158.0, transfo2.getRatedU2(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(0.21 / 1000 * (150.0 * 150.0 / 100.0), transfo2.getR(), std::numeric_limits<double>::epsilon());
@@ -217,13 +217,13 @@ BOOST_AUTO_TEST_CASE(createTutorial1NetworkTest) {
     BOOST_CHECK_CLOSE(0.0, step.getB(), std::numeric_limits<double>::epsilon());
 
     const auto& load = network.getLoad("LOAD");
-    BOOST_CHECK_EQUAL("LOAD", load.getName());
+    BOOST_CHECK(!load.getOptionalName());
     BOOST_CHECK_EQUAL(iidm::LoadType::UNDEFINED, load.getLoadType());
     BOOST_CHECK_CLOSE(600.0, load.getP0(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(200.0, load.getQ0(), std::numeric_limits<double>::epsilon());
 
     const auto& gen = network.getGenerator("GEN");
-    BOOST_CHECK_EQUAL("GEN", gen.getName());
+    BOOST_CHECK(!gen.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(iidm::EnergySource::OTHER, gen.getEnergySource());
     BOOST_TEST(std::isnan(gen.getRatedS()));
     BOOST_CHECK_CLOSE(-9999.99, gen.getMinP(), std::numeric_limits<double>::epsilon());
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE(createWithCurrentLimitsTest) {
     const iidm::Network& network = EurostagFactory::createWithCurrentLimits();
 
     BOOST_CHECK_EQUAL("sim1", network.getId());
-    BOOST_CHECK_EQUAL("sim1", network.getName());
+    BOOST_CHECK_EQUAL("sim1", *network.getOptionalName());
     BOOST_CHECK_EQUAL("test", network.getSourceFormat());
     BOOST_CHECK_EQUAL(0, network.getForecastDistance());
     BOOST_CHECK_EQUAL("2018-01-01T11:00:00+01:00", network.getCaseDate().toString());
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(createWithCurrentLimitsTest) {
     BOOST_TEST(std::isnan(nload.getV()));
 
     const auto& line1 = network.getLine("NHV1_NHV2_1");
-    BOOST_CHECK_EQUAL("NHV1_NHV2_1", line1.getName());
+    BOOST_CHECK(!line1.getOptionalName());
     BOOST_TEST(!line1.isTieLine());
     BOOST_CHECK_CLOSE(3.0, line1.getR(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(33.0, line1.getX(), std::numeric_limits<double>::epsilon());
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(createWithCurrentLimitsTest) {
     BOOST_TEST(!tempLimit.isFictitious());
 
     const auto& line2 = network.getLine("NHV1_NHV2_2");
-    BOOST_CHECK_EQUAL("NHV1_NHV2_2", line2.getName());
+    BOOST_CHECK(!line2.getOptionalName());
     BOOST_TEST(!line2.isTieLine());
     BOOST_CHECK_CLOSE(3.0, line2.getR(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(33.0, line2.getX(), std::numeric_limits<double>::epsilon());
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(createWithCurrentLimitsTest) {
     BOOST_CHECK_EQUAL(0, line2CurLimit2.getTemporaryLimits().size());
 
     const auto& transfo1 = network.getTwoWindingsTransformer("NGEN_NHV1");
-    BOOST_CHECK_EQUAL("NGEN_NHV1", transfo1.getName());
+    BOOST_CHECK(!transfo1.getOptionalName());
     BOOST_CHECK_CLOSE(24.0, transfo1.getRatedU1(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(400.0, transfo1.getRatedU2(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(0.24 / 1300.0 * (380.0 * 380.0 / 100.0), transfo1.getR(), std::numeric_limits<double>::epsilon());
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(createWithCurrentLimitsTest) {
     BOOST_TEST(!transfo1.isOverloaded());
 
     const auto& transfo2 = network.getTwoWindingsTransformer("NHV2_NLOAD");
-    BOOST_CHECK_EQUAL("NHV2_NLOAD", transfo2.getName());
+    BOOST_CHECK(!transfo2.getOptionalName());
     BOOST_CHECK_CLOSE(400.0, transfo2.getRatedU1(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(158.0, transfo2.getRatedU2(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(0.21 / 1000 * (150.0 * 150.0 / 100.0), transfo2.getR(), std::numeric_limits<double>::epsilon());
@@ -462,13 +462,13 @@ BOOST_AUTO_TEST_CASE(createWithCurrentLimitsTest) {
     BOOST_CHECK_CLOSE(0.0, step.getB(), std::numeric_limits<double>::epsilon());
 
     const auto& load = network.getLoad("LOAD");
-    BOOST_CHECK_EQUAL("LOAD", load.getName());
+    BOOST_CHECK(!load.getOptionalName());
     BOOST_CHECK_EQUAL(iidm::LoadType::UNDEFINED, load.getLoadType());
     BOOST_CHECK_CLOSE(600.0, load.getP0(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(200.0, load.getQ0(), std::numeric_limits<double>::epsilon());
 
     const auto& gen = network.getGenerator("GEN");
-    BOOST_CHECK_EQUAL("GEN", gen.getName());
+    BOOST_CHECK(!gen.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(iidm::EnergySource::OTHER, gen.getEnergySource());
     BOOST_TEST(std::isnan(gen.getRatedS()));
     BOOST_CHECK_CLOSE(-9999.99, gen.getMinP(), std::numeric_limits<double>::epsilon());
@@ -489,7 +489,7 @@ BOOST_AUTO_TEST_CASE(createWithCurrentLimitsTest) {
     BOOST_CHECK_CLOSE(9999.99, limits.getMaxQ(0), std::numeric_limits<double>::epsilon());
 
     const auto& gen2 = network.getGenerator("GEN2");
-    BOOST_CHECK_EQUAL("GEN2", gen2.getName());
+    BOOST_CHECK(!gen2.getOptionalName());
     POWSYBL_ASSERT_ENUM_EQ(iidm::EnergySource::OTHER, gen2.getEnergySource());
     BOOST_TEST(std::isnan(gen2.getRatedS()));
     BOOST_CHECK_CLOSE(-9999.99, gen2.getMinP(), std::numeric_limits<double>::epsilon());


### PR DESCRIPTION
`Identifiable::getName()` has been removed, user has to call `getNameOrId()` if needed or `getOptionalName()`.

Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#124 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
