### PR TITLE
Fix compilation on centos7

### DIFF
--- a/include/powsybl/iidm/Identifiable.hpp
+++ b/include/powsybl/iidm/Identifiable.hpp
@@ -31,7 +31,8 @@ public: // Validable
 public:
     Identifiable(const Identifiable&) = delete;
 
-    Identifiable(Identifiable&& identifiable) noexcept = default;
+    // Move constructor of stdcxx::Properties is not marked noexcept
+    Identifiable(Identifiable&&) = default;  // NOSONAR
 
     ~Identifiable() noexcept override = default;
 

--- a/include/powsybl/iidm/ShuntCompensatorNonLinearModelAdder.hpp
+++ b/include/powsybl/iidm/ShuntCompensatorNonLinearModelAdder.hpp
@@ -53,7 +53,7 @@ public:
 
     ~ShuntCompensatorNonLinearModelAdder() noexcept override = default;
 
-    ShuntCompensatorNonLinearModelAdder(ShuntCompensatorNonLinearModelAdder&& adder) noexcept = default;
+    ShuntCompensatorNonLinearModelAdder(ShuntCompensatorNonLinearModelAdder&&) noexcept = default;
 
     SectionAdder beginSection();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix regression introduced by PR https://github.com/powsybl/powsybl-iidm4cpp/pull/261 which makes compilation fail on Centos7


**What is the current behavior?** *(You can also link to an open issue here)*
Does not compile on centos7 because of `noexcept` addition on `Identifiable(&&)` move constructor.


**What is the new behavior (if this is a feature change)?**
Does not compile on centos7


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
