### PR TITLE
Fix ext-path parsing in iidm-benchmark tool

### DIFF
--- a/tools/benchmark/Benchmark.cpp
+++ b/tools/benchmark/Benchmark.cpp
@@ -43,8 +43,14 @@ void loadExtensions(const std::string& strPaths) {
     powsybl::iidm::ExtensionProviders<powsybl::iidm::converter::xml::ExtensionXmlSerializer>::getInstance().loadExtensions(boost::dll::program_location().parent_path().string(), fileRegex);
 
     if (!strPaths.empty()) {
+#if defined(BOOST_WINDOWS_API)
+        char pathSeparator = ';';
+#elif defined(BOOST_POSIX_API)
+        char pathSeparator = ':';
+#endif
+
         std::vector<std::string> paths;
-        boost::algorithm::split(paths, strPaths, [](char c) { return c == boost::filesystem::path::separator; });
+        boost::algorithm::split(paths, strPaths, [pathSeparator](char c) { return c == pathSeparator; });
         for (const auto& path : paths) {
             powsybl::iidm::ExtensionProviders<powsybl::iidm::converter::xml::ExtensionXmlSerializer>::getInstance().loadExtensions(path, fileRegex);
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The `ext-path` option's value is not well parsed, so it's not usable at all.


**What is the new behavior (if this is a feature change)?**
The ext-path option works properly


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
