### PR TITLE
Fix multi-variant implementation by adding the Network in the index

### DIFF
--- a/include/powsybl/iidm/NetworkIndex.hpp
+++ b/include/powsybl/iidm/NetworkIndex.hpp
@@ -69,7 +69,12 @@ private:
     static void checkId(const std::string& id);
 
 private:
-    using IdentifiableById = std::map<std::string, std::unique_ptr<Identifiable> >;
+    class Deleter {
+    public:
+        void operator()(Identifiable* ptr) const;
+    };
+
+    using IdentifiableById = std::map<std::string, std::unique_ptr<Identifiable, Deleter> >;
 
     using Identifiables = std::vector<std::reference_wrapper<Identifiable> >;
 

--- a/include/powsybl/iidm/NetworkIndex.hxx
+++ b/include/powsybl/iidm/NetworkIndex.hxx
@@ -38,7 +38,8 @@ T& NetworkIndex::checkAndAdd(std::unique_ptr<T>&& identifiable) {
         throw PowsyblException(stdcxx::format("Object '%1%' already exists (%2%)", identifiable->getId(), stdcxx::demangle(*other->second)));
     }
 
-    auto it = m_objectsById.emplace(std::make_pair(identifiable->getId(), std::move(identifiable)));
+    auto ptrIdentifiable = std::unique_ptr<Identifiable, Deleter>(identifiable.release());
+    auto it = m_objectsById.emplace(std::make_pair(ptrIdentifiable->getId(), std::move(ptrIdentifiable)));
 
     std::reference_wrapper<Identifiable> refIdentifiable = *it.first->second;
     m_objectsByType[typeid(T)].emplace_back(refIdentifiable);

--- a/include/powsybl/stdcxx/instanceof.hpp
+++ b/include/powsybl/stdcxx/instanceof.hpp
@@ -14,7 +14,12 @@ namespace stdcxx {
 
 template <typename Base, typename T>
 inline bool isInstanceOf(const T& object) {
-    return std::is_same<Base, T>::value ? true : dynamic_cast<const Base*>(&object) != nullptr;
+    return std::is_same<Base, T>::value || dynamic_cast<const Base*>(&object) != nullptr;
+}
+
+template <typename Base, typename T>
+inline bool isInstanceOf(const T* object) {
+    return object != nullptr && (std::is_same<Base, T>::value || dynamic_cast<const Base*>(object) != nullptr);
 }
 
 template <typename Base, typename T>

--- a/include/powsybl/stdcxx/instanceof.hpp
+++ b/include/powsybl/stdcxx/instanceof.hpp
@@ -14,7 +14,7 @@ namespace stdcxx {
 
 template <typename Base, typename T>
 inline bool isInstanceOf(const T* object) {
-    return object != nullptr && dynamic_cast<const Base*>(object) != nullptr;
+    return dynamic_cast<const Base*>(object) != nullptr;
 }
 
 template <typename Base, typename T>

--- a/include/powsybl/stdcxx/instanceof.hpp
+++ b/include/powsybl/stdcxx/instanceof.hpp
@@ -14,12 +14,12 @@ namespace stdcxx {
 
 template <typename Base, typename T>
 inline bool isInstanceOf(const T& object) {
-    return std::is_same<Base, T>::value || dynamic_cast<const Base*>(&object) != nullptr;
+    return dynamic_cast<const Base*>(&object) != nullptr;
 }
 
 template <typename Base, typename T>
 inline bool isInstanceOf(const T* object) {
-    return object != nullptr && (std::is_same<Base, T>::value || dynamic_cast<const Base*>(object) != nullptr);
+    return object != nullptr && dynamic_cast<const Base*>(object) != nullptr;
 }
 
 template <typename Base, typename T>

--- a/include/powsybl/stdcxx/instanceof.hpp
+++ b/include/powsybl/stdcxx/instanceof.hpp
@@ -13,13 +13,13 @@
 namespace stdcxx {
 
 template <typename Base, typename T>
-inline bool isInstanceOf(const T& object) {
-    return dynamic_cast<const Base*>(&object) != nullptr;
+inline bool isInstanceOf(const T* object) {
+    return object != nullptr && dynamic_cast<const Base*>(object) != nullptr;
 }
 
 template <typename Base, typename T>
-inline bool isInstanceOf(const T* object) {
-    return object != nullptr && dynamic_cast<const Base*>(object) != nullptr;
+inline bool isInstanceOf(const T& object) {
+    return isInstanceOf<Base, T>(&object);
 }
 
 template <typename Base, typename T>

--- a/src/iidm/Network.cpp
+++ b/src/iidm/Network.cpp
@@ -72,6 +72,7 @@ Network::Network(const std::string& id, const std::string& sourceFormat) :
     m_variantManager(*this),
     m_busBreakerView(*this),
     m_busView(*this) {
+    checkAndAdd(std::unique_ptr<Network>(this));
 }
 
 Network::Network(Network&& network) noexcept :

--- a/test/iidm/CMakeLists.txt
+++ b/test/iidm/CMakeLists.txt
@@ -22,6 +22,7 @@ set(UNIT_TEST_SOURCES
     LccConverterStationTest.cpp
     LineTest.cpp
     LoadTest.cpp
+    NetworkExtension.cpp
     NetworkFactory.cpp
     NetworkIndexTest.cpp
     NetworkTest.cpp

--- a/test/iidm/NetworkExtension.cpp
+++ b/test/iidm/NetworkExtension.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+ 
+#include "NetworkExtension.hpp"
+
+#include <powsybl/iidm/Network.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+NetworkExtension::NetworkExtension(Network& network, bool value) :
+    AbstractMultiVariantIdentifiableExtension(network) {
+    unsigned long variantArraySize = getVariantManagerHolder().getVariantManager().getVariantArraySize();
+    m_value.resize(variantArraySize, value);
+}
+
+void NetworkExtension::allocateVariantArrayElement(const std::set<unsigned long>& indexes, unsigned long sourceIndex) {
+    for (unsigned long index : indexes) {
+        m_value[index] = m_value[sourceIndex];
+    }
+}
+
+void NetworkExtension::assertExtendable(const stdcxx::Reference<Extendable>& extendable) const {
+    if (extendable && !stdcxx::isInstanceOf<Network>(extendable.get())) {
+        throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable.get()), stdcxx::demangle<Network>()));
+    }
+}
+
+void NetworkExtension::deleteVariantArrayElement(unsigned long /*index*/) {
+    // Does nothing
+}
+
+void NetworkExtension::extendVariantArraySize(unsigned long /*initVariantArraySize*/, unsigned long number, unsigned long sourceIndex) {
+    m_value.resize(m_value.size() + number, m_value[sourceIndex]);
+}
+
+const std::string& NetworkExtension::getName() const {
+    static std::string s_name = "networkExtension";
+    return s_name;
+}
+
+const std::type_index& NetworkExtension::getType() const {
+    static std::type_index s_type = typeid(NetworkExtension);
+    return s_type;
+}
+
+bool NetworkExtension::getValue() const {
+    return m_value[getVariantIndex()];
+}
+
+void NetworkExtension::reduceVariantArraySize(unsigned long number) {
+    m_value.resize(m_value.size() - number);
+}
+
+NetworkExtension& NetworkExtension::setValue(bool value) {
+    m_value[getVariantIndex()] = value;
+    return *this;
+}
+
+}  // namespace iidm
+
+}  // namespace powsybl

--- a/test/iidm/NetworkExtension.hpp
+++ b/test/iidm/NetworkExtension.hpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef POWSYBL_IIDM_NETWORKEXTENSION_HPP
+#define POWSYBL_IIDM_NETWORKEXTENSION_HPP
+
+#include <powsybl/iidm/AbstractMultiVariantIdentifiableExtension.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+class Network;
+
+class NetworkExtension : public AbstractMultiVariantIdentifiableExtension {
+public:  // Extension
+    const std::string& getName() const override;
+
+    const std::type_index& getType() const override;
+
+public: // MultiVariantObject
+    void allocateVariantArrayElement(const std::set<unsigned long>& indexes, unsigned long sourceIndex) override;
+
+    void deleteVariantArrayElement(unsigned long index) override;
+
+    void extendVariantArraySize(unsigned long initVariantArraySize, unsigned long number, unsigned long sourceIndex) override;
+
+    void reduceVariantArraySize(unsigned long number) override;
+
+public:
+    NetworkExtension(Network& network, bool value);
+
+    ~NetworkExtension() noexcept override = default;
+
+    bool getValue() const;
+
+    NetworkExtension& setValue(bool value);
+
+private:  // Extension
+    void assertExtendable(const stdcxx::Reference<Extendable>& extendable) const override;
+
+private:
+    std::vector<bool> m_value;
+};
+
+}  // namespace iidm
+
+}  // namespace powsybl
+
+#endif  // POWSYBL_IIDM_NETWORKEXTENSION_HPP

--- a/test/iidm/NetworkIndexTest.cpp
+++ b/test/iidm/NetworkIndexTest.cpp
@@ -23,13 +23,17 @@ BOOST_AUTO_TEST_CASE(RangeTest) {
     Network network = createNetwork();
     const Network& cNetwork = network;
 
+    // Network
+    const Identifiable& movedNetwork = network.getIdentifiable("test");
+    BOOST_CHECK(stdcxx::areSame(network, movedNetwork));
+
     // Substations
     BOOST_CHECK_EQUAL(1UL, cNetwork.getSubstationCount());
     BOOST_CHECK_EQUAL(1UL, boost::size(cNetwork.getSubstations()));
     BOOST_CHECK_EQUAL(1UL, boost::size(network.getSubstations()));
 
     // Identifiables
-    std::set<std::string> expected = {"LOAD1", "S1", "VL1", "VL1_BUS1", "VL2"};
+    std::set<std::string> expected = {"test", "LOAD1", "S1", "VL1", "VL1_BUS1", "VL2"};
     std::set<std::string> actual;
     std::set<std::string> actualConst;
     for (const auto& identifiable : network.getIdentifiables()) {
@@ -58,8 +62,8 @@ BOOST_AUTO_TEST_CASE(RangeTest) {
     BOOST_CHECK_EQUAL_COLLECTIONS(expectedVL.cbegin(), expectedVL.cend(), actualConstVL.cbegin(), actualConstVL.cend());
 
     // StatefulObjects
-    BOOST_CHECK_EQUAL(5UL, boost::size(cNetwork.getStatefulObjects()));
-    BOOST_CHECK_EQUAL(5UL, boost::size(network.getStatefulObjects()));
+    BOOST_CHECK_EQUAL(6UL, boost::size(cNetwork.getStatefulObjects()));
+    BOOST_CHECK_EQUAL(6UL, boost::size(network.getStatefulObjects()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/iidm/NetworkTest.cpp
+++ b/test/iidm/NetworkTest.cpp
@@ -27,6 +27,8 @@
 
 #include <powsybl/test/AssertionUtils.hpp>
 
+#include "NetworkExtension.hpp"
+
 namespace powsybl {
 
 namespace iidm {
@@ -536,6 +538,26 @@ BOOST_AUTO_TEST_CASE(Properties) {
     POWSYBL_ASSERT_THROW(n.getProperty("key3"),
                          stdcxx::PropertyNotFoundException, "Property key3 does not exist");
     BOOST_CHECK_EQUAL("value3", n.getProperty("key3", "value3"));
+}
+
+BOOST_AUTO_TEST_CASE(MultiVariant) {
+    Network n("test", "test");
+    n.addExtension(stdcxx::make_unique<NetworkExtension>(n, true));
+
+    auto& ext = n.getExtension<NetworkExtension>();
+    n.getVariantManager().cloneVariant(VariantManager::getInitialVariantId(), {"v1", "v2"});
+
+    n.getVariantManager().setWorkingVariant("v1");
+    ext.setValue(false);
+    BOOST_CHECK_EQUAL(false, ext.getValue());
+
+    n.getVariantManager().setWorkingVariant("v2");
+    BOOST_CHECK_EQUAL(true, ext.getValue());
+    n.getVariantManager().removeVariant("v2");
+
+    n.getVariantManager().cloneVariant("v1", "v2");
+    n.getVariantManager().setWorkingVariant("v2");
+    BOOST_CHECK_EQUAL(false, ext.getValue());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Currently the network is not in the index. When a variant is created or removed, the network is not notified. If a multi-variant extension is attached to the network, the extension fields are not extended.


**What is the new behavior (if this is a feature change)?**
This PR insert the network in its own index. To do that, we need to customize the `Deleter` parameter of `std::unique_ptr` to avoid to delete the network twice.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
