### PR TITLE
Add a way to pass import/export options to iidm-benchmark

### DIFF
--- a/tools/benchmark/Benchmark.cpp
+++ b/tools/benchmark/Benchmark.cpp
@@ -14,6 +14,7 @@
 
 #include <libxml/parser.h>
 
+#include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/ExtensionProviders.hpp>
 #include <powsybl/iidm/Network.hpp>
 #include <powsybl/iidm/converter/ExportOptions.hpp>
@@ -65,8 +66,11 @@ void readOptions(stdcxx::Properties& properties, const boost::program_options::v
         for (const auto& property : options.as<std::vector<std::string>>()) {
             std::vector<std::string> result;
             boost::split(result, property, boost::is_any_of("="));
-
-            properties.set(result[0], result[1]);
+            if (result.size() == 2) {
+                properties.set(result[0], result[1]);
+            } else {
+                throw powsybl::PowsyblException(stdcxx::format("Malformed option: %1%", property));
+            }
         }
     }
 }
@@ -83,8 +87,8 @@ int main(int argc, char** argv) {
         (INPUT_FILE, boost::program_options::value<std::string>()->required())
         (OUTPUT_FILE, boost::program_options::value<std::string>()->required())
         (EXT_PATH, boost::program_options::value<std::string>()->default_value(""))
-        (",E", boost::program_options::value<std::vector<std::string>>()->composing())
-        (",I", boost::program_options::value<std::vector<std::string>>()->composing());
+        (",E", boost::program_options::value<std::vector<std::string>>())
+        (",I", boost::program_options::value<std::vector<std::string>>());
 
     try {
         // Use the RAII to load/unload LibXml2

--- a/tools/benchmark/Benchmark.cpp
+++ b/tools/benchmark/Benchmark.cpp
@@ -16,6 +16,9 @@
 
 #include <powsybl/iidm/ExtensionProviders.hpp>
 #include <powsybl/iidm/Network.hpp>
+#include <powsybl/iidm/converter/ExportOptions.hpp>
+#include <powsybl/iidm/converter/FakeAnonymizer.hpp>
+#include <powsybl/iidm/converter/ImportOptions.hpp>
 #include <powsybl/iidm/converter/xml/ExtensionXmlSerializer.hpp>
 #include <powsybl/logging/ConsoleLogger.hpp>
 #include <powsybl/logging/LoggerFactory.hpp>
@@ -57,16 +60,31 @@ void loadExtensions(const std::string& strPaths) {
     }
 }
 
+void readOptions(stdcxx::Properties& properties, const boost::program_options::variable_value& options) {
+    if (!options.empty()) {
+        for (const auto& property : options.as<std::vector<std::string>>()) {
+            std::vector<std::string> result;
+            boost::split(result, property, boost::is_any_of("="));
+
+            properties.set(result[0], result[1]);
+        }
+    }
+}
+
 int main(int argc, char** argv) {
     const char* const INPUT_FILE = "input-file";
     const char* const OUTPUT_FILE = "output-file";
     const char* const EXT_PATH = "ext-path";
+    const char* const EXPORT_OPTION = "-E";
+    const char* const IMPORT_OPTION = "-I";
 
     boost::program_options::options_description desc("Options");
     desc.add_options()
         (INPUT_FILE, boost::program_options::value<std::string>()->required())
         (OUTPUT_FILE, boost::program_options::value<std::string>()->required())
-        (EXT_PATH, boost::program_options::value<std::string>()->default_value(""));
+        (EXT_PATH, boost::program_options::value<std::string>()->default_value(""))
+        (",E", boost::program_options::value<std::vector<std::string>>()->composing())
+        (",I", boost::program_options::value<std::vector<std::string>>()->composing());
 
     try {
         // Use the RAII to load/unload LibXml2
@@ -75,6 +93,10 @@ int main(int argc, char** argv) {
         boost::program_options::variables_map vm;
         boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
         boost::program_options::notify(vm);
+
+        stdcxx::Properties options;
+        readOptions(options, vm[EXPORT_OPTION]);
+        readOptions(options, vm[IMPORT_OPTION]);
 
         // Setup the logger
         auto logger = stdcxx::make_unique<powsybl::logging::ConsoleLogger>(powsybl::logging::Level::DEBUG);
@@ -97,8 +119,8 @@ int main(int argc, char** argv) {
             return EXIT_FAILURE;
         }
 
-        const powsybl::iidm::Network& network = powsybl::iidm::Network::readXml(inputStream);
-        powsybl::iidm::Network::writeXml(outputStream, network);
+        const powsybl::iidm::Network& network = powsybl::iidm::Network::readXml(inputStream, powsybl::iidm::converter::ImportOptions(options), powsybl::iidm::converter::FakeAnonymizer());
+        powsybl::iidm::Network::writeXml(outputStream, network, powsybl::iidm::converter::ExportOptions(options));
 
         inputStream.close();
         outputStream.close();

--- a/tools/benchmark/CMakeLists.txt
+++ b/tools/benchmark/CMakeLists.txt
@@ -11,3 +11,11 @@ set(IIDM_BENCHMARK_SOURCES
 
 add_executable(iidm-benchmark ${IIDM_BENCHMARK_SOURCES})
 target_link_libraries(iidm-benchmark PRIVATE iidm Boost::program_options)
+
+# Installation
+install(TARGETS iidm-benchmark
+    EXPORT iidm-targets
+    LIBRARY DESTINATION ${INSTALL_LIB_DIR}
+    ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
+    RUNTIME DESTINATION ${INSTALL_BIN_DIR}
+)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
It's not possible to pass import/export options to `iidm-benchmark`


**What is the new behavior (if this is a feature change)?**
Options can be passed using the `-E` and `-I` options. Note that this is not totally equivalent to the java usage because we need to separate the prefix and the option name.

The tool is now install in the `bin` directory


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
