### PR TITLE
Fix crash when removing a VoltageLevel

### DIFF
--- a/include/powsybl/iidm/NetworkIndex.hpp
+++ b/include/powsybl/iidm/NetworkIndex.hpp
@@ -21,6 +21,7 @@ namespace powsybl {
 namespace iidm {
 
 class Network;
+class VoltageLevel;
 
 class NetworkIndex {
 public:
@@ -85,6 +86,9 @@ const Identifiable& NetworkIndex::get(const std::string& id) const;
 
 template <>
 Identifiable& NetworkIndex::get(const std::string& id);
+
+template <>
+unsigned long NetworkIndex::getObjectCount<VoltageLevel>() const;
 
 }  // namespace iidm
 

--- a/include/powsybl/iidm/NetworkIndex.hxx
+++ b/include/powsybl/iidm/NetworkIndex.hxx
@@ -41,7 +41,7 @@ T& NetworkIndex::checkAndAdd(std::unique_ptr<T>&& identifiable) {
     auto it = m_objectsById.emplace(std::make_pair(identifiable->getId(), std::move(identifiable)));
 
     std::reference_wrapper<Identifiable> refIdentifiable = *it.first->second;
-    m_objectsByType[typeid(T)].emplace_back(refIdentifiable);
+    m_objectsByType[typeid(*it.first->second)].emplace_back(refIdentifiable);
 
     return dynamic_cast<T&>(*it.first->second);
 }
@@ -79,6 +79,12 @@ stdcxx::const_range<Identifiable> NetworkIndex::getAll<Identifiable, Identifiabl
 
 template <>
 stdcxx::range<Identifiable> NetworkIndex::getAll<Identifiable, Identifiable>();
+
+template <>
+stdcxx::const_range<VoltageLevel> NetworkIndex::getAll<VoltageLevel, VoltageLevel>() const;
+
+template <>
+stdcxx::range<VoltageLevel> NetworkIndex::getAll<VoltageLevel, VoltageLevel>();
 
 template <typename T, typename U>
 stdcxx::const_range<U> NetworkIndex::getAll() const {

--- a/include/powsybl/iidm/NetworkIndex.hxx
+++ b/include/powsybl/iidm/NetworkIndex.hxx
@@ -41,7 +41,7 @@ T& NetworkIndex::checkAndAdd(std::unique_ptr<T>&& identifiable) {
     auto it = m_objectsById.emplace(std::make_pair(identifiable->getId(), std::move(identifiable)));
 
     std::reference_wrapper<Identifiable> refIdentifiable = *it.first->second;
-    m_objectsByType[typeid(*it.first->second)].emplace_back(refIdentifiable);
+    m_objectsByType[typeid(T)].emplace_back(refIdentifiable);
 
     return dynamic_cast<T&>(*it.first->second);
 }

--- a/src/iidm/NetworkIndex.cpp
+++ b/src/iidm/NetworkIndex.cpp
@@ -87,14 +87,12 @@ stdcxx::range<MultiVariantObject> NetworkIndex::getAll<Identifiable, MultiVarian
 
 template <>
 stdcxx::const_range<VoltageLevel> NetworkIndex::getAll<VoltageLevel, VoltageLevel>() const {
-    stdcxx::const_range<VoltageLevel> bbvl = getAll<BusBreakerVoltageLevel, VoltageLevel>();
-    return boost::range::join(bbvl, getAll<NodeBreakerVoltageLevel, VoltageLevel>());
+    return boost::range::join(getAll<BusBreakerVoltageLevel, VoltageLevel>(), getAll<NodeBreakerVoltageLevel, VoltageLevel>());
 }
 
 template <>
 stdcxx::range<VoltageLevel> NetworkIndex::getAll<VoltageLevel, VoltageLevel>() {
-    stdcxx::range<VoltageLevel> bbvl = getAll<BusBreakerVoltageLevel, VoltageLevel>();
-    return boost::range::join(bbvl, getAll<NodeBreakerVoltageLevel, VoltageLevel>());
+    return boost::range::join(getAll<BusBreakerVoltageLevel, VoltageLevel>(), getAll<NodeBreakerVoltageLevel, VoltageLevel>());
 }
 
 template <>

--- a/src/iidm/NetworkIndex.cpp
+++ b/src/iidm/NetworkIndex.cpp
@@ -11,10 +11,14 @@
 #include <boost/range/adaptor/indirected.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/join.hpp>
 
 #include <powsybl/iidm/Substation.hpp>
 #include <powsybl/iidm/ValidationUtils.hpp>
 #include <powsybl/stdcxx/memory.hpp>
+
+#include "BusBreakerVoltageLevel.hpp"
+#include "NodeBreakerVoltageLevel.hpp"
 
 namespace powsybl {
 
@@ -82,8 +86,25 @@ stdcxx::range<MultiVariantObject> NetworkIndex::getAll<Identifiable, MultiVarian
 }
 
 template <>
+stdcxx::const_range<VoltageLevel> NetworkIndex::getAll<VoltageLevel, VoltageLevel>() const {
+    stdcxx::const_range<VoltageLevel> bbvl = getAll<BusBreakerVoltageLevel, VoltageLevel>();
+    return boost::range::join(bbvl, getAll<NodeBreakerVoltageLevel, VoltageLevel>());
+}
+
+template <>
+stdcxx::range<VoltageLevel> NetworkIndex::getAll<VoltageLevel, VoltageLevel>() {
+    stdcxx::range<VoltageLevel> bbvl = getAll<BusBreakerVoltageLevel, VoltageLevel>();
+    return boost::range::join(bbvl, getAll<NodeBreakerVoltageLevel, VoltageLevel>());
+}
+
+template <>
 unsigned long NetworkIndex::getObjectCount<Identifiable>() const {
     return m_objectsById.size();
+}
+
+template <>
+unsigned long NetworkIndex::getObjectCount<VoltageLevel>() const {
+    return getObjectCount<BusBreakerVoltageLevel>() + getObjectCount<NodeBreakerVoltageLevel>();
 }
 
 void NetworkIndex::remove(Identifiable& identifiable) {

--- a/src/iidm/VoltageLevelAdder.cpp
+++ b/src/iidm/VoltageLevelAdder.cpp
@@ -28,24 +28,24 @@ VoltageLevel& VoltageLevelAdder::add() {
     checkVoltageLimits(*this, m_lowVoltageLimit, m_highVoltageLimit);
     checkOptional(*this, m_topologyKind, "TopologyKind is not set");
 
-    std::unique_ptr<VoltageLevel> ptrVoltageLevel;
     switch (*m_topologyKind) {
-        case TopologyKind::NODE_BREAKER:
-            ptrVoltageLevel = stdcxx::make_unique<NodeBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), m_substation, m_nominalVoltage, m_lowVoltageLimit, m_highVoltageLimit);
-            break;
+        case TopologyKind::NODE_BREAKER: {
+            auto ptrVoltageLevel = stdcxx::make_unique<NodeBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), m_substation, m_nominalVoltage, m_lowVoltageLimit, m_highVoltageLimit);
+            auto& voltageLevel = getNetwork().checkAndAdd<NodeBreakerVoltageLevel>(std::move(ptrVoltageLevel));
+            m_substation.addVoltageLevel(voltageLevel);
+            return voltageLevel;
+        }
 
-        case TopologyKind::BUS_BREAKER:
-            ptrVoltageLevel = stdcxx::make_unique<BusBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), m_substation, m_nominalVoltage, m_lowVoltageLimit, m_highVoltageLimit);
-            break;
+        case TopologyKind::BUS_BREAKER: {
+            auto ptrVoltageLevel = stdcxx::make_unique<BusBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), m_substation, m_nominalVoltage, m_lowVoltageLimit, m_highVoltageLimit);
+            auto& voltageLevel = getNetwork().checkAndAdd<BusBreakerVoltageLevel>(std::move(ptrVoltageLevel));
+            m_substation.addVoltageLevel(voltageLevel);
+            return voltageLevel;
+        }
 
         default:
             throw AssertionError(stdcxx::format("Unexpected TopologyKind value: %1%", *m_topologyKind));
     }
-
-    auto& voltageLevel = getNetwork().checkAndAdd<VoltageLevel>(std::move(ptrVoltageLevel));
-    m_substation.addVoltageLevel(voltageLevel);
-
-    return voltageLevel;
 }
 
 const Network& VoltageLevelAdder::getNetwork() const {

--- a/src/iidm/VoltageLevelAdder.cpp
+++ b/src/iidm/VoltageLevelAdder.cpp
@@ -28,24 +28,24 @@ VoltageLevel& VoltageLevelAdder::add() {
     checkVoltageLimits(*this, m_lowVoltageLimit, m_highVoltageLimit);
     checkOptional(*this, m_topologyKind, "TopologyKind is not set");
 
+    stdcxx::Reference<VoltageLevel> voltageLevel;
     switch (*m_topologyKind) {
-        case TopologyKind::NODE_BREAKER: {
-            auto ptrVoltageLevel = stdcxx::make_unique<NodeBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), m_substation, m_nominalVoltage, m_lowVoltageLimit, m_highVoltageLimit);
-            auto& voltageLevel = getNetwork().checkAndAdd<NodeBreakerVoltageLevel>(std::move(ptrVoltageLevel));
-            m_substation.addVoltageLevel(voltageLevel);
-            return voltageLevel;
-        }
+        case TopologyKind::NODE_BREAKER:
+            voltageLevel = stdcxx::ref<VoltageLevel>(getNetwork().checkAndAdd<NodeBreakerVoltageLevel>(
+                stdcxx::make_unique<NodeBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), m_substation, m_nominalVoltage, m_lowVoltageLimit, m_highVoltageLimit)));
+            break;
 
-        case TopologyKind::BUS_BREAKER: {
-            auto ptrVoltageLevel = stdcxx::make_unique<BusBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), m_substation, m_nominalVoltage, m_lowVoltageLimit, m_highVoltageLimit);
-            auto& voltageLevel = getNetwork().checkAndAdd<BusBreakerVoltageLevel>(std::move(ptrVoltageLevel));
-            m_substation.addVoltageLevel(voltageLevel);
-            return voltageLevel;
-        }
+        case TopologyKind::BUS_BREAKER:
+            voltageLevel = stdcxx::ref<VoltageLevel>(getNetwork().checkAndAdd<BusBreakerVoltageLevel>(
+                stdcxx::make_unique<BusBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), m_substation, m_nominalVoltage, m_lowVoltageLimit, m_highVoltageLimit)));
+            break;
 
         default:
             throw AssertionError(stdcxx::format("Unexpected TopologyKind value: %1%", *m_topologyKind));
     }
+
+    m_substation.addVoltageLevel(voltageLevel);
+    return voltageLevel;
 }
 
 const Network& VoltageLevelAdder::getNetwork() const {

--- a/test/iidm/BusBreakerVoltageLevelTest.cpp
+++ b/test/iidm/BusBreakerVoltageLevelTest.cpp
@@ -485,6 +485,12 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
     POWSYBL_ASSERT_THROW(cTerminal.getNodeBreakerView(), AssertionError, "Not implemented");
 }
 
+BOOST_AUTO_TEST_CASE(TestRemoveVoltageLevel) {
+    Network network = createNetwork();
+    network.remove(network.getVoltageLevel("VL2"));
+    POWSYBL_ASSERT_THROW(network.getVoltageLevel("VL2"), PowsyblException, "Unable to find to the identifiable 'VL2'");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace iidm

--- a/test/iidm/NodeBreakerVoltageLevelTest.cpp
+++ b/test/iidm/NodeBreakerVoltageLevelTest.cpp
@@ -11,6 +11,7 @@
 
 #include <powsybl/iidm/Bus.hpp>
 #include <powsybl/iidm/BusbarSection.hpp>
+#include <powsybl/iidm/InternalConnection.hpp>
 #include <powsybl/iidm/Line.hpp>
 #include <powsybl/iidm/LineAdder.hpp>
 #include <powsybl/iidm/Load.hpp>
@@ -18,6 +19,8 @@
 #include <powsybl/iidm/Network.hpp>
 #include <powsybl/iidm/Substation.hpp>
 #include <powsybl/iidm/Switch.hpp>
+#include <powsybl/iidm/VoltageLevel.hpp>
+#include <powsybl/iidm/VoltageLevelAdder.hpp>
 
 #include <powsybl/test/AssertionUtils.hpp>
 
@@ -175,6 +178,109 @@ Network createCalculatedBusSwitchTestNetwork() {
         .add();
 
     return network;
+}
+
+void addInternalConnection( VoltageLevel::NodeBreakerView& topo, int node1, int node2) {
+    topo.newInternalConnection()
+        .setNode1(node1)
+        .setNode2(node2)
+        .add();
+}
+
+const std::string S5_10K_V = "S5 10kV";
+void createNetwork(Network& network) {
+    Substation& s = network.newSubstation()
+        .setId("S5")
+        .setCountry(Country::FR)
+        .add();
+    VoltageLevel& vl = s.newVoltageLevel()
+        .setId(S5_10K_V)
+        .setNominalVoltage(10.0)
+        .setTopologyKind(TopologyKind::NODE_BREAKER)
+        .add();
+    vl.getNodeBreakerView().setNodeCount(20);
+    vl.getNodeBreakerView().newBusbarSection()
+        .setId("NODE13")
+        .setNode(0)
+        .add();
+    vl.getNodeBreakerView().newBusbarSection()
+        .setId("NODE14")
+        .setNode(3)
+        .add();
+    vl.getNodeBreakerView().newBusbarSection()
+        .setId("NODE15")
+        .setNode(2)
+        .add();
+    vl.getNodeBreakerView().newBusbarSection()
+        .setId("NODE16")
+        .setNode(1)
+        .add();
+    vl.getNodeBreakerView().newSwitch()
+        .setId("BREAKER4")
+        .setNode1(4)
+        .setNode2(5)
+        .setKind(SwitchKind::BREAKER)
+    .add();
+    vl.getNodeBreakerView().newSwitch()
+        .setId("DISCONNECTOR7")
+        .setNode1(6)
+        .setNode2(7)
+        .setKind(SwitchKind::DISCONNECTOR)
+        .add();
+    vl.getNodeBreakerView().newSwitch()
+        .setId("DISCONNECTOR8")
+        .setNode1(8)
+        .setNode2(9)
+        .setKind(SwitchKind::DISCONNECTOR)
+        .add();
+    vl.newLoad()
+        .setId("M3")
+        .setNode(11)
+        .setP0(5)
+        .setQ0(3)
+        .add();
+    vl.newLoad()
+        .setId("M2a")
+        .setNode(12)
+        .setP0(2)
+        .setQ0(1)
+        .add();
+    vl.newLoad()
+        .setId("M2b")
+        .setNode(13)
+        .setP0(2)
+        .setQ0(1)
+        .add();
+    VoltageLevel::NodeBreakerView& topo = vl.getNodeBreakerView();
+    addInternalConnection(topo, 7, 0);
+    addInternalConnection(topo, 6, 3);
+    addInternalConnection(topo, 4, 3);
+    addInternalConnection(topo, 5, 2);
+    addInternalConnection(topo, 9, 2);
+    addInternalConnection(topo, 8, 1);
+    Substation& s4 = network.newSubstation()
+        .setId("S4")
+        .setCountry(Country::FR)
+        .add();
+    VoltageLevel& vl2 = s4.newVoltageLevel()
+    .setId("S4 10kV")
+    .setNominalVoltage(10.0)
+    .setTopologyKind(TopologyKind::NODE_BREAKER)
+    .add();
+    vl2.getNodeBreakerView().setNodeCount(10);
+    network.newLine()
+    .setId("L6")
+    .setVoltageLevel1("S4 10kV")
+    .setNode1(0)
+    .setVoltageLevel2(S5_10K_V)
+    .setNode2(10)
+    .setR(0.082)
+    .setX(0.086)
+    .setG1(0)
+    .setB1(0)
+    .setG2(0)
+    .setB2(0)
+    .add();
 }
 
 BOOST_AUTO_TEST_SUITE(NodeBreakerVoltageLevelTestSuite)
@@ -1044,6 +1150,15 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
     const auto& cVl = vl;
     const BusbarSection& cBbs = cVl.getNodeBreakerView().getBusbarSection("BBS");
     BOOST_CHECK_CLOSE(0, cBbs.getTerminal().getI(), std::numeric_limits<double>::epsilon());
+}
+
+BOOST_AUTO_TEST_CASE(TestRemoveVoltageLevelWithInternalConnectionsIssue) {
+    Network network("test", "test");
+
+    createNetwork(network);
+    network.getLine("L6").remove(); // needed to be allowed to remove the voltage level
+    network.remove(network.getVoltageLevel(S5_10K_V));
+    POWSYBL_ASSERT_THROW(network.getVoltageLevel(S5_10K_V), PowsyblException, "Unable to find to the identifiable 'S5 10kV'");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/iidm/NodeBreakerVoltageLevelTest.cpp
+++ b/test/iidm/NodeBreakerVoltageLevelTest.cpp
@@ -187,8 +187,8 @@ void addInternalConnection( VoltageLevel::NodeBreakerView& topo, int node1, int 
         .add();
 }
 
-const std::string S5_10K_V = "S5 10kV";
 void createNetwork(Network& network) {
+    const std::string S5_10K_V = "S5 10kV";
     Substation& s = network.newSubstation()
         .setId("S5")
         .setCountry(Country::FR)
@@ -1157,8 +1157,8 @@ BOOST_AUTO_TEST_CASE(TestRemoveVoltageLevelWithInternalConnectionsIssue) {
 
     createNetwork(network);
     network.getLine("L6").remove(); // needed to be allowed to remove the voltage level
-    network.remove(network.getVoltageLevel(S5_10K_V));
-    POWSYBL_ASSERT_THROW(network.getVoltageLevel(S5_10K_V), PowsyblException, "Unable to find to the identifiable 'S5 10kV'");
+    network.remove(network.getVoltageLevel("S5 10kV"));
+    POWSYBL_ASSERT_THROW(network.getVoltageLevel("S5 10kV"), PowsyblException, "Unable to find to the identifiable 'S5 10kV'");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No (found while testing issue #125)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Removing a VoltageLevel from a network crashes because `NetworkIndex::m_objectsByType` contains 1 entry/key for every VoltageLevels in the Network. While removing a NodeBreakerVoltageLevel, the effective type is not found in the map => crash


**What is the new behavior (if this is a feature change)?**
Now, `NetworkIndex::m_objectsByType` contains 1 entry/key for each concrete VoltageLevel (Node Breaker / Bus Breaker) in the network.
Accessors `NetworkIndex::getAll` and `NetworkIndex::getObjectCount` are now specialized for `VoltageLevel` to concatenate concrete VLs.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
