### PR TITLE
Add missing alias resolution when calling NetworkIndex::find()

### DIFF
--- a/include/powsybl/iidm/NetworkIndex.hpp
+++ b/include/powsybl/iidm/NetworkIndex.hpp
@@ -93,6 +93,9 @@ private:
 };
 
 template <>
+stdcxx::CReference<Identifiable> NetworkIndex::find(const std::string& id) const;
+
+template <>
 const Identifiable& NetworkIndex::get(const std::string& id) const;
 
 template <>

--- a/include/powsybl/iidm/NetworkIndex.hxx
+++ b/include/powsybl/iidm/NetworkIndex.hxx
@@ -17,6 +17,7 @@
 #include <powsybl/iidm/VscConverterStation.hpp>
 #include <powsybl/stdcxx/demangle.hpp>
 #include <powsybl/stdcxx/format.hpp>
+#include <powsybl/stdcxx/map.hpp>
 #include <powsybl/stdcxx/reference_wrapper.hpp>
 
 namespace powsybl {
@@ -114,9 +115,10 @@ unsigned long NetworkIndex::getObjectCount() const {
 
 template <typename T>
 stdcxx::CReference<T> NetworkIndex::find(const std::string& id) const {
-    checkId(id);
+    const auto& resolvedId = stdcxx::getOrDefault(m_idByAlias, id, id);
+    checkId(resolvedId);
 
-    const auto& it = m_objectsById.find(id);
+    const auto& it = m_objectsById.find(resolvedId);
     if (it != m_objectsById.end()) {
         auto* identifiable = dynamic_cast<T*>(it->second.get());
         if (identifiable != nullptr) {

--- a/src/iidm/NetworkIndex.cpp
+++ b/src/iidm/NetworkIndex.cpp
@@ -83,14 +83,21 @@ void NetworkIndex::checkId(const std::string& id) {
 }
 
 template <>
-const Identifiable& NetworkIndex::get(const std::string& id) const {
+stdcxx::CReference<Identifiable> NetworkIndex::find(const std::string& id) const {
     const auto& resolvedId = stdcxx::getOrDefault(m_idByAlias, id, id);
     checkId(resolvedId);
+
     const auto& it = m_objectsById.find(resolvedId);
-    if (it == m_objectsById.end()) {
-        throw PowsyblException(stdcxx::format("Unable to find to the identifiable '%1%'", resolvedId));
+    return it != m_objectsById.end() ? stdcxx::cref(*it->second) : stdcxx::cref<Identifiable>();
+}
+
+template <>
+const Identifiable& NetworkIndex::get(const std::string& id) const {
+    const auto& obj = find<Identifiable>(id);
+    if (!obj) {
+        throw PowsyblException(stdcxx::format("Unable to find to the identifiable '%1%'", id));
     }
-    return *it->second;
+    return obj.get();
 }
 
 template <>

--- a/test/iidm/AliasesTest.cpp
+++ b/test/iidm/AliasesTest.cpp
@@ -183,6 +183,14 @@ BOOST_AUTO_TEST_CASE(failWhenRemovingBadAlias) {
     POWSYBL_ASSERT_THROW(load.removeAlias("Generator alias"), PowsyblException, "Alias 'Generator alias' does not correspond to object 'load1'");
 }
 
+BOOST_AUTO_TEST_CASE(FindIdentifiableFromAlias) {
+    Network network = createNetwork();
+    Load& load = network.getLoad("load1");
+    load.addAlias("Load alias");
+
+    BOOST_CHECK(stdcxx::areSame(load, network.find("Load alias").get()));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace iidm


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
`Network::find` does not consider aliases at all (unlike `Network::get`)



**What is the new behavior (if this is a feature change)?**
Network::find tries to resolve alias before searching in the id map


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
