### PR TITLE
[IIDM v1.3] Exclude deleted files from clang-tidy analysis

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Clang Tidy
         run: |
-          export MODIFIED_FILES=$(git diff --name-only origin/${{ github.base_ref }} origin/${{ github.head_ref }}  | grep -E "\.(cpp|hpp|hxx)$")
+          export MODIFIED_FILES=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }} origin/${{ github.head_ref }}  | grep -E "\.(cpp|hpp|hxx)$")
           if [ -n "$MODIFIED_FILES" ]; then
               clang-tidy $MODIFIED_FILES -p $GITHUB_WORKSPACE/build
           fi


### PR DESCRIPTION

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When executing clang-tidy from CI, the analysis is performed on every files, even the deleted ones, so that an error occurs.


**What is the new behavior (if this is a feature change)?**
Deleted files are excluded by using `--diff-filter=d` option to the `git diff` command line.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
