### PR TITLE
Clang tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,6 @@ jobs:
           -DCODE_COVERAGE=TRUE
           -DBUILD_EXAMPLES=ON
           -DCMAKE_PREFIX_PATH=$BOOST_ROOT_1_72_0
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Build
         run:  >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,6 @@ jobs:
     name: QA
     runs-on: ubuntu-latest
     steps:
-      - name: Install clang-tidy
-        run: |
-          sudo apt-get install -y clang-tidy-9
-          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 100
-
       - name: Install Java 11
         uses: actions/setup-java@v1
         with:
@@ -140,13 +135,6 @@ jobs:
           ${{ runner.workspace }}/build-wrapper-linux-x86/build-wrapper-linux-x86-64
           --out-dir $GITHUB_WORKSPACE/build/output
           cmake --build $GITHUB_WORKSPACE/build --parallel 2
-
-      - name: Clang Tidy
-        run: |
-          export MODIFIED_FILES=$(git diff -U0 HEAD^ --name-only | grep -E "\.(cpp|hpp|hxx)$")
-          if [ -n "$MODIFIED_FILES" ]; then
-              clang-tidy $MODIFIED_FILES -p $GITHUB_WORKSPACE/build-linux
-          fi
 
       - name: Tests
         run: >

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,32 @@
+name: clang-tidy
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+
+jobs:
+  qa:
+    name: clang-tidy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install clang-tidy
+        run: |
+          sudo apt-get install -y clang-tidy-9
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 100
+
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Configure CMake
+        run: >
+          cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_PREFIX_PATH=$BOOST_ROOT_1_72_0
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: Clang Tidy
+        run: |
+          export MODIFIED_FILES=$(git diff --name-only origin/${{ github.base_ref }} origin/${{ github.head_ref }}  | grep -E "\.(cpp|hpp|hxx)$")
+          if [ -n "$MODIFIED_FILES" ]; then
+              clang-tidy $MODIFIED_FILES -p $GITHUB_WORKSPACE/build
+          fi


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#173 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
CI


**What is the current behavior?** *(You can also link to an open issue here)*
The PR #178 doesn't work properly when multiple commits are in a PR.


**What is the new behavior (if this is a feature change)?**
We create a separate jobs for clang-tidy analysis that is triggered on push and on pull_request events. If the branch is not associated to a pull request, the job fail.

In the existing CI script, we merge the QA and Linux jobs to run sonar analysis after linux build.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
