### PR TITLE
[IIDM v1.3] Add Enum to change behaviour in case of IIDM version incompatibility

### DIFF
--- a/include/powsybl/iidm/converter/ExportOptions.hpp
+++ b/include/powsybl/iidm/converter/ExportOptions.hpp
@@ -12,7 +12,6 @@
 #include <set>
 #include <string>
 
-#include <powsybl/iidm/Enum.hpp>
 #include <powsybl/iidm/TopologyLevel.hpp>
 #include <powsybl/stdcxx/Properties.hpp>
 

--- a/include/powsybl/iidm/converter/ExportOptions.hpp
+++ b/include/powsybl/iidm/converter/ExportOptions.hpp
@@ -56,19 +56,6 @@ public:
      * @param topologyLevel The maximum topology level to use
      * @param throwExceptionIfExtensionNotFound The extension's serializer lookup mode
      * @param version The expected XIIDM version
-     */
-    ExportOptions(bool withBranchSV, bool indent, bool onlyMainCc, const TopologyLevel& topologyLevel,
-                  bool throwExceptionIfExtensionNotFound, const std::string& version);
-
-    /**
-     * Constructor
-     *
-     * @param withBranchSV
-     * @param indent The indentation status
-     * @param onlyMainCc The connected components status
-     * @param topologyLevel The maximum topology level to use
-     * @param throwExceptionIfExtensionNotFound The extension's serializer lookup mode
-     * @param version The expected XIIDM version
      * @param iidmVersionIncompatibilityBehavior The expected behaviour when an IIDM's version incompatibility occurs
      */
     ExportOptions(bool withBranchSV, bool indent, bool onlyMainCc, const TopologyLevel& topologyLevel,

--- a/include/powsybl/iidm/converter/ExportOptions.hpp
+++ b/include/powsybl/iidm/converter/ExportOptions.hpp
@@ -12,6 +12,7 @@
 #include <set>
 #include <string>
 
+#include <powsybl/iidm/Enum.hpp>
 #include <powsybl/iidm/TopologyLevel.hpp>
 #include <powsybl/stdcxx/Properties.hpp>
 
@@ -27,12 +28,18 @@ class ExportOptions {
 public:
     static constexpr const char* const ANONYMISED = "iidm.export.xml.anonymised";
     static constexpr const char* const EXTENSIONS_LIST = "iidm.export.xml.extensions";
+    static constexpr const char* const IIDM_VERSION_INCOMPATIBILITY_BEHAVIOR = "iidm.export.xml.iidm-version-incompatibility-behavior";
     static constexpr const char* const INDENT = "iidm.export.xml.indent";
     static constexpr const char* const ONLY_MAIN_CC = "iidm.export.xml.only-main-cc";
     static constexpr const char* const THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND = "iidm.export.xml.throw-exception-if-extension-not-found";
     static constexpr const char* const TOPOLOGY_LEVEL = "iidm.export.xml.topology-level";
     static constexpr const char* const VERSION = "iidm.export.xml.version";
     static constexpr const char* const WITH_BRANCH_STATE_VARIABLES = "iidm.export.xml.with-branch-state-variables";
+
+    enum class IidmVersionIncompatibilityBehavior : unsigned char {
+        THROW_EXCEPTION,
+        LOG_ERROR
+    };
 
 public:
     /**
@@ -52,6 +59,21 @@ public:
      */
     ExportOptions(bool withBranchSV, bool indent, bool onlyMainCc, const TopologyLevel& topologyLevel,
                   bool throwExceptionIfExtensionNotFound, const std::string& version);
+
+    /**
+     * Constructor
+     *
+     * @param withBranchSV
+     * @param indent The indentation status
+     * @param onlyMainCc The connected components status
+     * @param topologyLevel The maximum topology level to use
+     * @param throwExceptionIfExtensionNotFound The extension's serializer lookup mode
+     * @param version The expected XIIDM version
+     * @param iidmVersionIncompatibilityBehavior The expected behaviour when an IIDM's version incompatibility occurs
+     */
+    ExportOptions(bool withBranchSV, bool indent, bool onlyMainCc, const TopologyLevel& topologyLevel,
+                  bool throwExceptionIfExtensionNotFound, const std::string& version,
+                  const IidmVersionIncompatibilityBehavior& iidmVersionIncompatibilityBehavior);
 
     /**
      * Constructor
@@ -95,6 +117,13 @@ public:
      * @return the version in which the extension should be exported or an empty string if the extension is not found
      */
     const std::string& getExtensionVersion(const std::string& extensionName) const;
+
+    /**
+     * Return the expecting behaviour if an IIDM's version incompatibility occurs
+     *
+     * @return the expecting behaviour if an IIDM's version incompatibility occurs
+     */
+    const IidmVersionIncompatibilityBehavior& getIidmVersionIncompatibilityBehavior() const;
 
     /**
      * Return the XIIDM version to use
@@ -173,6 +202,15 @@ public:
      * @return this ExportOptions object
      */
     ExportOptions& setExtensions(const std::set<std::string>& extensions);
+
+    /**
+     * Set the expected behaviour if an IIDM's version incompatibility occurs
+     *
+     * @param iidmVersionIncompatibilityBehavior The behaviour if an IIDM's version incompatibility occurs
+     *
+     * @return this ExportOptions object
+     */
+    ExportOptions& setIidmVersionIncompatibilityBehavior(const IidmVersionIncompatibilityBehavior& iidmVersionIncompatibilityBehavior);
 
     /**
      * Enable/disable the indentation of the XML
@@ -255,7 +293,11 @@ private:
     std::map<std::string, std::string> m_extensionsVersions;
 
     std::string m_version;
+
+    IidmVersionIncompatibilityBehavior m_iidmVersionIncompatibilityBehavior = IidmVersionIncompatibilityBehavior::THROW_EXCEPTION;
 };
+
+std::ostream& operator<<(std::ostream& stream, const ExportOptions::IidmVersionIncompatibilityBehavior& value);
 
 }  // namespace converter
 

--- a/include/powsybl/iidm/converter/xml/IidmXmlUtil.hpp
+++ b/include/powsybl/iidm/converter/xml/IidmXmlUtil.hpp
@@ -46,6 +46,19 @@ public:
      *
      * @throw a {@link PowsyblException} if the the context's version is more recent than the maxVersion
      */
+    static void assertMaximumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& maxVersion, const NetworkXmlReaderContext& context);
+
+    /**
+     * Assert that the context's IIDM-XML version equals or is less recent than a given IIDM-XML version
+     *
+     * @param rootElementName the name of the XML root element
+     * @param elementName the name of the XML element
+     * @param errorMessage the type of error message in case of an exception is thrown
+     * @param maxVersion the IIDM-XML version in which the element has been removed
+     * @param context the context
+     *
+     * @throw a {@link PowsyblException} if the the context's version is more recent than the maxVersion
+     */
     static void assertMaximumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& maxVersion, const NetworkXmlWriterContext& context);
 
     /**
@@ -87,6 +100,21 @@ public:
      *
      * @throw a {@link PowsyblException} if the context's version less recent than the minVersion
      */
+    static void assertMinimumVersionIfNotDefault(bool valueIsNotDefault, const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const NetworkXmlReaderContext& context);
+
+    /**
+     * Assert that the context's IIDM-XML version equals or is more recent than a given IIDM-XML version if the value of an attribute or the state of an equipment
+     * is not default (interpretable for previous versions)
+     *
+     * @param valueIsNotDefault assert only if this parameter is true
+     * @param rootElementName the name of the XML root element
+     * @param elementName the name of the XML element
+     * @param errorMessage the type of error message in case of an exception is thrown
+     * @param minVersion the IIDM-XML version in which the element has been added
+     * @param context the context
+     *
+     * @throw a {@link PowsyblException} if the context's version less recent than the minVersion
+     */
     static void assertMinimumVersionIfNotDefault(bool valueIsNotDefault, const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const NetworkXmlWriterContext& context);
 
     /**
@@ -104,7 +132,37 @@ public:
      *
      * @throw a {@link PowsyblException} if the context's version is less recent than the minVersion and valueIsNotDefault is true
      */
+    static void assertMinimumVersionAndRunIfNotDefault(bool valueIsNotDefault, const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const NetworkXmlReaderContext& context, const std::function<void()>& runnable);
+
+    /**
+     * Assert that the context's IIDM-XML version equals or is more recent than a given IIDM-XML version if the value of an attribute or the state of an equipment
+     * is not default (interpretable for previous versions).
+     * If the value is not default and no exception has been thrown, run a given runnable.
+     *
+     * @param valueIsNotDefault assert only if this parameter is true
+     * @param rootElementName the name of the XML root element
+     * @param elementName the name of the XML element
+     * @param errorMessage the type of error message in case of an exception is thrown
+     * @param minVersion the IIDM-XML version in which the element has been added
+     * @param context the context
+     * @param runnable the function to run
+     *
+     * @throw a {@link PowsyblException} if the context's version is less recent than the minVersion and valueIsNotDefault is true
+     */
     static void assertMinimumVersionAndRunIfNotDefault(bool valueIsNotDefault, const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const NetworkXmlWriterContext& context, const std::function<void()>& runnable);
+
+    /**
+     * Assert that the context's IIDM-XML version is strictly older than a given IIDM-XML version.
+     *
+     * @param rootElementName the name of the XML root element
+     * @param elementName the name of the XML element
+     * @param errorMessage the type of error message in case of an exception is thrown
+     * @param maxVersion the IIDM-XML version in which the element has been removed
+     * @param context the context
+     *
+     * @throw a {@link PowsyblException} if the context's version is more recent than or equal to the maxVersion
+     */
+    static void assertStrictMaximumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& maxVersion, const NetworkXmlReaderContext& context);
 
     /**
      * Assert that the context's IIDM-XML version is strictly older than a given IIDM-XML version.
@@ -207,11 +265,6 @@ public:
 
 private:
     static void writeAttributeFromMinimumVersion(const std::string& rootElementName, const std::string& attributeName, bool isNotDefaultValue, const char* errorMessage, const IidmXmlVersion& minVersion, const NetworkXmlWriterContext& context, const std::function<void()>& write);
-
-private:
-    static constexpr const char* const MAXIMUM_REASON = "IIDM-XML version should be <= ";
-
-    static constexpr const char* const MINIMUM_REASON = "IIDM-XML version should be >= ";
 };
 
 }  // namespace xml

--- a/include/powsybl/iidm/converter/xml/IidmXmlUtil.hpp
+++ b/include/powsybl/iidm/converter/xml/IidmXmlUtil.hpp
@@ -21,6 +21,7 @@ namespace converter {
 
 namespace xml {
 
+class NetworkXmlReaderContext;
 class NetworkXmlWriterContext;
 
 namespace ErrorMessage {
@@ -41,11 +42,11 @@ public:
      * @param elementName the name of the XML element
      * @param errorMessage the type of error message in case of an exception is thrown
      * @param maxVersion the IIDM-XML version in which the element has been removed
-     * @param contextVersion the context's IIDM-XML version
+     * @param context the context
      *
      * @throw a {@link PowsyblException} if the the context's version is more recent than the maxVersion
      */
-    static void assertMaximumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& maxVersion, const IidmXmlVersion& contextVersion);
+    static void assertMaximumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& maxVersion, const NetworkXmlWriterContext& context);
 
     /**
      * Assert that the context's IIDM-XML version equals or is more recent than a given IIDM-XML version
@@ -54,11 +55,24 @@ public:
      * @param elementName the name of the XML element
      * @param errorMessage the type of error message in case of an exception is thrown
      * @param minVersion the IIDM-XML version in which the element has been added
-     * @param contextVersion the context's IIDM-XML version
+     * @param context the context
      *
      * @throw a {@link PowsyblException} if the context's version less recent than the minVersion
      */
-    static void assertMinimumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const IidmXmlVersion& contextVersion);
+    static void assertMinimumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const NetworkXmlReaderContext& context);
+
+    /**
+     * Assert that the context's IIDM-XML version equals or is more recent than a given IIDM-XML version
+     *
+     * @param rootElementName the name of the XML root element
+     * @param elementName the name of the XML element
+     * @param errorMessage the type of error message in case of an exception is thrown
+     * @param minVersion the IIDM-XML version in which the element has been added
+     * @param context the context
+     *
+     * @throw a {@link PowsyblException} if the context's version less recent than the minVersion
+     */
+    static void assertMinimumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const NetworkXmlWriterContext& context);
 
     /**
      * Assert that the context's IIDM-XML version equals or is more recent than a given IIDM-XML version if the value of an attribute or the state of an equipment
@@ -69,11 +83,11 @@ public:
      * @param elementName the name of the XML element
      * @param errorMessage the type of error message in case of an exception is thrown
      * @param minVersion the IIDM-XML version in which the element has been added
-     * @param contextVersion the context's IIDM-XML version
+     * @param context the context
      *
      * @throw a {@link PowsyblException} if the context's version less recent than the minVersion
      */
-    static void assertMinimumVersionIfNotDefault(bool valueIsNotDefault, const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const IidmXmlVersion& contextVersion);
+    static void assertMinimumVersionIfNotDefault(bool valueIsNotDefault, const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const NetworkXmlWriterContext& context);
 
     /**
      * Assert that the context's IIDM-XML version equals or is more recent than a given IIDM-XML version if the value of an attribute or the state of an equipment
@@ -85,12 +99,12 @@ public:
      * @param elementName the name of the XML element
      * @param errorMessage the type of error message in case of an exception is thrown
      * @param minVersion the IIDM-XML version in which the element has been added
-     * @param contextVersion the context's IIDM-XML version
+     * @param context the context
      * @param runnable the function to run
      *
      * @throw a {@link PowsyblException} if the context's version is less recent than the minVersion and valueIsNotDefault is true
      */
-    static void assertMinimumVersionAndRunIfNotDefault(bool valueIsNotDefault, const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const IidmXmlVersion& contextVersion, const std::function<void()>& runnable);
+    static void assertMinimumVersionAndRunIfNotDefault(bool valueIsNotDefault, const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& minVersion, const NetworkXmlWriterContext& context, const std::function<void()>& runnable);
 
     /**
      * Assert that the context's IIDM-XML version is strictly older than a given IIDM-XML version.
@@ -99,11 +113,11 @@ public:
      * @param elementName the name of the XML element
      * @param errorMessage the type of error message in case of an exception is thrown
      * @param maxVersion the IIDM-XML version in which the element has been removed
-     * @param contextVersion the context's IIDM-XML version
+     * @param context the context
      *
      * @throw a {@link PowsyblException} if the context's version is more recent than or equal to the maxVersion
      */
-    static void assertStrictMaximumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& maxVersion, const IidmXmlVersion& contextVersion);
+    static void assertStrictMaximumVersion(const std::string& rootElementName, const std::string& elementName, const char* errorMessage, const IidmXmlVersion& maxVersion, const NetworkXmlWriterContext& context);
 
     /**
      * Run a given runnable if the context's IIDM-XML version equals or is more recent than a given minimum IIDM-XML version
@@ -192,7 +206,12 @@ public:
     IidmXmlUtil() = delete;
 
 private:
-    static void writeAttributeFromMinimumVersion(const std::string& rootElementName, const std::string& attributeName, bool isNotDefaultValue, const char* errorMessage, const IidmXmlVersion& minVersion, const IidmXmlVersion& contextVersion, const std::function<void()>& write);
+    static void writeAttributeFromMinimumVersion(const std::string& rootElementName, const std::string& attributeName, bool isNotDefaultValue, const char* errorMessage, const IidmXmlVersion& minVersion, const NetworkXmlWriterContext& context, const std::function<void()>& write);
+
+private:
+    static constexpr const char* const MAXIMUM_REASON = "IIDM-XML version should be <= ";
+
+    static constexpr const char* const MINIMUM_REASON = "IIDM-XML version should be >= ";
 };
 
 }  // namespace xml

--- a/src/iidm/converter/ExportOptions.cpp
+++ b/src/iidm/converter/ExportOptions.cpp
@@ -52,11 +52,6 @@ std::ostream& operator<<(std::ostream& stream, const ExportOptions::IidmVersionI
 }
 
 ExportOptions::ExportOptions(bool withBranchSV, bool indent, bool onlyMainCc, const TopologyLevel& topologyLevel,
-                             bool throwExceptionIfExtensionNotFound, const std::string& version) :
-    ExportOptions(withBranchSV, indent, onlyMainCc, topologyLevel, throwExceptionIfExtensionNotFound, version, IidmVersionIncompatibilityBehavior::THROW_EXCEPTION) {
-}
-
-ExportOptions::ExportOptions(bool withBranchSV, bool indent, bool onlyMainCc, const TopologyLevel& topologyLevel,
                              bool throwExceptionIfExtensionNotFound, const std::string& version,
                              const IidmVersionIncompatibilityBehavior& iidmVersionIncompatibilityBehavior) :
     m_indent(indent),

--- a/src/iidm/converter/ExportOptions.cpp
+++ b/src/iidm/converter/ExportOptions.cpp
@@ -21,26 +21,51 @@ namespace powsybl {
 
 namespace iidm {
 
+namespace Enum {
+
+template <>
+const std::initializer_list<std::string>& getNames<converter::ExportOptions::IidmVersionIncompatibilityBehavior>() {
+    static std::initializer_list<std::string> s_names {
+        "THROW_EXCEPTION",
+        "LOG_ERROR"
+    };
+    return s_names;
+}
+
+}  // namespace Enum
+
 namespace converter {
 
 static const Parameter ANONYMISED_PARAMETER(ExportOptions::ANONYMISED, Parameter::Type::BOOLEAN, "Anonymize exported network", "false");
 static const Parameter EXTENSIONS_LIST_PARAMETER(ExportOptions::EXTENSIONS_LIST, Parameter::Type::STRING_LIST, "The list of exported extensions", "");
+static const Parameter IIDM_VERSION_INCOMPATIBILITY_BEHAVIOR_PARAMETER (ExportOptions::IIDM_VERSION_INCOMPATIBILITY_BEHAVIOR, Parameter::Type::STRING, "Behavior when there is an IIDM version incompatibility", "THROW_EXCEPTION");
 static const Parameter INDENT_PARAMETER(ExportOptions::INDENT, Parameter::Type::BOOLEAN, "Indent export output file", "true");
 static const Parameter ONLY_MAIN_CC_PARAMETER(ExportOptions::ONLY_MAIN_CC, Parameter::Type::BOOLEAN, "Export only main CC", "false");
-static const Parameter THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER = Parameter(ExportOptions::THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND, Parameter::Type::BOOLEAN, "Throw exception if extension not found", "false")
-    .addAdditionalNames({"throwExceptionIfExtensionNotFound"});
+static const Parameter THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER = Parameter(ExportOptions::THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND, Parameter::Type::BOOLEAN, "Throw exception if extension not found", "false").addAdditionalNames({"throwExceptionIfExtensionNotFound"});
 static const Parameter TOPOLOGY_LEVEL_PARAMETER(ExportOptions::TOPOLOGY_LEVEL, Parameter::Type::STRING, "Export network in this topology level", "NODE_BREAKER");
 static const Parameter VERSION_PARAMETER(ExportOptions::VERSION, Parameter::Type::STRING, "IIDM-XML version in which files will be generated", xml::IidmXmlVersion::CURRENT_IIDM_XML_VERSION().toString("."));
 static const Parameter WITH_BRANCH_STATE_VARIABLES_PARAMETER(ExportOptions::WITH_BRANCH_STATE_VARIABLES, Parameter::Type::BOOLEAN, "Export network with branch state variables", "true");
 
+std::ostream& operator<<(std::ostream& stream, const ExportOptions::IidmVersionIncompatibilityBehavior& value) {
+    stream << iidm::Enum::toString(value);
+    return stream;
+}
+
 ExportOptions::ExportOptions(bool withBranchSV, bool indent, bool onlyMainCc, const TopologyLevel& topologyLevel,
                              bool throwExceptionIfExtensionNotFound, const std::string& version) :
+    ExportOptions(withBranchSV, indent, onlyMainCc, topologyLevel, throwExceptionIfExtensionNotFound, version, IidmVersionIncompatibilityBehavior::THROW_EXCEPTION) {
+}
+
+ExportOptions::ExportOptions(bool withBranchSV, bool indent, bool onlyMainCc, const TopologyLevel& topologyLevel,
+                             bool throwExceptionIfExtensionNotFound, const std::string& version,
+                             const IidmVersionIncompatibilityBehavior& iidmVersionIncompatibilityBehavior) :
     m_indent(indent),
     m_onlyMainCc(onlyMainCc),
     m_throwExceptionIfExtensionNotFound(throwExceptionIfExtensionNotFound),
     m_topologyLevel(topologyLevel),
     m_withBranchSV(withBranchSV),
-    m_version(version) {
+    m_version(version),
+    m_iidmVersionIncompatibilityBehavior(iidmVersionIncompatibilityBehavior) {
 }
 
 ExportOptions::ExportOptions(const stdcxx::Properties& parameters) :
@@ -51,7 +76,8 @@ ExportOptions::ExportOptions(const stdcxx::Properties& parameters) :
     m_topologyLevel(Enum::fromString<TopologyLevel>(ConversionParameters::readStringParameter(parameters, TOPOLOGY_LEVEL_PARAMETER))),
     m_withBranchSV(ConversionParameters::readBooleanParameter(parameters, WITH_BRANCH_STATE_VARIABLES_PARAMETER)),
     m_extensions(stdcxx::toSet(ConversionParameters::readStringListParameter(parameters, EXTENSIONS_LIST_PARAMETER))),
-    m_version(ConversionParameters::readStringParameter(parameters, VERSION_PARAMETER)) {
+    m_version(ConversionParameters::readStringParameter(parameters, VERSION_PARAMETER)),
+    m_iidmVersionIncompatibilityBehavior(Enum::fromString<IidmVersionIncompatibilityBehavior>(ConversionParameters::readStringParameter(parameters, IIDM_VERSION_INCOMPATIBILITY_BEHAVIOR_PARAMETER))) {
 }
 
 ExportOptions& ExportOptions::addExtension(const std::string& extension) {
@@ -79,6 +105,11 @@ const std::string& ExportOptions::getExtensionVersion(const std::string& extensi
 
     return it == m_extensionsVersions.end() ? s_noVersion : it->second;
 }
+
+const ExportOptions::IidmVersionIncompatibilityBehavior& ExportOptions::getIidmVersionIncompatibilityBehavior() const {
+    return m_iidmVersionIncompatibilityBehavior;
+}
+
 
 const std::string& ExportOptions::getVersion() const {
     return m_version;
@@ -127,6 +158,11 @@ ExportOptions& ExportOptions::setAnonymized(bool anonymized) {
 
 ExportOptions& ExportOptions::setExtensions(const std::set<std::string>& extensions) {
     m_extensions = extensions;
+    return *this;
+}
+
+ExportOptions& ExportOptions::setIidmVersionIncompatibilityBehavior(const IidmVersionIncompatibilityBehavior& iidmVersionIncompatibilityBehavior) {
+    m_iidmVersionIncompatibilityBehavior = iidmVersionIncompatibilityBehavior;
     return *this;
 }
 

--- a/src/iidm/converter/xml/StaticVarCompensatorXml.cpp
+++ b/src/iidm/converter/xml/StaticVarCompensatorXml.cpp
@@ -56,7 +56,7 @@ StaticVarCompensator& StaticVarCompensatorXml::readRootElementAttributes(StaticV
 void StaticVarCompensatorXml::readSubElements(StaticVarCompensator& svc, NetworkXmlReaderContext& context) const {
     context.getReader().readUntilEndElement(STATIC_VAR_COMPENSATOR, [this, &svc, &context]() {
         if (context.getReader().getLocalName() == REGULATING_TERMINAL) {
-            IidmXmlUtil::assertMinimumVersion(STATIC_VAR_COMPENSATOR, REGULATING_TERMINAL, xml::ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context.getVersion());
+            IidmXmlUtil::assertMinimumVersion(STATIC_VAR_COMPENSATOR, REGULATING_TERMINAL, xml::ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context);
             const std::string& id = context.getAnonymizer().deanonymizeString(context.getReader().getAttributeValue(ID));
             const std::string& side = context.getReader().getOptionalAttributeValue(SIDE, "");
             context.addEndTask([id, side, &svc]() {
@@ -82,7 +82,7 @@ void StaticVarCompensatorXml::writeRootElementAttributes(const StaticVarCompensa
 
 void StaticVarCompensatorXml::writeSubElements(const StaticVarCompensator& svc, const VoltageLevel& /*voltageLevel*/, NetworkXmlWriterContext& context) const {
     IidmXmlUtil::assertMinimumVersionAndRunIfNotDefault(!stdcxx::areSame(svc, svc.getRegulatingTerminal().getConnectable().get()),
-        STATIC_VAR_COMPENSATOR, REGULATING_TERMINAL, ErrorMessage::NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion::V1_1(), context.getVersion(), [&svc, &context]() {
+        STATIC_VAR_COMPENSATOR, REGULATING_TERMINAL, ErrorMessage::NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion::V1_1(), context, [&svc, &context]() {
         TerminalRefXml::writeTerminalRef(svc.getRegulatingTerminal(), context, REGULATING_TERMINAL);
     });
 }

--- a/src/iidm/converter/xml/ThreeWindingsTransformerXml.cpp
+++ b/src/iidm/converter/xml/ThreeWindingsTransformerXml.cpp
@@ -107,20 +107,20 @@ void ThreeWindingsTransformerXml::readSubElements(ThreeWindingsTransformer& twt,
             CurrentLimitsAdder<const std::nullptr_t, ThreeWindingsTransformer::Leg> adder = twt.getLeg3().newCurrentLimits();
             readCurrentLimits(adder, context.getReader(), 3);
         } else if (context.getReader().getLocalName() == RATIO_TAP_CHANGER1) {
-            IidmXmlUtil::assertMinimumVersion(THREE_WINDINGS_TRANSFORMER, RATIO_TAP_CHANGER1, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context.getVersion());
+            IidmXmlUtil::assertMinimumVersion(THREE_WINDINGS_TRANSFORMER, RATIO_TAP_CHANGER1, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context);
             readRatioTapChanger(1, twt.getLeg1(), context);
         } else if (context.getReader().getLocalName() == PHASE_TAP_CHANGER1) {
-            IidmXmlUtil::assertMinimumVersion(THREE_WINDINGS_TRANSFORMER, PHASE_TAP_CHANGER1, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context.getVersion());
+            IidmXmlUtil::assertMinimumVersion(THREE_WINDINGS_TRANSFORMER, PHASE_TAP_CHANGER1, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context);
             readPhaseTapChanger(1, twt.getLeg1(), context);
         } else if (context.getReader().getLocalName() == RATIO_TAP_CHANGER2) {
             readRatioTapChanger(2, twt.getLeg2(), context);
         } else if (context.getReader().getLocalName() == PHASE_TAP_CHANGER2) {
-            IidmXmlUtil::assertMinimumVersion(THREE_WINDINGS_TRANSFORMER, PHASE_TAP_CHANGER2, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context.getVersion());
+            IidmXmlUtil::assertMinimumVersion(THREE_WINDINGS_TRANSFORMER, PHASE_TAP_CHANGER2, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context);
             readPhaseTapChanger(2, twt.getLeg2(), context);
         } else if (context.getReader().getLocalName() == RATIO_TAP_CHANGER3) {
             readRatioTapChanger(3, twt.getLeg3(), context);
         } else if (context.getReader().getLocalName() == PHASE_TAP_CHANGER3) {
-            IidmXmlUtil::assertMinimumVersion(THREE_WINDINGS_TRANSFORMER, PHASE_TAP_CHANGER3, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context.getVersion());
+            IidmXmlUtil::assertMinimumVersion(THREE_WINDINGS_TRANSFORMER, PHASE_TAP_CHANGER3, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context);
             readPhaseTapChanger(3, twt.getLeg3(), context);
         } else {
             AbstractIdentifiableXml::readSubElements(twt, context);
@@ -177,18 +177,18 @@ void ThreeWindingsTransformerXml::writeRootElementAttributes(const ThreeWindings
 
 void ThreeWindingsTransformerXml::writeSubElements(const ThreeWindingsTransformer& twt, const Substation& /*substation*/, NetworkXmlWriterContext& context) const {
     IidmXmlUtil::assertMinimumVersionIfNotDefault(twt.getLeg1().hasRatioTapChanger(), THREE_WINDINGS_TRANSFORMER, RATIO_TAP_CHANGER1,
-        ErrorMessage::NOT_NULL_NOT_SUPPORTED, IidmXmlVersion::V1_1(), context.getVersion());
+        ErrorMessage::NOT_NULL_NOT_SUPPORTED, IidmXmlVersion::V1_1(), context);
     writeRatioTapChanger(twt.getLeg1().getOptionalRatioTapChanger(), 1, context);
     IidmXmlUtil::assertMinimumVersionIfNotDefault(twt.getLeg1().hasPhaseTapChanger(), THREE_WINDINGS_TRANSFORMER, PHASE_TAP_CHANGER1,
-        ErrorMessage::NOT_NULL_NOT_SUPPORTED, IidmXmlVersion::V1_1(), context.getVersion());
+        ErrorMessage::NOT_NULL_NOT_SUPPORTED, IidmXmlVersion::V1_1(), context);
     writePhaseTapChanger(twt.getLeg1().getOptionalPhaseTapChanger(), 1, context);
     writeRatioTapChanger(twt.getLeg2().getOptionalRatioTapChanger(), 2, context);
     IidmXmlUtil::assertMinimumVersionIfNotDefault(twt.getLeg2().hasPhaseTapChanger(), THREE_WINDINGS_TRANSFORMER, PHASE_TAP_CHANGER2,
-        ErrorMessage::NOT_NULL_NOT_SUPPORTED, IidmXmlVersion::V1_1(), context.getVersion());
+        ErrorMessage::NOT_NULL_NOT_SUPPORTED, IidmXmlVersion::V1_1(), context);
     writePhaseTapChanger(twt.getLeg2().getOptionalPhaseTapChanger(), 2, context);
     writeRatioTapChanger(twt.getLeg3().getOptionalRatioTapChanger(), 3, context);
     IidmXmlUtil::assertMinimumVersionIfNotDefault(twt.getLeg3().hasPhaseTapChanger(), THREE_WINDINGS_TRANSFORMER, PHASE_TAP_CHANGER3,
-        ErrorMessage::NOT_NULL_NOT_SUPPORTED, IidmXmlVersion::V1_1(), context.getVersion());
+        ErrorMessage::NOT_NULL_NOT_SUPPORTED, IidmXmlVersion::V1_1(), context);
     writePhaseTapChanger(twt.getLeg3().getOptionalPhaseTapChanger(), 3, context);
 
     if (twt.getLeg1().getCurrentLimits()) {

--- a/src/iidm/converter/xml/VoltageLevelXml.cpp
+++ b/src/iidm/converter/xml/VoltageLevelXml.cpp
@@ -71,7 +71,7 @@ void VoltageLevelXml::readBusBreakerTopology(VoltageLevel& voltageLevel, Network
 }
 
 void VoltageLevelXml::readCalculatedBus(VoltageLevel &voltageLevel, NetworkXmlReaderContext& context) const {
-    IidmXmlUtil::assertMinimumVersion(VOLTAGE_LEVEL, BUS, xml::ErrorMessage::NOT_SUPPORTED, xml::IidmXmlVersion::V1_1(), context.getVersion());
+    IidmXmlUtil::assertMinimumVersion(VOLTAGE_LEVEL, BUS, xml::ErrorMessage::NOT_SUPPORTED, xml::IidmXmlVersion::V1_1(), context);
     double v = context.getReader().getOptionalAttributeValue(V, stdcxx::nan());
     double angle = context.getReader().getOptionalAttributeValue(ANGLE, stdcxx::nan());
     const std::string& strNodes = context.getReader().getAttributeValue(NODES);

--- a/test/iidm/converter/ExportOptionsTest.cpp
+++ b/test/iidm/converter/ExportOptionsTest.cpp
@@ -69,20 +69,6 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_CHECK(options.isWithBranchSV());
     BOOST_TEST("V1.0", options.getVersion());
     BOOST_CHECK_EQUAL(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION, options.getIidmVersionIncompatibilityBehavior());
-
-    ExportOptions options2(true,  // withBranchSV
-                          false,  // indent
-                          true,  // onlyMainCc
-                          TopologyLevel::BUS_BREAKER,  // topologyLevel
-                          true,  // throwExceptionIfExtensionNotFound
-                          "V1.0");
-    BOOST_CHECK(!options2.isIndent());
-    BOOST_CHECK(options2.isOnlyMainCc());
-    BOOST_CHECK(options2.isThrowExceptionIfExtensionNotFound());
-    BOOST_CHECK_EQUAL(TopologyLevel::BUS_BREAKER, options2.getTopologyLevel());
-    BOOST_CHECK(options2.isWithBranchSV());
-    BOOST_TEST("V1.0", options2.getVersion());
-    BOOST_CHECK_EQUAL(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION, options2.getIidmVersionIncompatibilityBehavior());
 }
 
 BOOST_AUTO_TEST_CASE(initFromProperties) {

--- a/test/iidm/converter/ExportOptionsTest.cpp
+++ b/test/iidm/converter/ExportOptionsTest.cpp
@@ -59,19 +59,30 @@ BOOST_AUTO_TEST_CASE(constructor) {
                           true,  // onlyMainCc
                           TopologyLevel::BUS_BREAKER,  // topologyLevel
                           true,  // throwExceptionIfExtensionNotFound
-                          "V1.0");
+                          "V1.0",
+                          ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION);
 
     BOOST_CHECK(!options.isIndent());
-
     BOOST_CHECK(options.isOnlyMainCc());
-
     BOOST_CHECK(options.isThrowExceptionIfExtensionNotFound());
-
     BOOST_CHECK_EQUAL(static_cast<int>(TopologyLevel::BUS_BREAKER), static_cast<int>(options.getTopologyLevel()));
-
     BOOST_CHECK(options.isWithBranchSV());
-
     BOOST_TEST("V1.0", options.getVersion());
+    BOOST_CHECK_EQUAL(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION, options.getIidmVersionIncompatibilityBehavior());
+
+    ExportOptions options2(true,  // withBranchSV
+                          false,  // indent
+                          true,  // onlyMainCc
+                          TopologyLevel::BUS_BREAKER,  // topologyLevel
+                          true,  // throwExceptionIfExtensionNotFound
+                          "V1.0");
+    BOOST_CHECK(!options2.isIndent());
+    BOOST_CHECK(options2.isOnlyMainCc());
+    BOOST_CHECK(options2.isThrowExceptionIfExtensionNotFound());
+    BOOST_CHECK_EQUAL(TopologyLevel::BUS_BREAKER, options2.getTopologyLevel());
+    BOOST_CHECK(options2.isWithBranchSV());
+    BOOST_TEST("V1.0", options2.getVersion());
+    BOOST_CHECK_EQUAL(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION, options2.getIidmVersionIncompatibilityBehavior());
 }
 
 BOOST_AUTO_TEST_CASE(initFromProperties) {
@@ -84,6 +95,7 @@ BOOST_AUTO_TEST_CASE(initFromProperties) {
     properties.set(ExportOptions::WITH_BRANCH_STATE_VARIABLES, "true");
     properties.set(ExportOptions::EXTENSIONS_LIST, "");
     properties.set(ExportOptions::VERSION, "1.0");
+    properties.set(ExportOptions::IIDM_VERSION_INCOMPATIBILITY_BEHAVIOR, "LOG_ERROR");
 
     ExportOptions options(properties);
 
@@ -96,6 +108,7 @@ BOOST_AUTO_TEST_CASE(initFromProperties) {
     BOOST_CHECK(!options.withExtension("abc"));
     BOOST_CHECK(!options.withExtension("def"));
     BOOST_CHECK_EQUAL("1.0", options.getVersion());
+    BOOST_CHECK_EQUAL(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR, options.getIidmVersionIncompatibilityBehavior());
 }
 
 BOOST_AUTO_TEST_CASE(checkAllExtensions) {

--- a/test/iidm/converter/xml/CMakeLists.txt
+++ b/test/iidm/converter/xml/CMakeLists.txt
@@ -24,6 +24,7 @@ set(UNIT_TEST_SOURCES
     EurostagTest.cpp
     FictitiousSwitchTest.cpp
     IdentifiableExtensionXmlSerializerTest.cpp
+    IidmXmlUtilTest.cpp
     InternalConnectionsRoundTripTest.cpp
     LinesRoundTripTest.cpp
     LccRoundTripRef.cpp

--- a/test/iidm/converter/xml/IidmXmlUtilTest.cpp
+++ b/test/iidm/converter/xml/IidmXmlUtilTest.cpp
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <sstream>
+
+#include <boost/test/unit_test.hpp>
+
+#include <powsybl/iidm/Network.hpp>
+#include <powsybl/iidm/converter/FakeAnonymizer.hpp>
+#include <powsybl/iidm/converter/xml/IidmXmlUtil.hpp>
+#include <powsybl/iidm/converter/xml/NetworkXmlReaderContext.hpp>
+#include <powsybl/iidm/converter/xml/NetworkXmlWriterContext.hpp>
+#include <powsybl/test/AssertionUtils.hpp>
+#include <powsybl/xml/XmlStreamReader.hpp>
+#include <powsybl/xml/XmlStreamWriter.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+namespace converter {
+
+namespace xml {
+
+BOOST_AUTO_TEST_SUITE(IidmXmlUtilTestSuite)
+
+static constexpr const char* const ELEMENT = "element";
+static constexpr const char* const ROOT = "root";
+
+BOOST_AUTO_TEST_CASE(testWriteMaximumVersion) {
+    std::stringstream ss;
+    FakeAnonymizer anonymizer;
+    powsybl::xml::XmlStreamWriter writer(ss, true);
+    ExportOptions options = ExportOptions().setVersion("1.1");
+    Network network("test", "test");
+    BusFilter busFilter = BusFilter::create(network, options);
+
+    NetworkXmlWriterContext contextThrow(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION), busFilter, IidmXmlVersion::V1_1());
+    POWSYBL_ASSERT_THROW(IidmXmlUtil::assertMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), contextThrow), PowsyblException, "root.element is not supported for IIDM-XML version 1.1. IIDM-XML version should be <= 1.0");
+
+    NetworkXmlWriterContext contextLog(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR), busFilter, IidmXmlVersion::V1_1());
+    BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), contextLog));
+}
+
+BOOST_AUTO_TEST_CASE(testWriteStrictMaximumVersion) {
+    std::stringstream ss;
+    FakeAnonymizer anonymizer;
+    powsybl::xml::XmlStreamWriter writer(ss, true);
+    ExportOptions options = ExportOptions().setVersion("1.1");
+    Network network("test", "test");
+    BusFilter busFilter = BusFilter::create(network, options);
+
+    NetworkXmlWriterContext contextThrow(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION), busFilter, IidmXmlVersion::V1_1());
+    POWSYBL_ASSERT_THROW(IidmXmlUtil::assertStrictMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), contextThrow), PowsyblException, "root.element is not supported for IIDM-XML version 1.1. IIDM-XML version should be < 1.0");
+
+    NetworkXmlWriterContext contextLog(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR), busFilter, IidmXmlVersion::V1_1());
+    BOOST_CHECK_NO_THROW(IidmXmlUtil::assertStrictMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), contextLog));
+}
+
+BOOST_AUTO_TEST_CASE(testWriteMinimumVersion) {
+    std::stringstream ss;
+    FakeAnonymizer anonymizer;
+    powsybl::xml::XmlStreamWriter writer(ss, true);
+    ExportOptions options = ExportOptions().setVersion("1.0");
+    Network network("test", "test");
+    BusFilter busFilter = BusFilter::create(network, options);
+
+    NetworkXmlWriterContext contextThrow(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION), busFilter, IidmXmlVersion::V1_0());
+    POWSYBL_ASSERT_THROW(IidmXmlUtil::assertMinimumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextThrow), PowsyblException, "root.element is not supported for IIDM-XML version 1.0. IIDM-XML version should be >= 1.1");
+
+    NetworkXmlWriterContext contextLog(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR), busFilter, IidmXmlVersion::V1_0());
+    BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMinimumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextLog));
+}
+
+BOOST_AUTO_TEST_CASE(testWriteMinimumVersionIfNotDefault) {
+    std::stringstream ss;
+    FakeAnonymizer anonymizer;
+    powsybl::xml::XmlStreamWriter writer(ss, true);
+    ExportOptions options = ExportOptions().setVersion("1.0");
+    Network network("test", "test");
+    BusFilter busFilter = BusFilter::create(network, options);
+
+    NetworkXmlWriterContext contextThrow(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION), busFilter, IidmXmlVersion::V1_0());
+    POWSYBL_ASSERT_THROW(IidmXmlUtil::assertMinimumVersionIfNotDefault(true, ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextThrow), PowsyblException, "root.element is not supported for IIDM-XML version 1.0. IIDM-XML version should be >= 1.1");
+
+    NetworkXmlWriterContext contextLog(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR), busFilter, IidmXmlVersion::V1_0());
+    BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMinimumVersionIfNotDefault(true, ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextLog));
+}
+
+BOOST_AUTO_TEST_CASE(testWriteMinimumVersionAndRunIfNotDefault) {
+    std::stringstream ss;
+    FakeAnonymizer anonymizer;
+    powsybl::xml::XmlStreamWriter writer(ss, true);
+    ExportOptions options = ExportOptions().setVersion("1.0");
+    Network network("test", "test");
+    BusFilter busFilter = BusFilter::create(network, options);
+
+    NetworkXmlWriterContext contextThrow(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION), busFilter, IidmXmlVersion::V1_0());
+    POWSYBL_ASSERT_THROW(IidmXmlUtil::assertMinimumVersionAndRunIfNotDefault(true, ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextThrow, [](){}), PowsyblException, "root.element is not supported for IIDM-XML version 1.0. IIDM-XML version should be >= 1.1");
+
+    NetworkXmlWriterContext contextLog(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR), busFilter, IidmXmlVersion::V1_0());
+    BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMinimumVersionAndRunIfNotDefault(true, ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextLog, [](){}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace xml
+
+}  // namespace converter
+
+}  // namespace iidm
+
+}  // namespace powsybl

--- a/test/iidm/converter/xml/IidmXmlUtilTest.cpp
+++ b/test/iidm/converter/xml/IidmXmlUtilTest.cpp
@@ -37,10 +37,8 @@ const std::string& networkStr = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 BOOST_AUTO_TEST_CASE(testReadMaximumVersion) {
     std::stringstream ss;
     ss << networkStr;
-    FakeAnonymizer anonymizer;
     powsybl::xml::XmlStreamReader reader(ss);
-    ImportOptions options;
-    NetworkXmlReaderContext context(anonymizer, reader, options, IidmXmlVersion::V1_1());
+    NetworkXmlReaderContext context(FakeAnonymizer(), reader, ImportOptions(), IidmXmlVersion::V1_1());
 
     POWSYBL_ASSERT_THROW(IidmXmlUtil::assertMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), context), PowsyblException, "root.element is not supported for IIDM-XML version 1.1. IIDM-XML version should be <= 1.0");
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context));
@@ -55,20 +53,20 @@ BOOST_AUTO_TEST_CASE(testWriteMaximumVersion) {
     Network network("test", "test");
     BusFilter busFilter = BusFilter::create(network, options);
 
-    NetworkXmlWriterContext contextThrow(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION), busFilter, IidmXmlVersion::V1_1());
+    options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION);
+    NetworkXmlWriterContext contextThrow(anonymizer, writer, options, busFilter, IidmXmlVersion::V1_1());
     POWSYBL_ASSERT_THROW(IidmXmlUtil::assertMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), contextThrow), PowsyblException, "root.element is not supported for IIDM-XML version 1.1. IIDM-XML version should be <= 1.0");
 
-    NetworkXmlWriterContext contextLog(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR), busFilter, IidmXmlVersion::V1_1());
+    options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR);
+    NetworkXmlWriterContext contextLog(anonymizer, writer, options, busFilter, IidmXmlVersion::V1_1());
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), contextLog));
 }
 
 BOOST_AUTO_TEST_CASE(testReadStrictMaximumVersion) {
     std::stringstream ss;
     ss << networkStr;
-    FakeAnonymizer anonymizer;
     powsybl::xml::XmlStreamReader reader(ss);
-    ImportOptions options;
-    NetworkXmlReaderContext context(anonymizer, reader, options, IidmXmlVersion::V1_1());
+    NetworkXmlReaderContext context(FakeAnonymizer(), reader, ImportOptions(), IidmXmlVersion::V1_1());
 
     POWSYBL_ASSERT_THROW(IidmXmlUtil::assertStrictMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context), PowsyblException, "root.element is not supported for IIDM-XML version 1.1. IIDM-XML version should be < 1.1");
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertStrictMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_2(), context));
@@ -82,20 +80,20 @@ BOOST_AUTO_TEST_CASE(testWriteStrictMaximumVersion) {
     Network network("test", "test");
     BusFilter busFilter = BusFilter::create(network, options);
 
-    NetworkXmlWriterContext contextThrow(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION), busFilter, IidmXmlVersion::V1_1());
+    options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION);
+    NetworkXmlWriterContext contextThrow(anonymizer, writer, options, busFilter, IidmXmlVersion::V1_1());
     POWSYBL_ASSERT_THROW(IidmXmlUtil::assertStrictMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), contextThrow), PowsyblException, "root.element is not supported for IIDM-XML version 1.1. IIDM-XML version should be < 1.0");
 
-    NetworkXmlWriterContext contextLog(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR), busFilter, IidmXmlVersion::V1_1());
+    options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR);
+    NetworkXmlWriterContext contextLog(anonymizer, writer, options, busFilter, IidmXmlVersion::V1_1());
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertStrictMaximumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), contextLog));
 }
 
 BOOST_AUTO_TEST_CASE(testReadMinimumVersion) {
     std::stringstream ss;
     ss << networkStr;
-    FakeAnonymizer anonymizer;
     powsybl::xml::XmlStreamReader reader(ss);
-    ImportOptions options;
-    NetworkXmlReaderContext context(anonymizer, reader, options, IidmXmlVersion::V1_1());
+    NetworkXmlReaderContext context(FakeAnonymizer(), reader, ImportOptions(), IidmXmlVersion::V1_1());
 
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMinimumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), context));
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMinimumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context));
@@ -110,20 +108,20 @@ BOOST_AUTO_TEST_CASE(testWriteMinimumVersion) {
     Network network("test", "test");
     BusFilter busFilter = BusFilter::create(network, options);
 
-    NetworkXmlWriterContext contextThrow(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION), busFilter, IidmXmlVersion::V1_0());
+    options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION);
+    NetworkXmlWriterContext contextThrow(anonymizer, writer, options, busFilter, IidmXmlVersion::V1_0());
     POWSYBL_ASSERT_THROW(IidmXmlUtil::assertMinimumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextThrow), PowsyblException, "root.element is not supported for IIDM-XML version 1.0. IIDM-XML version should be >= 1.1");
 
-    NetworkXmlWriterContext contextLog(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR), busFilter, IidmXmlVersion::V1_0());
+    options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR);
+    NetworkXmlWriterContext contextLog(anonymizer, writer, options, busFilter, IidmXmlVersion::V1_0());
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMinimumVersion(ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextLog));
 }
 
 BOOST_AUTO_TEST_CASE(testReadMinimumVersionIfNotDefault) {
     std::stringstream ss;
     ss << networkStr;
-    FakeAnonymizer anonymizer;
     powsybl::xml::XmlStreamReader reader(ss);
-    ImportOptions options;
-    NetworkXmlReaderContext context(anonymizer, reader, options, IidmXmlVersion::V1_1());
+    NetworkXmlReaderContext context(FakeAnonymizer(), reader, ImportOptions(), IidmXmlVersion::V1_1());
 
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMinimumVersionIfNotDefault(true, ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_0(), context));
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMinimumVersionIfNotDefault(true, ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), context));
@@ -141,10 +139,12 @@ BOOST_AUTO_TEST_CASE(testWriteMinimumVersionIfNotDefault) {
     Network network("test", "test");
     BusFilter busFilter = BusFilter::create(network, options);
 
-    NetworkXmlWriterContext contextThrow(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION), busFilter, IidmXmlVersion::V1_0());
+    options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION);
+    NetworkXmlWriterContext contextThrow(anonymizer, writer, options, busFilter, IidmXmlVersion::V1_0());
     POWSYBL_ASSERT_THROW(IidmXmlUtil::assertMinimumVersionIfNotDefault(true, ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextThrow), PowsyblException, "root.element is not supported for IIDM-XML version 1.0. IIDM-XML version should be >= 1.1");
 
-    NetworkXmlWriterContext contextLog(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR), busFilter, IidmXmlVersion::V1_0());
+    options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR);
+    NetworkXmlWriterContext contextLog(anonymizer, writer, options, busFilter, IidmXmlVersion::V1_0());
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMinimumVersionIfNotDefault(true, ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextLog));
 }
 
@@ -183,10 +183,12 @@ BOOST_AUTO_TEST_CASE(testWriteMinimumVersionAndRunIfNotDefault) {
     Network network("test", "test");
     BusFilter busFilter = BusFilter::create(network, options);
 
-    NetworkXmlWriterContext contextThrow(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION), busFilter, IidmXmlVersion::V1_0());
+    options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::THROW_EXCEPTION);
+    NetworkXmlWriterContext contextThrow(anonymizer, writer, options, busFilter, IidmXmlVersion::V1_0());
     POWSYBL_ASSERT_THROW(IidmXmlUtil::assertMinimumVersionAndRunIfNotDefault(true, ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextThrow, [](){}), PowsyblException, "root.element is not supported for IIDM-XML version 1.0. IIDM-XML version should be >= 1.1");
 
-    NetworkXmlWriterContext contextLog(anonymizer, writer, options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR), busFilter, IidmXmlVersion::V1_0());
+    options.setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR);
+    NetworkXmlWriterContext contextLog(anonymizer, writer, options, busFilter, IidmXmlVersion::V1_0());
     BOOST_CHECK_NO_THROW(IidmXmlUtil::assertMinimumVersionAndRunIfNotDefault(true, ROOT, ELEMENT, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_1(), contextLog, [](){}));
 }
 


### PR DESCRIPTION
Partial backport of Java PR https://github.com/powsybl/powsybl-core/pull/1535.
This PR reports the add of `ExportOptions::IidmVersionIncompatibilityBehavior` and updates `IidmXmlUtil` functions to consider the attribute value.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Developper wants to configure the behaviour (thrown exception / log error) when an IIDM version incompatibility occurs while reading/writing a network. This PR allows that feature.


**What is the current behavior?** *(You can also link to an open issue here)*
An exception is always thrown if an IIDM version incompatibility occurs.


**What is the new behavior (if this is a feature change)?**
User can configure the expected behaviour (exception or lor error) when an IIDM version incompatibility occurs by setting `ExportOptions::m_iidmVersionIncompatibilityBehavior` to `IidmVersionIncompatibilityBehavior::THROW_EXCEPTION` or `IidmVersionIncompatibilityBehavior::LOG_ERROR`

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
