### PR TITLE
Fix Lcc/Vsc and shunts round trip tests

### DIFF
--- a/test/iidm/converter/xml/CMakeLists.txt
+++ b/test/iidm/converter/xml/CMakeLists.txt
@@ -23,11 +23,11 @@ set(UNIT_TEST_SOURCES
     BatteryRoundTripTest.cpp
     EurostagTest.cpp
     FictitiousSwitchTest.cpp
+    HvdcRoundTripTest.cpp
     IdentifiableExtensionXmlSerializerTest.cpp
     IidmXmlUtilTest.cpp
     InternalConnectionsRoundTripTest.cpp
     LinesRoundTripTest.cpp
-    LccRoundTripRef.cpp
     NetworkXmlTest.cpp
     NetworkXmlReaderContextTest.cpp
     NetworkXmlWriterContextTest.cpp
@@ -35,12 +35,12 @@ set(UNIT_TEST_SOURCES
     PhaseShifterRoundTripTest.cpp
     ReactiveLimitsRoundTripTest.cpp
     RegulatingTerminalRoundTripTest.cpp
+    ShuntCompensatorRoundTripTest.cpp
     SkipExtensionTest.cpp
     StaticVarCompensatorRoundTripTest.cpp
     TerminalRefTest.cpp
     ThreeWindingsTransformerRoundTripTest.cpp
     TieLineWithAliasesXmlTest.cpp
-    VscRoundTripTest.cpp
     xiidm.cpp
 )
 

--- a/test/iidm/converter/xml/HvdcRoundTripTest.cpp
+++ b/test/iidm/converter/xml/HvdcRoundTripTest.cpp
@@ -18,7 +18,11 @@ namespace converter {
 
 namespace xml {
 
-BOOST_AUTO_TEST_SUITE(VscRoundTrip)
+BOOST_AUTO_TEST_SUITE(HvdcRoundTrip)
+
+BOOST_FIXTURE_TEST_CASE(LccRoundTripTest, test::ResourceFixture) {
+    test::converter::RoundTrip::roundTripVersionedXmlTest("LccRoundTripRef.xml", IidmXmlVersion::all());
+}
 
 BOOST_FIXTURE_TEST_CASE(VscRoundTripTest, test::ResourceFixture) {
     test::converter::RoundTrip::roundTripVersionedXmlTest("VscRoundTripRef.xml", IidmXmlVersion::all());

--- a/test/iidm/converter/xml/ShuntCompensatorRoundTripTest.cpp
+++ b/test/iidm/converter/xml/ShuntCompensatorRoundTripTest.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -95,11 +95,7 @@ Network createNonLinear() {
     return network;
 }
 
-BOOST_AUTO_TEST_SUITE(LccRoundTrip)
-
-BOOST_FIXTURE_TEST_CASE(LccRoundTripTest, test::ResourceFixture) {
-    test::converter::RoundTrip::roundTripVersionedXmlTest("LccRoundTripRef.xml", IidmXmlVersion::all());
-}
+BOOST_AUTO_TEST_SUITE(ShuntCompensatorRoundTrip)
 
 BOOST_FIXTURE_TEST_CASE(ShuntLinearRoundTripTest, test::ResourceFixture) {
     test::converter::RoundTrip::roundTripVersionedXmlTest("shuntRoundTripRef.xml", IidmXmlVersion::CURRENT_IIDM_XML_VERSION());
@@ -111,8 +107,8 @@ BOOST_FIXTURE_TEST_CASE(ShuntLinearRoundTripTest, test::ResourceFixture) {
 BOOST_FIXTURE_TEST_CASE(ShuntNonLinearRoundTripTest, test::ResourceFixture) {
     test::converter::RoundTrip::roundTripVersionedXmlTest("nonLinearShuntRoundTripRef.xml", IidmXmlVersion::CURRENT_IIDM_XML_VERSION());
 
-    // backward compatibility from version 1.2
-    test::converter::RoundTrip::roundTripVersionedXmlFromMinToCurrentVersionTest("nonLinearShuntRoundTripRef.xml", IidmXmlVersion::CURRENT_IIDM_XML_VERSION());
+    // backward compatibility from version 1.3
+    test::converter::RoundTrip::roundTripVersionedXmlFromMinToCurrentVersionTest("nonLinearShuntRoundTripRef.xml", IidmXmlVersion::V1_3());
 
     Network network = createNonLinear();
 
@@ -142,4 +138,3 @@ BOOST_AUTO_TEST_SUITE_END()
 }  // namespace iidm
 
 }  // namespace powsybl
-


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Test refactoring


**What is the current behavior?** *(You can also link to an open issue here)*
Shunt compensator round trip tests are in LccRoundTripRef.cpp (with LccRoundTrip test)
Vsc round trip test is in VscRoundTripTest.cpp



**What is the new behavior (if this is a feature change)?**
Shunt compensator round trip tests are in ShuntCompensatorRoundTripTest.cpp
Lcc and Vsc round trip tests are in HvdcRoundTripTest.cpp


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
