### PR TITLE
Add check to ensure that HalfLine is not attached twice

### DIFF
--- a/src/iidm/HalfLine.cpp
+++ b/src/iidm/HalfLine.cpp
@@ -7,6 +7,7 @@
  
 #include <powsybl/iidm/HalfLine.hpp>
 
+#include <powsybl/iidm/TieLine.hpp>
 #include <powsybl/stdcxx/format.hpp>
 
 namespace powsybl {
@@ -109,6 +110,9 @@ HalfLine& HalfLine::setG2(double g2) {
 }
 
 void HalfLine::setParent(TieLine& parent) {
+    if (m_parent) {
+        throw AssertionError(stdcxx::format("TieLine.HalfLine already attached to %1%", m_parent.get().getId()));
+    }
     m_parent = parent;
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Improvement


**What is the current behavior?** *(You can also link to an open issue here)*
A HalfLine may be attached to a TieLine twice by a iidm4cpp developper mistake (from TieLine : halfLine::setParent is private, TieLine is friend)


**What is the new behavior (if this is a feature change)?**
Throw an error when trying to setParent twice


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
