### PR TITLE
[IIDM v1.2] Fix XML read/write of shunts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           export MODIFIED_FILES=$(git diff -U0 HEAD^ --name-only | grep -E "\.(cpp|hpp|hxx)$")
           if [ -n "$MODIFIED_FILES" ]; then
-              clang-tidy $MODIFIED_FILES -p $GITHUB_WORKSPACE/build-linux
+              clang-tidy $MODIFIED_FILES -p $GITHUB_WORKSPACE/build
           fi
 
       - name: Tests

--- a/src/iidm/converter/xml/ShuntCompensatorXml.cpp
+++ b/src/iidm/converter/xml/ShuntCompensatorXml.cpp
@@ -8,6 +8,7 @@
 #include "ShuntCompensatorXml.hpp"
 
 #include <powsybl/iidm/converter/Constants.hpp>
+#include <powsybl/iidm/converter/xml/TerminalRefXml.hpp>
 
 namespace powsybl {
 
@@ -34,6 +35,14 @@ ShuntCompensator& ShuntCompensatorXml::readRootElementAttributes(ShuntCompensato
     auto bPerSection = context.getReader().getAttributeValue<double>(B_PER_SECTION);
     auto maximumSectionCount = context.getReader().getAttributeValue<unsigned long>(MAXIMUM_SECTION_COUNT);
     auto currentSectionCount = context.getReader().getAttributeValue<unsigned long>(CURRENT_SECTION_COUNT);
+    IidmXmlUtil::runFromMinimumVersion(IidmXmlVersion::V1_2(), context.getVersion(), [&context, &adder]() {
+        bool voltageRegulatorOn = context.getReader().getOptionalAttributeValue(VOLTAGE_REGULATOR_ON, false);
+        double targetV = context.getReader().getOptionalAttributeValue(TARGET_V, stdcxx::nan());
+        double targetDeadband = context.getReader().getOptionalAttributeValue(TARGET_DEADBAND, stdcxx::nan());
+        adder.setVoltageRegulatorOn(voltageRegulatorOn)
+            .setTargetV(targetV)
+            .setTargetDeadband(targetDeadband);
+    });
     adder.setbPerSection(bPerSection)
         .setMaximumSectionCount(maximumSectionCount)
         .setCurrentSectionCount(currentSectionCount);
@@ -45,7 +54,16 @@ ShuntCompensator& ShuntCompensatorXml::readRootElementAttributes(ShuntCompensato
 
 void ShuntCompensatorXml::readSubElements(ShuntCompensator& shuntCompensator, NetworkXmlReaderContext& context) const {
     context.getReader().readUntilEndElement(SHUNT, [this, &shuntCompensator, &context]() {
-        AbstractIdentifiableXml::readSubElements(shuntCompensator, context);
+        if (context.getReader().getLocalName() == REGULATING_TERMINAL) {
+            IidmXmlUtil::assertMinimumVersion(SHUNT, REGULATING_TERMINAL, ErrorMessage::NOT_SUPPORTED, IidmXmlVersion::V1_2(), context.getVersion());
+            const auto& id = context.getAnonymizer().deanonymizeString(context.getReader().getAttributeValue(ID));
+            const auto& side = context.getReader().getOptionalAttributeValue(SIDE, "");
+            context.addEndTask([id, side, &shuntCompensator]() {
+                shuntCompensator.setRegulatingTerminal(stdcxx::ref<Terminal>(TerminalRefXml::readTerminalRef(shuntCompensator.getNetwork(), id, side)));
+            });
+        } else {
+            AbstractIdentifiableXml::readSubElements(shuntCompensator, context);
+        }
     });
 }
 
@@ -53,8 +71,20 @@ void ShuntCompensatorXml::writeRootElementAttributes(const ShuntCompensator& shu
     context.getWriter().writeAttribute(B_PER_SECTION, shuntCompensator.getbPerSection());
     context.getWriter().writeAttribute(MAXIMUM_SECTION_COUNT, shuntCompensator.getMaximumSectionCount());
     context.getWriter().writeAttribute(CURRENT_SECTION_COUNT, shuntCompensator.getCurrentSectionCount());
+    IidmXmlUtil::writeBooleanAttributeFromMinimumVersion(SHUNT, VOLTAGE_REGULATOR_ON, shuntCompensator.isVoltageRegulatorOn(), false, ErrorMessage::NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion::V1_2(), context);
+    IidmXmlUtil::writeDoubleAttributeFromMinimumVersion(SHUNT, TARGET_V, shuntCompensator.getTargetV(), ErrorMessage::NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion::V1_2(), context);
+    IidmXmlUtil::writeDoubleAttributeFromMinimumVersion(SHUNT, TARGET_DEADBAND, shuntCompensator.getTargetDeadband(), ErrorMessage::NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion::V1_2(), context);
     writeNodeOrBus(shuntCompensator.getTerminal(), context);
     writePQ(shuntCompensator.getTerminal(), context.getWriter());
+}
+
+void ShuntCompensatorXml::writeSubElements(const ShuntCompensator& shuntCompensator, const VoltageLevel& /*voltageLevel*/, NetworkXmlWriterContext& context) const {
+    if (!stdcxx::areSame(shuntCompensator, shuntCompensator.getRegulatingTerminal().getConnectable().get())) {
+        IidmXmlUtil::assertMinimumVersion(SHUNT, REGULATING_TERMINAL, ErrorMessage::NOT_DEFAULT_NOT_SUPPORTED, IidmXmlVersion::V1_2(), context.getVersion());
+        IidmXmlUtil::runFromMinimumVersion(IidmXmlVersion::V1_2(), context.getVersion(), [&context, &shuntCompensator]() {
+            TerminalRefXml::writeTerminalRef(shuntCompensator.getRegulatingTerminal(), context, REGULATING_TERMINAL);
+        });
+    }
 }
 
 }  // namespace xml

--- a/src/iidm/converter/xml/ShuntCompensatorXml.hpp
+++ b/src/iidm/converter/xml/ShuntCompensatorXml.hpp
@@ -37,6 +37,8 @@ protected:  // AbstractIdentifiableXml
 
     void writeRootElementAttributes(const ShuntCompensator& shuntCompensator, const VoltageLevel& voltageLevel, NetworkXmlWriterContext& context) const override;
 
+    void writeSubElements(const ShuntCompensator& shuntCompensator, const VoltageLevel& voltageLevel, NetworkXmlWriterContext& context) const override;
+
 private:
     ShuntCompensatorXml() = default;
 

--- a/test/iidm/converter/xml/CMakeLists.txt
+++ b/test/iidm/converter/xml/CMakeLists.txt
@@ -34,6 +34,7 @@ set(UNIT_TEST_SOURCES
     PhaseShifterRoundTripTest.cpp
     ReactiveLimitsRoundTripTest.cpp
     RegulatingTerminalRoundTripTest.cpp
+    ShuntCompensatorRoundTripTest.cpp
     SkipExtensionTest.cpp
     StaticVarCompensatorRoundTripTest.cpp
     TerminalRefTest.cpp

--- a/test/iidm/converter/xml/ShuntCompensatorRoundTripTest.cpp
+++ b/test/iidm/converter/xml/ShuntCompensatorRoundTripTest.cpp
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <powsybl/test/ResourceFixture.hpp>
+#include <powsybl/test/converter/RoundTrip.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+namespace converter {
+
+namespace xml {
+
+BOOST_AUTO_TEST_SUITE(ShuntCompensatorRoundTrip)
+
+BOOST_FIXTURE_TEST_CASE(ShuntCompensatorRoundTripTest, test::ResourceFixture) {
+    test::converter::RoundTrip::roundTripVersionedXmlTest("shuntRoundTripRef.xml", IidmXmlVersion::CURRENT_IIDM_XML_VERSION());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace xml
+
+}  // namespace converter
+
+}  // namespace iidm
+
+}  // namespace powsybl

--- a/test/resources/V1_2/LccRoundTripRef.xml
+++ b/test/resources/V1_2/LccRoundTripRef.xml
@@ -5,8 +5,8 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="B1"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="C1_Filter1" name="Filter 1" bPerSection="1.0000000000000001e-05" maximumSectionCount="1" currentSectionCount="1" bus="B1" connectableBus="B1" q="25"/>
-            <iidm:shunt id="C1_Filter2" name="Filter 2" bPerSection="2.0000000000000002e-05" maximumSectionCount="1" currentSectionCount="0" connectableBus="B1" q="25"/>
+            <iidm:shunt id="C1_Filter1" name="Filter 1" bPerSection="1.0000000000000001e-05" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" bus="B1" connectableBus="B1" q="25"/>
+            <iidm:shunt id="C1_Filter2" name="Filter 2" bPerSection="2.0000000000000002e-05" maximumSectionCount="1" currentSectionCount="0" voltageRegulatorOn="false" connectableBus="B1" q="25"/>
             <iidm:lccConverterStation id="C1" name="Converter1" lossFactor="1.1000000000000001" powerFactor="0.5" bus="B1" connectableBus="B1" p="100" q="50"/>
         </iidm:voltageLevel>
     </iidm:substation>
@@ -21,8 +21,8 @@
                 <iidm:switch id="DISC_BBS1_BK3" name="Disconnector" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="5"/>
                 <iidm:switch id="BK3" name="Breaker" kind="BREAKER" retained="true" open="false" node1="5" node2="6"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="C2_Filter1" name="Filter 3" bPerSection="3.0000000000000001e-05" maximumSectionCount="1" currentSectionCount="1" node="4" q="12.5"/>
-            <iidm:shunt id="C2_Filter2" name="Filter 4" bPerSection="4.0000000000000003e-05" maximumSectionCount="1" currentSectionCount="1" node="6" q="12.5"/>
+            <iidm:shunt id="C2_Filter1" name="Filter 3" bPerSection="3.0000000000000001e-05" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" node="4" q="12.5"/>
+            <iidm:shunt id="C2_Filter2" name="Filter 4" bPerSection="4.0000000000000003e-05" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" node="6" q="12.5"/>
             <iidm:lccConverterStation id="C2" name="Converter2" lossFactor="1.1000000000000001" powerFactor="0.59999999999999998" node="2" p="75" q="25"/>
         </iidm:voltageLevel>
     </iidm:substation>

--- a/test/resources/V1_2/shuntRoundTripRef.xml
+++ b/test/resources/V1_2/shuntRoundTripRef.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="shuntTestCase" caseDate="2019-09-30T16:29:18.263000+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="S1" country="FR">
+        <iidm:voltageLevel id="VL1" nominalV="380" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B1"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="SHUNT" bPerSection="1.0000000000000001e-05" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="true" targetV="200" targetDeadband="5" bus="B1" connectableBus="B1">
+                <iidm:property name="test" value="test"/>
+                <iidm:regulatingTerminal id="LOAD"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S2" country="FR">
+        <iidm:voltageLevel id="VL2" nominalV="220" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B2"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="100" q0="50" bus="B2" connectableBus="B2"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>

--- a/test/resources/V1_2/terminalRef.xml
+++ b/test/resources/V1_2/terminalRef.xml
@@ -5,9 +5,9 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="VL41" v="91.126113899999993" angle="-11.178720500000001"/>
             </iidm:busBreakerTopology>
-            <iidm:shunt id="SHUNT_VL4.11" bPerSection="0.0035802468191832304" maximumSectionCount="1" currentSectionCount="1" connectableBus="VL41" q="9999"/>
-            <iidm:shunt id="SHUNT_VL4.21" bPerSection="0.0037037036381661892" maximumSectionCount="1" currentSectionCount="1" connectableBus="VL41" q="9999"/>
-            <iidm:shunt id="SHUNT_VL4.31" bPerSection="0.0037037036381661892" maximumSectionCount="1" currentSectionCount="1" connectableBus="VL41" q="9999"/>
+            <iidm:shunt id="SHUNT_VL4.11" bPerSection="0.0035802468191832304" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" connectableBus="VL41" q="9999"/>
+            <iidm:shunt id="SHUNT_VL4.21" bPerSection="0.0037037036381661892" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" connectableBus="VL41" q="9999"/>
+            <iidm:shunt id="SHUNT_VL4.31" bPerSection="0.0037037036381661892" maximumSectionCount="1" currentSectionCount="1" voltageRegulatorOn="false" connectableBus="VL41" q="9999"/>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="VL6" nominalV="225" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Shunt with regulation are not correctly written and read from XML : 
 - <regulatingTerminal> is not emitted and read
 - attribute "voltageRegulatorOn" is not written


**What is the new behavior (if this is a feature change)?**
 - <regulatingTerminal> is written and read
 - attribute "voltageRegulatorOn" is written


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
