### PR TITLE
Fix performance issue with boost::range::join

### DIFF
--- a/include/powsybl/stdcxx/flattened.hpp
+++ b/include/powsybl/stdcxx/flattened.hpp
@@ -101,14 +101,14 @@ template <typename SinglePassRange>
 using FlattenRange = boost::iterator_range<FlatteningIterator<typename boost::range_iterator<SinglePassRange>::type>>;
 
 template <typename SinglePassRange>
-FlattenRange<SinglePassRange> operator|(SinglePassRange& range, FlattenForwarder) {
+FlattenRange<SinglePassRange> operator|(SinglePassRange& range, FlattenForwarder /* unused */) {
     using Iterator = typename boost::range_iterator<SinglePassRange>::type;
 
     return boost::make_iterator_range(FlatteningIterator<Iterator>(boost::begin(range), boost::end(range)), FlatteningIterator<Iterator>(boost::end(range)));
 }
 
 template <typename SinglePassRange>
-FlattenRange<SinglePassRange> operator|(const SinglePassRange& range, FlattenForwarder) {
+FlattenRange<SinglePassRange> operator|(const SinglePassRange& range, FlattenForwarder /* unused */) {
     using Iterator = typename boost::range_iterator<const SinglePassRange>::type;
 
     return boost::make_iterator_range(FlatteningIterator<Iterator>(boost::begin(range), boost::end(range)), FlatteningIterator<Iterator>(boost::end(range)));

--- a/include/powsybl/stdcxx/flattened.hpp
+++ b/include/powsybl/stdcxx/flattened.hpp
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef POWSYBL_STDCXX_FLATTENED_HPP
+#define POWSYBL_STDCXX_FLATTENED_HPP
+
+#include <boost/iterator_adaptors.hpp>
+#include <boost/range/iterator.hpp>
+#include <boost/range/iterator_range.hpp>
+
+namespace stdcxx {
+
+/**
+ * The FlatteningIterator is used to iterate over a range of ranges:
+ * - the OuterIterator is a forward iterator for the outer range
+ * - the InnerIterator is a forward iterator for the inner ranges.
+ *
+ * This iterator SHOULD not be used directly. Use the pipe operator instead.
+ */
+template <typename Iterator>
+class FlatteningIterator :
+    public boost::iterator_adaptor<
+        FlatteningIterator<Iterator>,
+        Iterator,
+        typename Iterator::value_type::iterator::value_type,
+        boost::forward_traversal_tag,
+        typename Iterator::value_type::iterator::value_type> {
+public:
+    using OuterIterator = Iterator;
+    using InnerIterator = typename Iterator::value_type::iterator;
+    using Value = typename Iterator::value_type::iterator::value_type;
+
+    using base = boost::iterator_adaptor<FlatteningIterator<Iterator>, Iterator, Value, boost::forward_traversal_tag, Value>;
+
+public:
+    FlatteningIterator() = default;
+
+    FlatteningIterator(Iterator it) :
+        base(it),
+        m_outer_end(it),
+        m_inner_begin(),
+        m_inner_end() {
+    }
+
+    FlatteningIterator(Iterator begin, Iterator end) :
+        base(begin),
+        m_outer_end(end) {
+
+        if (begin != end) {
+            m_inner_begin = (*begin).begin(),
+            m_inner_end = (*begin).end();
+            skipEmptyRanges();
+        }
+    }
+
+private:
+    void increment() {
+        if (this->base_reference() == m_outer_end) {
+            return;
+        }
+
+        ++m_inner_begin;
+        skipEmptyRanges();
+    }
+
+    Value dereference() const {
+        return *m_inner_begin;
+    }
+
+    void skipEmptyRanges() {
+        while ((this->base_reference() != m_outer_end) && (m_inner_begin == m_inner_end)) {
+            ++this->base_reference();
+            if (this->base_reference() != m_outer_end) {
+                m_inner_begin = (*this->base_reference()).begin();
+                m_inner_end = (*this->base_reference()).end();
+            }
+        }
+    }
+
+    friend class boost::iterator_core_access;
+
+private:
+    OuterIterator m_outer_end;
+    InnerIterator m_inner_begin;
+    InnerIterator m_inner_end;
+};
+
+struct FlattenForwarder {};
+
+namespace {
+
+const FlattenForwarder flattened;
+
+}  // namespace
+
+template <typename SinglePassRange>
+using FlattenRange = boost::iterator_range<FlatteningIterator<typename boost::range_iterator<SinglePassRange>::type>>;
+
+template <typename SinglePassRange>
+FlattenRange<SinglePassRange> operator|(SinglePassRange& range, FlattenForwarder) {
+    using Iterator = typename boost::range_iterator<SinglePassRange>::type;
+
+    return boost::make_iterator_range(FlatteningIterator<Iterator>(boost::begin(range), boost::end(range)), FlatteningIterator<Iterator>(boost::end(range)));
+}
+
+template <typename SinglePassRange>
+FlattenRange<SinglePassRange> operator|(const SinglePassRange& range, FlattenForwarder) {
+    using Iterator = typename boost::range_iterator<const SinglePassRange>::type;
+
+    return boost::make_iterator_range(FlatteningIterator<Iterator>(boost::begin(range), boost::end(range)), FlatteningIterator<Iterator>(boost::end(range)));
+}
+
+}  // namespace stdcxx
+
+#endif  // POWSYBL_STDCXX_FLATTENED_HPP

--- a/include/powsybl/stdcxx/flattened.hpp
+++ b/include/powsybl/stdcxx/flattened.hpp
@@ -39,7 +39,7 @@ public:
 public:
     FlatteningIterator() = default;
 
-    FlatteningIterator(Iterator it) :
+    explicit FlatteningIterator(Iterator it) :
         base(it),
         m_outer_end(it),
         m_inner_begin(),
@@ -56,6 +56,16 @@ public:
             skipEmptyRanges();
         }
     }
+
+    FlatteningIterator(const FlatteningIterator&) = default;
+
+    FlatteningIterator(FlatteningIterator&&) noexcept = default;
+
+    ~FlatteningIterator() noexcept = default;
+
+    FlatteningIterator& operator=(const FlatteningIterator&) = default;
+
+    FlatteningIterator& operator=(FlatteningIterator&&) noexcept = default;
 
 private:
     void increment() {
@@ -91,11 +101,7 @@ private:
 
 struct FlattenForwarder {};
 
-namespace {
-
 const FlattenForwarder flattened;
-
-}  // namespace
 
 template <typename SinglePassRange>
 using FlattenRange = boost::iterator_range<FlatteningIterator<typename boost::range_iterator<SinglePassRange>::type>>;

--- a/src/iidm/BusBreakerVoltageLevel.cpp
+++ b/src/iidm/BusBreakerVoltageLevel.cpp
@@ -9,11 +9,12 @@
 
 #include <cassert>
 
-#include <boost/range/join.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
 #include <powsybl/iidm/Substation.hpp>
 #include <powsybl/iidm/Switch.hpp>
 #include <powsybl/iidm/ValidationUtils.hpp>
+#include <powsybl/stdcxx/flattened.hpp>
 
 #include "BusTerminal.hpp"
 
@@ -243,25 +244,19 @@ stdcxx::range<Switch> BusBreakerVoltageLevel::getSwitches() {
 }
 
 stdcxx::const_range<Terminal> BusBreakerVoltageLevel::getTerminals() const {
-    stdcxx::const_range<Terminal> terminals;
-    for (const auto& bus : m_graph.getVertexObjects()) {
-        if (bus) {
-            terminals = boost::range::join(terminals, bus.get().getTerminals());
-        }
-    }
+    const auto& mapper = [](const stdcxx::Reference<ConfiguredBus>& bus) {
+        return bus.get().getTerminals();
+    };
 
-    return terminals;
+    return m_graph.getVertexObjects() | boost::adaptors::transformed(mapper) | stdcxx::flattened;
 }
 
 stdcxx::range<Terminal> BusBreakerVoltageLevel::getTerminals() {
-    stdcxx::range<Terminal> terminals;
-    for (const auto& bus : m_graph.getVertexObjects()) {
-        if (bus) {
-            terminals = boost::range::join(terminals, bus.get().getTerminals());
-        }
-    }
+    const auto& mapper = [](const stdcxx::Reference<ConfiguredBus>& bus) {
+        return bus.get().getTerminals();
+    };
 
-    return terminals;
+    return m_graph.getVertexObjects() | boost::adaptors::transformed(mapper) | stdcxx::flattened;
 }
 
 const TopologyKind& BusBreakerVoltageLevel::getTopologyKind() const {

--- a/src/iidm/MergedBus.cpp
+++ b/src/iidm/MergedBus.cpp
@@ -10,11 +10,12 @@
 #include <cassert>
 #include <cmath>
 
-#include <boost/range/join.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/Terminal.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
+#include <powsybl/stdcxx/flattened.hpp>
 #include <powsybl/stdcxx/math.hpp>
 
 namespace powsybl {
@@ -76,25 +77,21 @@ unsigned long MergedBus::getConnectedTerminalCount() const {
 stdcxx::const_range<Terminal> MergedBus::getConnectedTerminals() const {
     checkValidity();
 
-    stdcxx::const_range<Terminal> range;
+    const auto& mapper = [](const std::reference_wrapper<ConfiguredBus>& bus) {
+        return bus.get().getConnectedTerminals();
+    };
 
-    for (const auto& bus : m_buses) {
-        range = boost::range::join(range, bus.get().getConnectedTerminals());
-    }
-
-    return range;
+    return m_buses | boost::adaptors::transformed(mapper) | stdcxx::flattened;
 }
 
 stdcxx::range<Terminal> MergedBus::getConnectedTerminals() {
     checkValidity();
 
-    stdcxx::range<Terminal> range;
+    const auto& mapper = [](const std::reference_wrapper<ConfiguredBus>& bus) {
+        return bus.get().getConnectedTerminals();
+    };
 
-    for (const auto& bus : m_buses) {
-        range = boost::range::join(range, bus.get().getConnectedTerminals());
-    }
-
-    return range;
+    return m_buses | boost::adaptors::transformed(mapper) | stdcxx::flattened;
 }
 
 stdcxx::CReference<Component> MergedBus::getSynchronousComponent() const {

--- a/src/iidm/NetworkViews.cpp
+++ b/src/iidm/NetworkViews.cpp
@@ -7,12 +7,13 @@
 
 #include <powsybl/iidm/NetworkViews.hpp>
 
-#include <boost/range/join.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
 #include <powsybl/iidm/Bus.hpp>
 #include <powsybl/iidm/Network.hpp>
 #include <powsybl/iidm/Switch.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
+#include <powsybl/stdcxx/flattened.hpp>
 
 #include "BusBreakerVoltageLevelViews.hpp"
 
@@ -47,23 +48,19 @@ stdcxx::Reference<Bus> BusBreakerView::getBus(const std::string& id) {
 }
 
 stdcxx::const_range<Bus> BusBreakerView::getBuses() const {
-    stdcxx::const_range<Bus> range;
+    const auto& mapper = [](const VoltageLevel& voltageLevel) {
+        return voltageLevel.getBusBreakerView().getBuses();
+    };
 
-    for (const auto& vl : m_network.getVoltageLevels()) {
-        range = boost::range::join(range, vl.getBusBreakerView().getBuses());
-    }
-
-    return range;
+    return m_network.getVoltageLevels() | boost::adaptors::transformed(mapper) | stdcxx::flattened;
 }
 
 stdcxx::range<Bus> BusBreakerView::getBuses() {
-    stdcxx::range<Bus> range;
+    const auto& mapper = [](const VoltageLevel& voltageLevel) {
+        return voltageLevel.getBusBreakerView().getBuses();
+    };
 
-    for (auto& vl : m_network.getVoltageLevels()) {
-        range = boost::range::join(range, vl.getBusBreakerView().getBuses());
-    }
-
-    return range;
+    return m_network.getVoltageLevels() | boost::adaptors::transformed(mapper) | stdcxx::flattened;
 }
 
 unsigned long BusBreakerView::getSwitchCount() const {
@@ -77,23 +74,19 @@ unsigned long BusBreakerView::getSwitchCount() const {
 }
 
 stdcxx::const_range<Switch> BusBreakerView::getSwitches() const {
-    stdcxx::const_range<Switch> range;
+    const auto& mapper = [](const VoltageLevel& voltageLevel) {
+        return voltageLevel.getBusBreakerView().getSwitches();
+    };
 
-    for (const auto& vl : m_network.getVoltageLevels()) {
-        range = boost::range::join(range, vl.getBusBreakerView().getSwitches());
-    }
-
-    return range;
+    return m_network.getVoltageLevels() | boost::adaptors::transformed(mapper) | stdcxx::flattened;
 }
 
 stdcxx::range<Switch> BusBreakerView::getSwitches() {
-    stdcxx::range<Switch> range;
+    const auto& mapper = [](const VoltageLevel& voltageLevel) {
+        return voltageLevel.getBusBreakerView().getSwitches();
+    };
 
-    for (auto& vl : m_network.getVoltageLevels()) {
-        range = boost::range::join(range, vl.getBusBreakerView().getSwitches());
-    }
-
-    return range;
+    return m_network.getVoltageLevels() | boost::adaptors::transformed(mapper) | stdcxx::flattened;
 }
 
 BusView::BusView(Network& network) :
@@ -121,23 +114,19 @@ stdcxx::Reference<Bus> BusView::getBus(const std::string& id) {
 }
 
 stdcxx::const_range<Bus> BusView::getBuses() const {
-    stdcxx::const_range<Bus> range;
+    const auto& mapper = [](const VoltageLevel& voltageLevel) {
+        return voltageLevel.getBusView().getBuses();
+    };
 
-    for (const auto& vl : m_network.getVoltageLevels()) {
-        range = boost::range::join(range, vl.getBusView().getBuses());
-    }
-
-    return range;
+    return m_network.getVoltageLevels() | boost::adaptors::transformed(mapper) | stdcxx::flattened;
 }
 
 stdcxx::range<Bus> BusView::getBuses() {
-    stdcxx::range<Bus> range;
+    const auto& mapper = [](const VoltageLevel& voltageLevel) {
+        return voltageLevel.getBusView().getBuses();
+    };
 
-    for (auto& vl : m_network.getVoltageLevels()) {
-        range = boost::range::join(range, vl.getBusView().getBuses());
-    }
-
-    return range;
+    return m_network.getVoltageLevels() | boost::adaptors::transformed(mapper) | stdcxx::flattened;
 }
 
 stdcxx::const_range<Component> BusView::getConnectedComponents() const {

--- a/src/iidm/Substation.cpp
+++ b/src/iidm/Substation.cpp
@@ -8,13 +8,14 @@
 #include <powsybl/iidm/Substation.hpp>
 
 #include <boost/range/adaptor/filtered.hpp>
-#include <boost/range/join.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
 #include <powsybl/iidm/RatioTapChanger.hpp>
 #include <powsybl/iidm/ThreeWindingsTransformerAdder.hpp>
 #include <powsybl/iidm/TwoWindingsTransformer.hpp>
 #include <powsybl/iidm/TwoWindingsTransformerAdder.hpp>
 #include <powsybl/iidm/util/DistinctPredicate.hpp>
+#include <powsybl/stdcxx/flattened.hpp>
 
 namespace powsybl {
 
@@ -58,23 +59,19 @@ unsigned long Substation::getThreeWindingsTransformerCount() const {
 }
 
 stdcxx::const_range<ThreeWindingsTransformer> Substation::getThreeWindingsTransformers() const {
-    stdcxx::const_range<ThreeWindingsTransformer> range;
+    const auto& mapper = [](const std::reference_wrapper<VoltageLevel>& voltageLevel) {
+        return voltageLevel.get().getConnectables<ThreeWindingsTransformer>();
+    };
 
-    for (const auto& it : m_voltageLevels) {
-        range = boost::range::join(range, it.get().getConnectables<ThreeWindingsTransformer>());
-    }
-
-    return range | boost::adaptors::filtered(DistinctPredicate());
+    return m_voltageLevels | boost::adaptors::transformed(mapper) | stdcxx::flattened | boost::adaptors::filtered(DistinctPredicate());
 }
 
 stdcxx::range<ThreeWindingsTransformer> Substation::getThreeWindingsTransformers() {
-    stdcxx::range<ThreeWindingsTransformer> range;
+    const auto& mapper = [](const std::reference_wrapper<VoltageLevel>& voltageLevel) {
+        return voltageLevel.get().getConnectables<ThreeWindingsTransformer>();
+    };
 
-    for (const auto& it : m_voltageLevels) {
-        range = boost::range::join(range, it.get().getConnectables<ThreeWindingsTransformer>());
-    }
-
-    return range | boost::adaptors::filtered(DistinctPredicate());
+    return m_voltageLevels | boost::adaptors::transformed(mapper) | stdcxx::flattened | boost::adaptors::filtered(DistinctPredicate());
 }
 
 const std::string& Substation::getTso() const {
@@ -86,23 +83,19 @@ unsigned long Substation::getTwoWindingsTransformerCount() const {
 }
 
 stdcxx::const_range<TwoWindingsTransformer> Substation::getTwoWindingsTransformers() const {
-    stdcxx::const_range<TwoWindingsTransformer> range;
+    const auto& mapper = [](const std::reference_wrapper<VoltageLevel>& voltageLevel) {
+        return voltageLevel.get().getConnectables<TwoWindingsTransformer>();
+    };
 
-    for (const auto& it : m_voltageLevels) {
-        range = boost::range::join(range, it.get().getConnectables<TwoWindingsTransformer>());
-    }
-
-    return range | boost::adaptors::filtered(DistinctPredicate());
+    return m_voltageLevels | boost::adaptors::transformed(mapper) | stdcxx::flattened | boost::adaptors::filtered(DistinctPredicate());
 }
 
 stdcxx::range<TwoWindingsTransformer> Substation::getTwoWindingsTransformers() {
-    stdcxx::range<TwoWindingsTransformer> range;
+    const auto& mapper = [](const std::reference_wrapper<VoltageLevel>& voltageLevel) {
+        return voltageLevel.get().getConnectables<TwoWindingsTransformer>();
+    };
 
-    for (const auto& it : m_voltageLevels) {
-        range = boost::range::join(range, it.get().getConnectables<TwoWindingsTransformer>());
-    }
-
-    return range | boost::adaptors::filtered(DistinctPredicate());
+    return m_voltageLevels | boost::adaptors::transformed(mapper) | stdcxx::flattened | boost::adaptors::filtered(DistinctPredicate());
 }
 
 const std::string& Substation::getTypeDescription() const {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#44 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Performance


**What is the current behavior?** *(You can also link to an open issue here)*
The usage of `boost::range::join` in a for loop in not efficient and can lead to a memory crash (OOMKiller) as explained in boostorg/range#118.


**What is the new behavior (if this is a feature change)?**
A custom iterator has been implemented to flatten a range of ranges. The design is based on [this implementation](https://stackoverflow.com/questions/3623082/flattening-iterator) with additional changes:
- fix handling of empty ranges
- defined the pipe operator to chain ranges operations


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
