### PR TITLE
3wt leg getterminal

### DIFF
--- a/include/powsybl/iidm/ThreeWindingsTransformer.hpp
+++ b/include/powsybl/iidm/ThreeWindingsTransformer.hpp
@@ -74,9 +74,9 @@ public:
 
         double getRatedU() const;
 
-        virtual stdcxx::CReference<Terminal> getTerminal() const;
+        const Terminal& getTerminal() const;
 
-        virtual stdcxx::Reference<Terminal> getTerminal();
+        Terminal& getTerminal();
 
         double getX() const;
 

--- a/src/iidm/ThreeWindingsTransformer.cpp
+++ b/src/iidm/ThreeWindingsTransformer.cpp
@@ -115,15 +115,12 @@ unsigned long ThreeWindingsTransformer::Leg::getRegulatingTapChangerCount() cons
     return count;
 }
 
-stdcxx::CReference<Terminal> ThreeWindingsTransformer::Leg::getTerminal() const {
-    if (m_transformer) {
-        return stdcxx::cref<Terminal>(m_transformer.get().Connectable::getTerminal(m_legNumber - 1));
-    }
-    return {};
+const Terminal& ThreeWindingsTransformer::Leg::getTerminal() const {
+    return m_transformer.get().Connectable::getTerminal(m_legNumber - 1);
 }
 
-stdcxx::Reference<Terminal> ThreeWindingsTransformer::Leg::getTerminal() {
-    return stdcxx::ref(static_cast<const ThreeWindingsTransformer::Leg*>(this)->getTerminal());
+Terminal& ThreeWindingsTransformer::Leg::getTerminal() {
+    return m_transformer.get().Connectable::getTerminal(m_legNumber - 1);
 }
 
 const std::string& ThreeWindingsTransformer::Leg::getTypeDescription() const {
@@ -316,34 +313,34 @@ double ThreeWindingsTransformer::getRatedU0() const {
 }
 
 ThreeWindingsTransformer::Side ThreeWindingsTransformer::getSide(const Terminal& terminal) const {
-    if (stdcxx::areSame(m_leg1->getTerminal().get(), terminal)) {
+    if (stdcxx::areSame(m_leg1->getTerminal(), terminal)) {
         return Side::ONE;
     }
-    if (stdcxx::areSame(m_leg2->getTerminal().get(), terminal)) {
+    if (stdcxx::areSame(m_leg2->getTerminal(), terminal)) {
         return Side::TWO;
     }
-    if (stdcxx::areSame(m_leg3->getTerminal().get(), terminal)) {
+    if (stdcxx::areSame(m_leg3->getTerminal(), terminal)) {
         return Side::THREE;
     }
     throw AssertionError("The terminal is not connected to this three windings transformer");
 }
 
 const Substation& ThreeWindingsTransformer::getSubstation() const {
-    return m_leg1->getTerminal().get().getVoltageLevel().getSubstation();
+    return m_leg1->getTerminal().getVoltageLevel().getSubstation();
 }
 
 Substation& ThreeWindingsTransformer::getSubstation() {
-    return m_leg1->getTerminal().get().getVoltageLevel().getSubstation();
+    return m_leg1->getTerminal().getVoltageLevel().getSubstation();
 }
 
 const Terminal& ThreeWindingsTransformer::getTerminal(const Side& side) const {
     switch (side) {
         case Side::ONE:
-            return m_leg1->getTerminal().get();
+            return m_leg1->getTerminal();
         case Side::TWO:
-            return m_leg2->getTerminal().get();
+            return m_leg2->getTerminal();
         case Side::THREE:
-            return m_leg3->getTerminal().get();
+            return m_leg3->getTerminal();
         default:
             throw AssertionError(stdcxx::format("Unexpected side value: %1%", side));
     }

--- a/test/iidm/ThreeWindingsTransformerTest.cpp
+++ b/test/iidm/ThreeWindingsTransformerTest.cpp
@@ -288,8 +288,8 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_TEST(!leg1.getCurrentLimits());
     BOOST_TEST(!cLeg1.getCurrentLimits());
 
-    BOOST_TEST(stdcxx::areSame(terminal1, leg1.getTerminal().get()));
-    BOOST_TEST(stdcxx::areSame(cTerminal1, cLeg1.getTerminal().get()));
+    BOOST_TEST(stdcxx::areSame(terminal1, leg1.getTerminal()));
+    BOOST_TEST(stdcxx::areSame(cTerminal1, cLeg1.getTerminal()));
 
     // Leg 2 tests
     ThreeWindingsTransformer::Leg& leg2 = transformer.getLeg2();
@@ -306,8 +306,8 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_TEST(!leg2.hasRatioTapChanger());
     BOOST_TEST(!cLeg2.hasRatioTapChanger());
 
-    BOOST_TEST(stdcxx::areSame(terminal2, leg2.getTerminal().get()));
-    BOOST_TEST(stdcxx::areSame(cTerminal2, cLeg2.getTerminal().get()));
+    BOOST_TEST(stdcxx::areSame(terminal2, leg2.getTerminal()));
+    BOOST_TEST(stdcxx::areSame(cTerminal2, cLeg2.getTerminal()));
     BOOST_TEST(stdcxx::areSame(network, leg2.getNetwork()));
     BOOST_TEST(stdcxx::areSame(network, cLeg2.getNetwork()));
 
@@ -325,8 +325,8 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_TEST(!leg3.hasRatioTapChanger());
     BOOST_TEST(!cLeg3.hasRatioTapChanger());
 
-    BOOST_TEST(stdcxx::areSame(terminal3, leg3.getTerminal().get()));
-    BOOST_TEST(stdcxx::areSame(cTerminal3, cLeg3.getTerminal().get()));
+    BOOST_TEST(stdcxx::areSame(terminal3, leg3.getTerminal()));
+    BOOST_TEST(stdcxx::areSame(cTerminal3, cLeg3.getTerminal()));
     BOOST_TEST(stdcxx::areSame(network, leg3.getNetwork()));
     BOOST_TEST(stdcxx::areSame(network, cLeg3.getNetwork()));
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
The `getTerminal()` method of the 3WT legs return a `Reference<Terminal>` object instead of a `Terminal&` like other identifiables


**What is the new behavior (if this is a feature change)?**
The methods are consistent with the rest of the API


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
