### PR TITLE
Fix compilation on CentOS 7

### DIFF
--- a/include/powsybl/iidm/ExtensionAdder.hpp
+++ b/include/powsybl/iidm/ExtensionAdder.hpp
@@ -50,7 +50,7 @@ protected:
     /**
      * Copy constructor
      */
-    ExtensionAdder(const ExtensionAdder& extendable) = default;
+    ExtensionAdder(const ExtensionAdder&) = default;
 
     /**
      * Move constructor

--- a/include/powsybl/iidm/ShuntCompensatorLinearModelAdder.hpp
+++ b/include/powsybl/iidm/ShuntCompensatorLinearModelAdder.hpp
@@ -27,7 +27,7 @@ public:  // ShuntCompensatorModelAdder
 public:
     explicit ShuntCompensatorLinearModelAdder(ShuntCompensatorAdder& parent);
 
-    ShuntCompensatorLinearModelAdder(ShuntCompensatorLinearModelAdder&& adder) noexcept = default;
+    ShuntCompensatorLinearModelAdder(ShuntCompensatorLinearModelAdder&&) noexcept = default;
 
     ShuntCompensatorLinearModelAdder& setBPerSection(double bPerSection);
 

--- a/include/powsybl/iidm/util/TerminalFinder.hpp
+++ b/include/powsybl/iidm/util/TerminalFinder.hpp
@@ -38,11 +38,13 @@ public:
 
     TerminalFinder(const TerminalFinder&) = delete;
 
-    TerminalFinder(TerminalFinder&&) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor): move constructor of std::function is not marked noexcept
+    TerminalFinder(TerminalFinder&&) = default;
 
     TerminalFinder& operator=(const TerminalFinder&) = delete;
 
-    TerminalFinder& operator=(TerminalFinder&&) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor): move constructor of std::function is not marked noexcept
+    TerminalFinder& operator=(TerminalFinder&&) = default;
 
     stdcxx::CReference<Terminal> find(const stdcxx::const_range<Terminal>& terminals) const;
 

--- a/include/powsybl/stdcxx/flattened.hpp
+++ b/include/powsybl/stdcxx/flattened.hpp
@@ -59,13 +59,15 @@ public:
 
     FlatteningIterator(const FlatteningIterator&) = default;
 
-    FlatteningIterator(FlatteningIterator&&) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor): move constructor of boost::range_detail::default_constructible_unary_fn_wrapper is not marked noexcept
+    FlatteningIterator(FlatteningIterator&&) = default;
 
     ~FlatteningIterator() noexcept = default;
 
     FlatteningIterator& operator=(const FlatteningIterator&) = default;
 
-    FlatteningIterator& operator=(FlatteningIterator&&) noexcept = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor): move constructor of boost::range_detail::default_constructible_unary_fn_wrapper is not marked noexcept
+    FlatteningIterator& operator=(FlatteningIterator&&) = default;
 
 private:
     void increment() {


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Compilation fix on CentOS 7


**What is the current behavior?** *(You can also link to an open issue here)*
integration/v1.3.0 does not compile on CentOS7 operating system



**What is the new behavior (if this is a feature change)?**
integration/v1.3.0 compiles on CentOS7 operating system


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
