### PR TITLE
Refactoring XML read/write of a Network API

### DIFF
--- a/examples/example1/example1.cpp
+++ b/examples/example1/example1.cpp
@@ -27,11 +27,9 @@ int main(int argc, char** argv) {
     try {
         xmlInitParser();
 
-        std::ifstream inputStream(argv[1]);
-        powsybl::iidm::Network network = powsybl::iidm::Network::readXml(inputStream);
+        powsybl::iidm::Network network = powsybl::iidm::Network::readXml(argv[1]);
 
-        std::ofstream outputStream(argv[2]);
-        powsybl::iidm::Network::writeXml(outputStream, network);
+        powsybl::iidm::Network::writeXml(argv[2], network);
 
         xmlCleanupParser();
 

--- a/include/powsybl/iidm/Identifiable.hpp
+++ b/include/powsybl/iidm/Identifiable.hpp
@@ -32,7 +32,7 @@ public: // Validable
 public:
     Identifiable(const Identifiable&) = delete;
 
-    // Move constructor of stdcxx::Properties is not marked noexcept
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor): move constructor of stdcxx::Properties is not marked noexcept
     Identifiable(Identifiable&&) = default;  // NOSONAR
 
     ~Identifiable() noexcept override = default;

--- a/include/powsybl/iidm/Network.hpp
+++ b/include/powsybl/iidm/Network.hpp
@@ -8,6 +8,8 @@
 #ifndef POWSYBL_IIDM_NETWORK_HPP
 #define POWSYBL_IIDM_NETWORK_HPP
 
+#include <boost/filesystem/path.hpp>
+
 #include <powsybl/iidm/Container.hpp>
 #include <powsybl/iidm/NetworkIndex.hpp>
 #include <powsybl/iidm/NetworkVariant.hpp>
@@ -16,7 +18,8 @@
 #include <powsybl/iidm/VariantArray.hpp>
 #include <powsybl/iidm/VariantManager.hpp>
 #include <powsybl/iidm/VariantManagerHolder.hpp>
-#include <powsybl/iidm/converter/Anonymizer.hpp>
+#include <powsybl/iidm/converter/ExportOptions.hpp>
+#include <powsybl/iidm/converter/ImportOptions.hpp>
 #include <powsybl/stdcxx/DateTime.hpp>
 #include <powsybl/stdcxx/range.hpp>
 
@@ -50,13 +53,6 @@ class TwoWindingsTransformer;
 class VoltageLevel;
 class VscConverterStation;
 
-namespace converter {
-
-class ExportOptions;
-class ImportOptions;
-
-}  // namespace converter
-
 class Network : public Container, public VariantManagerHolder {
 public:
     using BusBreakerView = network::BusBreakerView;
@@ -64,15 +60,13 @@ public:
     using BusView = network::BusView;
 
 public:
-    static Network readXml(const std::string& data);
+    static Network readXml(const boost::filesystem::path& path, const converter::ImportOptions& options = converter::ImportOptions());
 
-    static Network readXml(std::istream& istream);
+    static Network readXml(const std::string& filename, std::istream& istream, const converter::ImportOptions& options = converter::ImportOptions());
 
-    static Network readXml(std::istream& istream, const converter::ImportOptions& options, const converter::Anonymizer& anonymizer);
+    static void writeXml(const boost::filesystem::path& path, const Network& network, const converter::ExportOptions& options = converter::ExportOptions());
 
-    static std::unique_ptr<converter::Anonymizer> writeXml(std::ostream& ostream, const Network& network);
-
-    static std::unique_ptr<converter::Anonymizer> writeXml(std::ostream& ostream, const Network& network, const converter::ExportOptions& options);
+    static void writeXml(const std::string& filename, std::ostream& ostream, const Network& network, const converter::ExportOptions& options = converter::ExportOptions());
 
 public:  // Identifiable
     const Network& getNetwork() const override;

--- a/include/powsybl/test/ResourceFixture.hpp
+++ b/include/powsybl/test/ResourceFixture.hpp
@@ -10,6 +10,8 @@
 
 #include <string>
 
+#include <boost/filesystem/path.hpp>
+
 #include <powsybl/test/CommandLine.hpp>
 
 namespace powsybl {
@@ -21,6 +23,8 @@ public:
     ResourceFixture();
 
     std::string getResource(const std::string& name) const;
+
+    boost::filesystem::path getResourcePath(const std::string& name) const;
 };
 
 }  // namespace test

--- a/include/powsybl/test/converter/RoundTrip.hpp
+++ b/include/powsybl/test/converter/RoundTrip.hpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/filesystem/path.hpp>
+
 #include <powsybl/iidm/Network.hpp>
 #include <powsybl/iidm/converter/xml/IidmXmlVersion.hpp>
 
@@ -40,7 +42,7 @@ public:
 
     static std::string getVersionedNetwork(const std::string& filename, const iidm::converter::xml::IidmXmlVersion& version);
 
-    static std::string getVersionedNetworkPath(const std::string& filename, const iidm::converter::xml::IidmXmlVersion& version);
+    static boost::filesystem::path getVersionedNetworkPath(const std::string& filename, const iidm::converter::xml::IidmXmlVersion& version);
 
     static void roundTripAllPreviousVersionedXmlTest(const std::string& filename);
 

--- a/src/iidm/Network.cpp
+++ b/src/iidm/Network.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <unordered_set>
 
+#include <boost/filesystem/fstream.hpp>
 #include <boost/range/join.hpp>
 
 #include <powsybl/iidm/Battery.hpp>
@@ -44,26 +45,28 @@ namespace powsybl {
 
 namespace iidm {
 
-Network Network::readXml(const std::string& data) {
-    std::stringstream stream(data);
-    return readXml(stream);
+Network Network::readXml(const boost::filesystem::path& path, const converter::ImportOptions& options) {
+    boost::filesystem::ifstream is(path);
+    if (!is.is_open()) {
+        throw PowsyblException(stdcxx::format("Unable to open file '%1%' for reading", path.filename().string()));
+    }
+    return readXml(path.filename().string(), is, options);
 }
 
-Network Network::readXml(std::istream& istream) {
-    return readXml(istream, converter::ImportOptions(), converter::FakeAnonymizer());
+Network Network::readXml(const std::string& filename, std::istream& istream, const converter::ImportOptions& options) {
+    return converter::xml::NetworkXml::read(filename, istream, options);
 }
 
-Network Network::readXml(std::istream& istream, const converter::ImportOptions& options, const converter::Anonymizer& anonymizer) {
-    return converter::xml::NetworkXml::read(istream, options, anonymizer);
+void Network::writeXml(const boost::filesystem::path& path, const Network& network, const converter::ExportOptions& options) {
+    boost::filesystem::ofstream os(path);
+    if (!os.is_open()) {
+        throw PowsyblException(stdcxx::format("Unable to open file '%1%' for writing", path.filename().string()));
+    }
+    writeXml(path.filename().string(), os, network, options);
 }
 
-std::unique_ptr<converter::Anonymizer> Network::writeXml(std::ostream& ostream, const Network& network) {
-    converter::ExportOptions options;
-    return writeXml(ostream, network, options);
-}
-
-std::unique_ptr<converter::Anonymizer> Network::writeXml(std::ostream& ostream, const Network& network, const converter::ExportOptions& options) {
-    return converter::xml::NetworkXml::write(ostream, network, options);
+void Network::writeXml(const std::string& filename, std::ostream& ostream, const Network& network, const converter::ExportOptions& options) {
+    converter::xml::NetworkXml::write(filename, ostream, network, options);
 }
 
 Network::Network(const std::string& id, const std::string& sourceFormat) :

--- a/src/iidm/Network.cpp
+++ b/src/iidm/Network.cpp
@@ -50,7 +50,7 @@ Network Network::readXml(const boost::filesystem::path& path, const converter::I
     if (!is.is_open()) {
         throw PowsyblException(stdcxx::format("Unable to open file '%1%' for reading", path.filename().string()));
     }
-    return readXml(path.filename().string(), is, options);
+    return converter::xml::NetworkXml::read(path.filename().string(), is, options);
 }
 
 Network Network::readXml(const std::string& filename, std::istream& istream, const converter::ImportOptions& options) {
@@ -62,7 +62,7 @@ void Network::writeXml(const boost::filesystem::path& path, const Network& netwo
     if (!os.is_open()) {
         throw PowsyblException(stdcxx::format("Unable to open file '%1%' for writing", path.filename().string()));
     }
-    writeXml(path.filename().string(), os, network, options);
+    converter::xml::NetworkXml::write(path.filename().string(), os, network, options);
 }
 
 void Network::writeXml(const std::string& filename, std::ostream& ostream, const Network& network, const converter::ExportOptions& options) {

--- a/src/iidm/converter/xml/NetworkXml.cpp
+++ b/src/iidm/converter/xml/NetworkXml.cpp
@@ -192,7 +192,7 @@ void writeExtensions(const Network& network, NetworkXmlWriterContext& context) {
     }
 }
 
-Network NetworkXml::read(std::istream& is, const ImportOptions& options, const Anonymizer& anonymizer) {
+Network NetworkXml::read(const std::string& /*filename*/, std::istream& is, const ImportOptions& options) {
     logging::Logger& logger = logging::LoggerFactory::getLogger<NetworkXml>();
 
     auto startTime = std::chrono::high_resolution_clock::now();
@@ -216,6 +216,10 @@ Network NetworkXml::read(std::istream& is, const ImportOptions& options, const A
     } catch (const PowsyblException& err) {
         throw powsybl::xml::XmlStreamException(err.what());
     }
+
+    // TODO(sebalaig) handle anonymization by reading csv file if it exists
+    // For now on, use a FakeAnonymizer
+    FakeAnonymizer anonymizer;
 
     NetworkXmlReaderContext context(anonymizer, reader, options, version);
 
@@ -260,12 +264,12 @@ Network NetworkXml::read(std::istream& is, const ImportOptions& options, const A
     return network;
 }
 
-std::unique_ptr<Anonymizer> NetworkXml::write(std::ostream& ostream, const Network& network, const ExportOptions& options) {
+std::unique_ptr<Anonymizer> NetworkXml::write(const std::string& /*filename*/, std::ostream& os, const Network& network, const ExportOptions& options) {
     logging::Logger& logger = logging::LoggerFactory::getLogger<NetworkXml>();
 
     auto startTime = std::chrono::high_resolution_clock::now();
 
-    powsybl::xml::XmlStreamWriter writer(ostream, options.isIndent());
+    powsybl::xml::XmlStreamWriter writer(os, options.isIndent());
 
     // FIXME(sebalaig): for now on, only one kind of anonymizer = FakeAnonymizer
     // later, a real anonymizer will be instantiated depending on options.isAnonymized()

--- a/src/iidm/converter/xml/NetworkXml.hpp
+++ b/src/iidm/converter/xml/NetworkXml.hpp
@@ -10,6 +10,7 @@
 
 #include <iosfwd>
 #include <memory>
+#include <string>
 
 namespace powsybl {
 
@@ -27,9 +28,9 @@ namespace xml {
 
 class NetworkXml {
 public:
-    static Network read(std::istream& is, const ImportOptions& options, const Anonymizer& anonymizer);
+    static Network read(const std::string& filename, std::istream& is, const ImportOptions& options);
 
-    static std::unique_ptr<Anonymizer> write(std::ostream& ostream, const Network& network, const ExportOptions& options);
+    static std::unique_ptr<Anonymizer> write(const std::string& filename, std::ostream& os, const Network& network, const ExportOptions& options);
 
 public:
     NetworkXml() = delete;

--- a/src/test/ResourceFixture.cpp
+++ b/src/test/ResourceFixture.cpp
@@ -29,8 +29,7 @@ ResourceFixture::ResourceFixture() {
 }
 
 std::string ResourceFixture::getResource(const std::string& name) const {
-    boost::filesystem::path path(getOptionValue("resources").as<std::string>());
-    path /= name;
+    const boost::filesystem::path& path = getResourcePath(name);
 
     if (!boost::filesystem::exists(path)) {
         throw powsybl::AssertionError(stdcxx::format("Unable to find the resource: %1%", path.string()));
@@ -45,6 +44,12 @@ std::string ResourceFixture::getResource(const std::string& name) const {
     buffer << stream.rdbuf();
 
     return buffer.str();
+}
+
+boost::filesystem::path ResourceFixture::getResourcePath(const std::string& name) const {
+    boost::filesystem::path path(getOptionValue("resources").as<std::string>());
+    path /= name;
+    return path;
 }
 
 }  // namespace test

--- a/src/test/converter/RoundTrip.cpp
+++ b/src/test/converter/RoundTrip.cpp
@@ -40,11 +40,13 @@ std::string RoundTrip::getVersionDir(const iidm::converter::xml::IidmXmlVersion&
 std::string RoundTrip::getVersionedNetwork(const std::string& filename, const iidm::converter::xml::IidmXmlVersion& version) {
     ResourceFixture fixture;
 
-    return fixture.getResource(getVersionedNetworkPath(filename, version));
+    return fixture.getResource(getVersionDir(version) + filename);
 }
 
-std::string RoundTrip::getVersionedNetworkPath(const std::string& filename, const iidm::converter::xml::IidmXmlVersion& version) {
-    return getVersionDir(version) + filename;
+boost::filesystem::path RoundTrip::getVersionedNetworkPath(const std::string& filename, const iidm::converter::xml::IidmXmlVersion& version) {
+    ResourceFixture fixture;
+
+    return fixture.getResourcePath(getVersionDir(version) + filename);
 }
 
 void RoundTrip::roundTripAllPreviousVersionedXmlTest(const std::string& filename) {

--- a/src/test/converter/RoundTrip.cpp
+++ b/src/test/converter/RoundTrip.cpp
@@ -68,16 +68,17 @@ void RoundTrip::roundTripVersionedXmlTest(const std::string& filename, const iid
     const auto& writer = [&version](const iidm::Network& n, std::ostream& stream) {
         iidm::converter::ExportOptions options;
         options.setVersion(version.toString("."));
-        iidm::Network::writeXml(stream, n, options);
+        iidm::Network::writeXml(stdcxx::format("%1%.xiidm", n.getId()), stream, n, options);
     };
 
-    const auto& reader = [](const std::string& xml) {
-        std::istringstream stream(xml);
-        return iidm::Network::readXml(stream);
+    const auto& reader = [](const std::string& networkStr) {
+        std::istringstream stream(networkStr);
+        return iidm::Network::readXml("network.xiidm", stream);
     };
 
     const std::string& expected = getVersionedNetwork(filename, version);
-    iidm::Network network = iidm::Network::readXml(expected);
+    std::istringstream stream(expected);
+    iidm::Network network = iidm::Network::readXml("network.xiidm", stream);
     run(network, writer, reader, compareXml, expected);
 }
 
@@ -96,12 +97,12 @@ iidm::Network RoundTrip::run(const iidm::Network& network, const Writer& out, co
 
 iidm::Network RoundTrip::runXml(const iidm::Network& network, const std::string& ref) {
     const auto& writer = [](const iidm::Network& n, std::ostream& stream) {
-        iidm::Network::writeXml(stream, n);
+        iidm::Network::writeXml(stdcxx::format("%1%.xiidm", n.getId()), stream, n);
     };
 
-    const auto& reader = [](const std::string& xml) {
-        std::istringstream stream(xml);
-        return iidm::Network::readXml(stream);
+    const auto& reader = [](const std::string& networkStr) {
+        std::istringstream stream(networkStr);
+        return iidm::Network::readXml("network.xiidm", stream);
     };
 
     return run(network, writer, reader, compareXml, ref);

--- a/src/test/converter/RoundTrip.cpp
+++ b/src/test/converter/RoundTrip.cpp
@@ -65,20 +65,20 @@ void RoundTrip::roundTripVersionedXmlFromMinToCurrentVersionTest(const std::stri
 }
 
 void RoundTrip::roundTripVersionedXmlTest(const std::string& filename, const iidm::converter::xml::IidmXmlVersion& version) {
-    const auto& writer = [&version](const iidm::Network& n, std::ostream& stream) {
+    const auto& writer = [&version, &filename](const iidm::Network& n, std::ostream& stream) {
         iidm::converter::ExportOptions options;
         options.setVersion(version.toString("."));
-        iidm::Network::writeXml(stdcxx::format("%1%.xiidm", n.getId()), stream, n, options);
+        iidm::Network::writeXml(filename, stream, n, options);
     };
 
-    const auto& reader = [](const std::string& networkStr) {
+    const auto& reader = [&filename](const std::string& networkStr) {
         std::istringstream stream(networkStr);
-        return iidm::Network::readXml("network.xiidm", stream);
+        return iidm::Network::readXml(filename, stream);
     };
 
     const std::string& expected = getVersionedNetwork(filename, version);
     std::istringstream stream(expected);
-    iidm::Network network = iidm::Network::readXml("network.xiidm", stream);
+    iidm::Network network = iidm::Network::readXml(filename, stream);
     run(network, writer, reader, compareXml, expected);
 }
 
@@ -97,7 +97,8 @@ iidm::Network RoundTrip::run(const iidm::Network& network, const Writer& out, co
 
 iidm::Network RoundTrip::runXml(const iidm::Network& network, const std::string& ref) {
     const auto& writer = [](const iidm::Network& n, std::ostream& stream) {
-        iidm::Network::writeXml(stdcxx::format("%1%.xiidm", n.getId()), stream, n);
+        const std::string& filename = stdcxx::format("%1%.xiidm", n.getId());
+        iidm::Network::writeXml(filename, stream, n);
     };
 
     const auto& reader = [](const std::string& networkStr) {

--- a/src/test/converter/RoundTrip.cpp
+++ b/src/test/converter/RoundTrip.cpp
@@ -73,8 +73,8 @@ void RoundTrip::roundTripVersionedXmlTest(const std::string& filename, const iid
         iidm::Network::writeXml(filename, stream, n, options);
     };
 
-    const auto& reader = [&filename](const std::string& networkStr) {
-        std::istringstream stream(networkStr);
+    const auto& reader = [&filename](const std::string& xmlBytes) {
+        std::istringstream stream(xmlBytes);
         return iidm::Network::readXml(filename, stream);
     };
 
@@ -98,14 +98,15 @@ iidm::Network RoundTrip::run(const iidm::Network& network, const Writer& out, co
 }
 
 iidm::Network RoundTrip::runXml(const iidm::Network& network, const std::string& ref) {
-    const auto& writer = [](const iidm::Network& n, std::ostream& stream) {
-        const std::string& filename = stdcxx::format("%1%.xiidm", n.getId());
+    const std::string& filename = stdcxx::format("%1%.xiidm", network.getId());
+
+    const auto& writer = [&filename](const iidm::Network& n, std::ostream& stream) {
         iidm::Network::writeXml(filename, stream, n);
     };
 
-    const auto& reader = [](const std::string& networkStr) {
-        std::istringstream stream(networkStr);
-        return iidm::Network::readXml("network.xiidm", stream);
+    const auto& reader = [&filename](const std::string& xmlBytes) {
+        std::istringstream stream(xmlBytes);
+        return iidm::Network::readXml(filename, stream);
     };
 
     return run(network, writer, reader, compareXml, ref);

--- a/test/iidm/converter/xml/IdentifiableExtensionXmlSerializerTest.cpp
+++ b/test/iidm/converter/xml/IdentifiableExtensionXmlSerializerTest.cpp
@@ -56,8 +56,9 @@ BOOST_AUTO_TEST_CASE(TerminalExtension) {
     Load& load = network.getLoad("LOAD");
     load.addExtension(stdcxx::make_unique<extensions::TerminalMockExt>(load));
 
-    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork("eurostag-tutorial-example1-with-terminalMock-ext.xml", IidmXmlVersion::CURRENT_IIDM_XML_VERSION()));
-    Network network2 = Network::readXml("network.xiidm", stream);
+    const std::string& filename = "eurostag-tutorial-example1-with-terminalMock-ext.xml";
+    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::CURRENT_IIDM_XML_VERSION()));
+    Network network2 = Network::readXml(filename, stream);
     Load& load2 = network2.getLoad("LOAD");
     const auto& terminalMockExt = load2.getExtension<extensions::TerminalMockExt>();
     BOOST_TEST(stdcxx::areSame(load2.getTerminal(), terminalMockExt.getTerminal()));
@@ -66,17 +67,19 @@ BOOST_AUTO_TEST_CASE(TerminalExtension) {
 }
 
 BOOST_AUTO_TEST_CASE(IncompatibleExtensionVersion) {
-    const std::string& strNetwork = test::converter::RoundTrip::getVersionedNetwork("eurostag-tutorial-example1-with-bad-loadMockExt.xml", IidmXmlVersion::V1_1());
+    const std::string& filename = "eurostag-tutorial-example1-with-bad-loadMockExt.xml";
+    const std::string& strNetwork = test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_1());
 
     std::istringstream stream(strNetwork);
-    POWSYBL_ASSERT_THROW(Network::readXml("network.xiidm", stream), PowsyblException, "IIDM-XML version of network (1.1) is not compatible with the loadMock extension's namespace URI");
+    POWSYBL_ASSERT_THROW(Network::readXml(filename, stream), PowsyblException, "IIDM-XML version of network (1.1) is not compatible with the loadMock extension's namespace URI");
 }
 
 BOOST_AUTO_TEST_CASE(UnsupportedExtensionVersion) {
-    const std::string& strNetwork = test::converter::RoundTrip::getVersionedNetwork("eurostag-tutorial-example1-with-bad-loadQuxExt.xml", IidmXmlVersion::V1_1());
+    const std::string& filename = "eurostag-tutorial-example1-with-bad-loadQuxExt.xml";
+    const std::string& strNetwork = test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_1());
 
     std::istringstream stream(strNetwork);
-    POWSYBL_ASSERT_THROW(Network::readXml("network.xiidm", stream), PowsyblException, "IIDM-XML version of network (1.1) is not supported by the loadQux extension's XML serializer");
+    POWSYBL_ASSERT_THROW(Network::readXml(filename, stream), PowsyblException, "IIDM-XML version of network (1.1) is not supported by the loadQux extension's XML serializer");
 }
 
 BOOST_AUTO_TEST_CASE(MultipleExtensionRoundTrip) {
@@ -84,8 +87,9 @@ BOOST_AUTO_TEST_CASE(MultipleExtensionRoundTrip) {
 }
 
 BOOST_AUTO_TEST_CASE(NotLatestVersionTerminalExtension) {
-    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork("eurostag-tutorial-example1-with-loadMockExt-1_2.xml", IidmXmlVersion::V1_1()));
-    const auto& network = Network::readXml("network.xiidm", stream);
+    const std::string& filename = "eurostag-tutorial-example1-with-loadMockExt-1_2.xml";
+    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_1()));
+    const auto& network = Network::readXml(filename, stream);
 
     // properties specify that IIDM-XML network version to export is 1.1
     // FIXME(mathbag): Implement properties
@@ -97,18 +101,19 @@ BOOST_AUTO_TEST_CASE(NotLatestVersionTerminalExtension) {
     options.addExtensionVersion("loadMock", "1.1");
 
     std::stringstream buffer;
-    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), buffer, network, options);
+    Network::writeXml(filename, buffer, network, options);
 
     // check that loadMock has been serialized in v1.1
     test::converter::RoundTrip::compareXml(test::converter::RoundTrip::getVersionedNetwork("eurostag-tutorial-example1-with-loadMockExt-1_1.xml", IidmXmlVersion::V1_1()), buffer.str());
 }
 
 BOOST_AUTO_TEST_CASE(ThrowErrorIncompatibleExtensionVersion) {
-    const auto& strNetwork = test::converter::RoundTrip::getVersionedNetwork("eurostag-tutorial-example1-with-bad-loadMockExt.xml", IidmXmlVersion::V1_1());
+    const std::string& filename = "eurostag-tutorial-example1-with-bad-loadMockExt.xml";
+    const auto& strNetwork = test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_1());
 
     // should fail while trying to import a file in IIDM-XML network version 1.1 and loadMock in v1.0 (not compatible)
     std::istringstream stream(strNetwork);
-    POWSYBL_ASSERT_THROW(Network::readXml("network.xiidm", stream), PowsyblException, "IIDM-XML version of network (1.1) is not compatible with the loadMock extension's namespace URI");
+    POWSYBL_ASSERT_THROW(Network::readXml(filename, stream), PowsyblException, "IIDM-XML version of network (1.1) is not compatible with the loadMock extension's namespace URI");
 }
 
 BOOST_AUTO_TEST_CASE(ThrowErrorUnsupportedExtensionVersion1) {
@@ -119,15 +124,17 @@ BOOST_AUTO_TEST_CASE(ThrowErrorUnsupportedExtensionVersion1) {
 
     // should fail while trying to import a file with loadBar in v1.1 (does not exist, considered as not supported)
     std::ostringstream buffer;
-    POWSYBL_ASSERT_THROW(Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), buffer, network, options), PowsyblException, "The version 1.1 of the loadBar extension's XML serializer is not supported");
+    const std::string& filename = stdcxx::format("%1%.xiidm", network.getId());
+    POWSYBL_ASSERT_THROW(Network::writeXml(filename, buffer, network, options), PowsyblException, "The version 1.1 of the loadBar extension's XML serializer is not supported");
 }
 
 BOOST_AUTO_TEST_CASE(ThrowErrorUnsupportedExtensionVersion2) {
-    const auto& strNetwork = test::converter::RoundTrip::getVersionedNetwork("eurostag-tutorial-example1-with-bad-loadQuxExt.xml", IidmXmlVersion::V1_1());
+    const std::string& filename = "eurostag-tutorial-example1-with-bad-loadQuxExt.xml";
+    const auto& strNetwork = test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_1());
 
     // should fail while trying to import a file in IIDM-XML network version 1.1 and loadMock in v1.0 (not compatible)
     std::istringstream stream(strNetwork);
-    POWSYBL_ASSERT_THROW(Network::readXml("network.xiidm", stream), PowsyblException, "IIDM-XML version of network (1.1) is not supported by the loadQux extension's XML serializer");
+    POWSYBL_ASSERT_THROW(Network::readXml(filename, stream), PowsyblException, "IIDM-XML version of network (1.1) is not supported by the loadQux extension's XML serializer");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/iidm/converter/xml/IdentifiableExtensionXmlSerializerTest.cpp
+++ b/test/iidm/converter/xml/IdentifiableExtensionXmlSerializerTest.cpp
@@ -56,9 +56,7 @@ BOOST_AUTO_TEST_CASE(TerminalExtension) {
     Load& load = network.getLoad("LOAD");
     load.addExtension(stdcxx::make_unique<extensions::TerminalMockExt>(load));
 
-    const std::string& filename = "eurostag-tutorial-example1-with-terminalMock-ext.xml";
-    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::CURRENT_IIDM_XML_VERSION()));
-    Network network2 = Network::readXml(filename, stream);
+    Network network2 = Network::readXml(test::converter::RoundTrip::getVersionedNetworkPath("eurostag-tutorial-example1-with-terminalMock-ext.xml", IidmXmlVersion::CURRENT_IIDM_XML_VERSION()));
     Load& load2 = network2.getLoad("LOAD");
     const auto& terminalMockExt = load2.getExtension<extensions::TerminalMockExt>();
     BOOST_TEST(stdcxx::areSame(load2.getTerminal(), terminalMockExt.getTerminal()));
@@ -67,19 +65,13 @@ BOOST_AUTO_TEST_CASE(TerminalExtension) {
 }
 
 BOOST_AUTO_TEST_CASE(IncompatibleExtensionVersion) {
-    const std::string& filename = "eurostag-tutorial-example1-with-bad-loadMockExt.xml";
-    const std::string& strNetwork = test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_1());
-
-    std::istringstream stream(strNetwork);
-    POWSYBL_ASSERT_THROW(Network::readXml(filename, stream), PowsyblException, "IIDM-XML version of network (1.1) is not compatible with the loadMock extension's namespace URI");
+    const auto& path = test::converter::RoundTrip::getVersionedNetworkPath("eurostag-tutorial-example1-with-bad-loadMockExt.xml", IidmXmlVersion::V1_1());
+    POWSYBL_ASSERT_THROW(Network::readXml(path), PowsyblException, "IIDM-XML version of network (1.1) is not compatible with the loadMock extension's namespace URI");
 }
 
 BOOST_AUTO_TEST_CASE(UnsupportedExtensionVersion) {
-    const std::string& filename = "eurostag-tutorial-example1-with-bad-loadQuxExt.xml";
-    const std::string& strNetwork = test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_1());
-
-    std::istringstream stream(strNetwork);
-    POWSYBL_ASSERT_THROW(Network::readXml(filename, stream), PowsyblException, "IIDM-XML version of network (1.1) is not supported by the loadQux extension's XML serializer");
+    const auto& path = test::converter::RoundTrip::getVersionedNetworkPath("eurostag-tutorial-example1-with-bad-loadQuxExt.xml", IidmXmlVersion::V1_1());
+    POWSYBL_ASSERT_THROW(Network::readXml(path), PowsyblException, "IIDM-XML version of network (1.1) is not supported by the loadQux extension's XML serializer");
 }
 
 BOOST_AUTO_TEST_CASE(MultipleExtensionRoundTrip) {
@@ -88,8 +80,7 @@ BOOST_AUTO_TEST_CASE(MultipleExtensionRoundTrip) {
 
 BOOST_AUTO_TEST_CASE(NotLatestVersionTerminalExtension) {
     const std::string& filename = "eurostag-tutorial-example1-with-loadMockExt-1_2.xml";
-    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_1()));
-    const auto& network = Network::readXml(filename, stream);
+    const auto& network = Network::readXml(test::converter::RoundTrip::getVersionedNetworkPath(filename, IidmXmlVersion::V1_1()));
 
     // properties specify that IIDM-XML network version to export is 1.1
     // FIXME(mathbag): Implement properties
@@ -108,12 +99,10 @@ BOOST_AUTO_TEST_CASE(NotLatestVersionTerminalExtension) {
 }
 
 BOOST_AUTO_TEST_CASE(ThrowErrorIncompatibleExtensionVersion) {
-    const std::string& filename = "eurostag-tutorial-example1-with-bad-loadMockExt.xml";
-    const auto& strNetwork = test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_1());
+    const auto& path = test::converter::RoundTrip::getVersionedNetworkPath("eurostag-tutorial-example1-with-bad-loadMockExt.xml", IidmXmlVersion::V1_1());
 
     // should fail while trying to import a file in IIDM-XML network version 1.1 and loadMock in v1.0 (not compatible)
-    std::istringstream stream(strNetwork);
-    POWSYBL_ASSERT_THROW(Network::readXml(filename, stream), PowsyblException, "IIDM-XML version of network (1.1) is not compatible with the loadMock extension's namespace URI");
+    POWSYBL_ASSERT_THROW(Network::readXml(path), PowsyblException, "IIDM-XML version of network (1.1) is not compatible with the loadMock extension's namespace URI");
 }
 
 BOOST_AUTO_TEST_CASE(ThrowErrorUnsupportedExtensionVersion1) {
@@ -129,12 +118,10 @@ BOOST_AUTO_TEST_CASE(ThrowErrorUnsupportedExtensionVersion1) {
 }
 
 BOOST_AUTO_TEST_CASE(ThrowErrorUnsupportedExtensionVersion2) {
-    const std::string& filename = "eurostag-tutorial-example1-with-bad-loadQuxExt.xml";
-    const auto& strNetwork = test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_1());
+    const auto& path = test::converter::RoundTrip::getVersionedNetworkPath("eurostag-tutorial-example1-with-bad-loadQuxExt.xml", IidmXmlVersion::V1_1());
 
     // should fail while trying to import a file in IIDM-XML network version 1.1 and loadMock in v1.0 (not compatible)
-    std::istringstream stream(strNetwork);
-    POWSYBL_ASSERT_THROW(Network::readXml(filename, stream), PowsyblException, "IIDM-XML version of network (1.1) is not supported by the loadQux extension's XML serializer");
+    POWSYBL_ASSERT_THROW(Network::readXml(path), PowsyblException, "IIDM-XML version of network (1.1) is not supported by the loadQux extension's XML serializer");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/iidm/converter/xml/LinesRoundTripTest.cpp
+++ b/test/iidm/converter/xml/LinesRoundTripTest.cpp
@@ -121,7 +121,8 @@ BOOST_FIXTURE_TEST_CASE(DanglingLineWithGenerationTest, test::ResourceFixture) {
     test::converter::RoundTrip::testForAllPreviousVersions(IidmXmlVersion::V1_3(), [&network](const iidm::converter::xml::IidmXmlVersion& version) {
         std::stringstream ss;
         ExportOptions options = ExportOptions().setVersion(version.toString("."));
-        POWSYBL_ASSERT_THROW(Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ss, network, options), PowsyblException, stdcxx::format("danglingLine.generation is not null and not supported for IIDM-XML version %1%. IIDM-XML version should be >= 1.3", version.toString(".")).c_str());
+        const std::string& filename = stdcxx::format("%1%.xiidm", network.getId());
+        POWSYBL_ASSERT_THROW(Network::writeXml(filename, ss, network, options), PowsyblException, stdcxx::format("danglingLine.generation is not null and not supported for IIDM-XML version %1%. IIDM-XML version should be >= 1.3", version.toString(".")).c_str());
     });
 
     // check it doesn't fail for all versions < 1.3 if IidmVersionIncompatibilityBehavior is to log error

--- a/test/iidm/converter/xml/LinesRoundTripTest.cpp
+++ b/test/iidm/converter/xml/LinesRoundTripTest.cpp
@@ -121,14 +121,14 @@ BOOST_FIXTURE_TEST_CASE(DanglingLineWithGenerationTest, test::ResourceFixture) {
     test::converter::RoundTrip::testForAllPreviousVersions(IidmXmlVersion::V1_3(), [&network](const iidm::converter::xml::IidmXmlVersion& version) {
         std::stringstream ss;
         ExportOptions options = ExportOptions().setVersion(version.toString("."));
-        POWSYBL_ASSERT_THROW(Network::writeXml(ss, network, options), PowsyblException, stdcxx::format("danglingLine.generation is not null and not supported for IIDM-XML version %1%. IIDM-XML version should be >= 1.3", version.toString(".")).c_str());
+        POWSYBL_ASSERT_THROW(Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ss, network, options), PowsyblException, stdcxx::format("danglingLine.generation is not null and not supported for IIDM-XML version %1%. IIDM-XML version should be >= 1.3", version.toString(".")).c_str());
     });
 
     // check it doesn't fail for all versions < 1.3 if IidmVersionIncompatibilityBehavior is to log error
     test::converter::RoundTrip::testForAllPreviousVersions(IidmXmlVersion::V1_3(), [&network](const iidm::converter::xml::IidmXmlVersion& version) {
         ExportOptions options = ExportOptions().setVersion(version.toString(".")).setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR);
         const auto& writer = [&options](const iidm::Network& n, std::ostream& stream) {
-            iidm::Network::writeXml(stream, n, options);
+            iidm::Network::writeXml(stdcxx::format("%1%.xiidm", n.getId()), stream, n, options);
         };
         test::converter::RoundTrip::writeXmlTest(network, writer, test::converter::RoundTrip::getVersionedNetwork("danglingLineWithGeneration.xml", version));
     });

--- a/test/iidm/converter/xml/NetworkXmlTest.cpp
+++ b/test/iidm/converter/xml/NetworkXmlTest.cpp
@@ -117,17 +117,18 @@ BOOST_AUTO_TEST_CASE(FromParameters) {
     const Network& network = Network::readXml("network.xiidm", stream, ImportOptions(properties));
 
     std::stringstream ostream;
-    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ostream, network, ExportOptions(properties));
+    const std::string& filename = stdcxx::format("%1%.xiidm", network.getId());
+    Network::writeXml(filename, ostream, network, ExportOptions(properties));
 
     properties.set(ExportOptions::TOPOLOGY_LEVEL, "true");
-    POWSYBL_ASSERT_THROW(Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ostream, network, ExportOptions(properties)), AssertionError, "Unexpected TopologyLevel name: true");
+    POWSYBL_ASSERT_THROW(Network::writeXml(filename, ostream, network, ExportOptions(properties)), AssertionError, "Unexpected TopologyLevel name: true");
     properties.remove(ExportOptions::TOPOLOGY_LEVEL);
 
     std::set<std::string> extensions;
     extensions.insert("extension1");
     extensions.insert("extension2");
     properties.set(ExportOptions::EXTENSIONS_LIST, boost::algorithm::join(extensions, ","));
-    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ostream, network, ExportOptions(properties));
+    Network::writeXml(filename, ostream, network, ExportOptions(properties));
 }
 
 BOOST_AUTO_TEST_CASE(WriteFromParametersCheckExtensions) {
@@ -135,9 +136,10 @@ BOOST_AUTO_TEST_CASE(WriteFromParametersCheckExtensions) {
 
     stdcxx::Properties properties;
     std::stringstream ostream;
+    const std::string& filename = stdcxx::format("%1%.xiidm", network.getId());
 
     properties.set(ExportOptions::EXTENSIONS_LIST, "loadBar");
-    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ostream, network, ExportOptions(properties));
+    Network::writeXml(filename, ostream, network, ExportOptions(properties));
     const std::string& loadBarOnly = ostream.str();
     BOOST_TEST(loadBarOnly.find("loadBar") != std::string::npos);
     BOOST_TEST(loadBarOnly.find("loadFoo") == std::string::npos);
@@ -145,7 +147,7 @@ BOOST_AUTO_TEST_CASE(WriteFromParametersCheckExtensions) {
     ostream.str("");
     ostream.clear();
     properties.set(ExportOptions::EXTENSIONS_LIST, "loadFoo");
-    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ostream, network, ExportOptions(properties));
+    Network::writeXml(filename, ostream, network, ExportOptions(properties));
     const std::string& loadFooOnly = ostream.str();
     BOOST_TEST(loadFooOnly.find("loadBar") == std::string::npos);
     BOOST_TEST(loadFooOnly.find("loadFoo") != std::string::npos);
@@ -153,13 +155,13 @@ BOOST_AUTO_TEST_CASE(WriteFromParametersCheckExtensions) {
     ostream.str("");
     ostream.clear();
     properties.remove(ExportOptions::EXTENSIONS_LIST);
-    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ostream, network, ExportOptions(properties));
+    Network::writeXml(filename, ostream, network, ExportOptions(properties));
     const std::string& loadAllExtsOutput = ostream.str();
     BOOST_TEST(loadAllExtsOutput.find("loadBar") != std::string::npos);
     BOOST_TEST(loadAllExtsOutput.find("loadFoo") != std::string::npos);
 
     std::stringstream referenceStream;
-    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), referenceStream, network);
+    Network::writeXml(filename, referenceStream, network);
     const std::string& refOutput = referenceStream.str();
     BOOST_TEST(refOutput.find("loadBar") != std::string::npos);
     BOOST_TEST(refOutput.find("loadFoo") != std::string::npos);
@@ -172,28 +174,29 @@ BOOST_AUTO_TEST_CASE(ReadFromParametersCheckExtensions) {
     std::stringstream inputStream;
 
     Network network = powsybl::network::MultipleExtensionsTestNetworkFactory::MultipleExtensionsTestNetworkFactory::create();
-    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), inputStream, network);
+    const std::string& filename = stdcxx::format("%1%.xiidm", network.getId());
+    Network::writeXml(filename, inputStream, network);
 
     std::string refString = inputStream.str();
 
     properties.set(ImportOptions::EXTENSIONS_LIST, "loadFoo");
     inputStream.str(refString);
     inputStream.clear();
-    Network fooNetwork = Network::readXml(stdcxx::format("%1%.xiidm", network.getId()), inputStream, ImportOptions(properties));
+    Network fooNetwork = Network::readXml(filename, inputStream, ImportOptions(properties));
     BOOST_CHECK_EQUAL(1UL, boost::size(fooNetwork.getLoad("LOAD").getExtensions()));
     BOOST_CHECK_EQUAL(1UL, boost::size(fooNetwork.getLoad("LOAD2").getExtensions()));
 
     properties.set(ImportOptions::EXTENSIONS_LIST, "loadBar");
     inputStream.str(refString);
     inputStream.clear();
-    Network barNetwork = Network::readXml(stdcxx::format("%1%.xiidm", network.getId()), inputStream, ImportOptions(properties));
+    Network barNetwork = Network::readXml(filename, inputStream, ImportOptions(properties));
     BOOST_CHECK_EQUAL(1UL, boost::size(barNetwork.getLoad("LOAD").getExtensions()));
     BOOST_CHECK_EQUAL(0UL, boost::size(barNetwork.getLoad("LOAD2").getExtensions()));
 
     properties.remove(ImportOptions::EXTENSIONS_LIST);
     inputStream.str(refString);
     inputStream.clear();
-    Network allExtNetwork = Network::readXml(stdcxx::format("%1%.xiidm", network.getId()), inputStream, ImportOptions(properties));
+    Network allExtNetwork = Network::readXml(filename, inputStream, ImportOptions(properties));
     BOOST_CHECK_EQUAL(2UL, boost::size(allExtNetwork.getLoad("LOAD").getExtensions()));
     BOOST_CHECK_EQUAL(1UL, boost::size(allExtNetwork.getLoad("LOAD2").getExtensions()));
 }

--- a/test/iidm/converter/xml/OptionalLoadTypeBugTest.cpp
+++ b/test/iidm/converter/xml/OptionalLoadTypeBugTest.cpp
@@ -25,8 +25,9 @@ BOOST_AUTO_TEST_SUITE(OptionalLoadTypeTest)
 
 BOOST_AUTO_TEST_CASE(OptionalLoadTypeFromXml) {
     for (const auto& version : IidmXmlVersion::all()) {
-        std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork("optionalLoadTypeBug.xml", version.get()));
-        Network network = Network::readXml("network.xiidm", stream);
+        const std::string& filename = "optionalLoadTypeBug.xml";
+        std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, version.get()));
+        Network network = Network::readXml(filename, stream);
         BOOST_CHECK_EQUAL(LoadType::UNDEFINED, network.getLoad("L").getLoadType());
     }
 }

--- a/test/iidm/converter/xml/OptionalLoadTypeBugTest.cpp
+++ b/test/iidm/converter/xml/OptionalLoadTypeBugTest.cpp
@@ -25,7 +25,8 @@ BOOST_AUTO_TEST_SUITE(OptionalLoadTypeTest)
 
 BOOST_AUTO_TEST_CASE(OptionalLoadTypeFromXml) {
     for (const auto& version : IidmXmlVersion::all()) {
-        Network network = Network::readXml(test::converter::RoundTrip::getVersionedNetwork("optionalLoadTypeBug.xml", version.get()));
+        std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork("optionalLoadTypeBug.xml", version.get()));
+        Network network = Network::readXml("network.xiidm", stream);
         BOOST_CHECK_EQUAL(LoadType::UNDEFINED, network.getLoad("L").getLoadType());
     }
 }

--- a/test/iidm/converter/xml/OptionalLoadTypeBugTest.cpp
+++ b/test/iidm/converter/xml/OptionalLoadTypeBugTest.cpp
@@ -25,9 +25,7 @@ BOOST_AUTO_TEST_SUITE(OptionalLoadTypeTest)
 
 BOOST_AUTO_TEST_CASE(OptionalLoadTypeFromXml) {
     for (const auto& version : IidmXmlVersion::all()) {
-        const std::string& filename = "optionalLoadTypeBug.xml";
-        std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, version.get()));
-        Network network = Network::readXml(filename, stream);
+        Network network = Network::readXml(test::converter::RoundTrip::getVersionedNetworkPath("optionalLoadTypeBug.xml", version.get()));
         BOOST_CHECK_EQUAL(LoadType::UNDEFINED, network.getLoad("L").getLoadType());
     }
 }

--- a/test/iidm/converter/xml/ShuntCompensatorRoundTripTest.cpp
+++ b/test/iidm/converter/xml/ShuntCompensatorRoundTripTest.cpp
@@ -115,8 +115,9 @@ BOOST_FIXTURE_TEST_CASE(ShuntNonLinearRoundTripTest, test::ResourceFixture) {
     // check that it fails for versions previous to 1.2
     test::converter::RoundTrip::testForAllPreviousVersions(IidmXmlVersion::V1_3(), [&network](const iidm::converter::xml::IidmXmlVersion& version) {
         std::stringstream ss;
+        const std::string& filename = stdcxx::format("%1%.xiidm", network.getId());
         ExportOptions options = ExportOptions().setVersion(version.toString("."));
-        POWSYBL_ASSERT_THROW(Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ss, network, options), PowsyblException, stdcxx::format("shunt.shuntNonLinearModel is not supported for IIDM-XML version %1%. IIDM-XML version should be >= 1.3", version.toString(".")).c_str());
+        POWSYBL_ASSERT_THROW(Network::writeXml(filename, ss, network, options), PowsyblException, stdcxx::format("shunt.shuntNonLinearModel is not supported for IIDM-XML version %1%. IIDM-XML version should be >= 1.3", version.toString(".")).c_str());
     });
 
     // check that it doesn't fail for versions previous to 1.2 when log error is the IIDM version incompatibility behavior

--- a/test/iidm/converter/xml/ShuntCompensatorRoundTripTest.cpp
+++ b/test/iidm/converter/xml/ShuntCompensatorRoundTripTest.cpp
@@ -116,14 +116,14 @@ BOOST_FIXTURE_TEST_CASE(ShuntNonLinearRoundTripTest, test::ResourceFixture) {
     test::converter::RoundTrip::testForAllPreviousVersions(IidmXmlVersion::V1_3(), [&network](const iidm::converter::xml::IidmXmlVersion& version) {
         std::stringstream ss;
         ExportOptions options = ExportOptions().setVersion(version.toString("."));
-        POWSYBL_ASSERT_THROW(Network::writeXml(ss, network, options), PowsyblException, stdcxx::format("shunt.shuntNonLinearModel is not supported for IIDM-XML version %1%. IIDM-XML version should be >= 1.3", version.toString(".")).c_str());
+        POWSYBL_ASSERT_THROW(Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ss, network, options), PowsyblException, stdcxx::format("shunt.shuntNonLinearModel is not supported for IIDM-XML version %1%. IIDM-XML version should be >= 1.3", version.toString(".")).c_str());
     });
 
     // check that it doesn't fail for versions previous to 1.2 when log error is the IIDM version incompatibility behavior
     test::converter::RoundTrip::testForAllPreviousVersions(IidmXmlVersion::V1_3(), [&network](const iidm::converter::xml::IidmXmlVersion& version) {
         ExportOptions options = ExportOptions().setVersion(version.toString(".")).setIidmVersionIncompatibilityBehavior(ExportOptions::IidmVersionIncompatibilityBehavior::LOG_ERROR);
         const auto& writer = [&options](const iidm::Network& n, std::ostream& stream) {
-            iidm::Network::writeXml(stream, n, options);
+            iidm::Network::writeXml(stdcxx::format("%1%.xiidm", n.getId()), stream, n, options);
         };
         test::converter::RoundTrip::writeXmlTest(network, writer, test::converter::RoundTrip::getVersionedNetwork("nonLinearShuntRoundTripRef.xml", version));
     });

--- a/test/iidm/converter/xml/SkipExtensionTest.cpp
+++ b/test/iidm/converter/xml/SkipExtensionTest.cpp
@@ -34,8 +34,9 @@ namespace xml {
 BOOST_AUTO_TEST_SUITE(SkipExtensionTestSuite)
 
 BOOST_FIXTURE_TEST_CASE(SkipExtensionTest, test::ResourceFixture) {
-    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork("multiple-extensions.xml", IidmXmlVersion::V1_0()));
-    Network network = Network::readXml("network.xiidm", stream);
+    const std::string& filename = "multiple-extensions.xml";
+    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_0()));
+    Network network = Network::readXml(filename, stream);
     const std::string& refNetwork = test::converter::RoundTrip::getVersionedNetwork("noExtension.xml", IidmXmlVersion::V1_0());
 
     stdcxx::Properties properties;
@@ -43,44 +44,44 @@ BOOST_FIXTURE_TEST_CASE(SkipExtensionTest, test::ResourceFixture) {
 
     properties.set(ExportOptions::EXTENSIONS_LIST, "");
     properties.set(ExportOptions::VERSION, "1.0");
-    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ostream, network, ExportOptions(properties));
+    Network::writeXml(filename, ostream, network, ExportOptions(properties));
     BOOST_CHECK_EQUAL(refNetwork, ostream.str());
 }
 
 BOOST_FIXTURE_TEST_CASE(checkSomeFiltered, test::ResourceFixture) {
-    std::stringstream stream;
-    stream << test::converter::RoundTrip::getVersionedNetwork("multiple-extensions.xml", IidmXmlVersion::V1_0());
+    const std::string& filename = "multiple-extensions.xml";
+    std::stringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_0()));
 
     stdcxx::Properties properties;
     properties.set(ImportOptions::EXTENSIONS_LIST, "loadFoo");
 
-    Network network = Network::readXml("network.xiidm", stream, ImportOptions(properties));
+    Network network = Network::readXml(filename, stream, ImportOptions(properties));
     network.getLoad("LOAD").getExtension<powsybl::network::LoadFooExt>();
     POWSYBL_ASSERT_THROW(network.getLoad("LOAD").getExtension<powsybl::network::LoadBarExt>(), PowsyblException, "Extension powsybl::network::LoadBarExt not found");
     network.getLoad("LOAD2").getExtension<powsybl::network::LoadFooExt>();
 }
 
 BOOST_FIXTURE_TEST_CASE(checkReadNoExtension, test::ResourceFixture) {
-    std::stringstream stream;
-    stream << test::converter::RoundTrip::getVersionedNetwork("multiple-extensions.xml", IidmXmlVersion::V1_0());
+    const std::string& filename = "multiple-extensions.xml";
+    std::stringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_0()));
 
     stdcxx::Properties properties;
     properties.set(ImportOptions::EXTENSIONS_LIST, "");
 
-    Network network = Network::readXml("network.xiidm", stream, ImportOptions(properties));
+    Network network = Network::readXml(filename, stream, ImportOptions(properties));
     POWSYBL_ASSERT_THROW(network.getLoad("LOAD").getExtension<powsybl::network::LoadFooExt>(), PowsyblException, "Extension powsybl::network::LoadFooExt not found");
     POWSYBL_ASSERT_THROW(network.getLoad("LOAD").getExtension<powsybl::network::LoadBarExt>(), PowsyblException, "Extension powsybl::network::LoadBarExt not found");
     POWSYBL_ASSERT_THROW(network.getLoad("LOAD2").getExtension<powsybl::network::LoadFooExt>(), PowsyblException, "Extension powsybl::network::LoadFooExt not found");
 }
 
 BOOST_FIXTURE_TEST_CASE(checkReadAllExtensions, test::ResourceFixture) {
-    std::stringstream stream;
-    stream << test::converter::RoundTrip::getVersionedNetwork("multiple-extensions.xml", IidmXmlVersion::V1_0());
+    const std::string& filename = "multiple-extensions.xml";
+    std::stringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_0()));
 
     stdcxx::Properties properties;
     properties.set(ImportOptions::EXTENSIONS_LIST, "loadFoo,loadBar");
 
-    Network network = Network::readXml("network.xiidm", stream, ImportOptions(properties));
+    Network network = Network::readXml(filename, stream, ImportOptions(properties));
     network.getLoad("LOAD").getExtension<powsybl::network::LoadFooExt>();
     network.getLoad("LOAD").getExtension<powsybl::network::LoadBarExt>();
     network.getLoad("LOAD2").getExtension<powsybl::network::LoadFooExt>();

--- a/test/iidm/converter/xml/SkipExtensionTest.cpp
+++ b/test/iidm/converter/xml/SkipExtensionTest.cpp
@@ -35,8 +35,7 @@ BOOST_AUTO_TEST_SUITE(SkipExtensionTestSuite)
 
 BOOST_FIXTURE_TEST_CASE(SkipExtensionTest, test::ResourceFixture) {
     const std::string& filename = "multiple-extensions.xml";
-    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_0()));
-    Network network = Network::readXml(filename, stream);
+    Network network = Network::readXml(test::converter::RoundTrip::getVersionedNetworkPath(filename, IidmXmlVersion::V1_0()));
     const std::string& refNetwork = test::converter::RoundTrip::getVersionedNetwork("noExtension.xml", IidmXmlVersion::V1_0());
 
     stdcxx::Properties properties;
@@ -50,38 +49,30 @@ BOOST_FIXTURE_TEST_CASE(SkipExtensionTest, test::ResourceFixture) {
 
 BOOST_FIXTURE_TEST_CASE(checkSomeFiltered, test::ResourceFixture) {
     const std::string& filename = "multiple-extensions.xml";
-    std::stringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_0()));
-
     stdcxx::Properties properties;
     properties.set(ImportOptions::EXTENSIONS_LIST, "loadFoo");
 
-    Network network = Network::readXml(filename, stream, ImportOptions(properties));
+    Network network = Network::readXml(test::converter::RoundTrip::getVersionedNetworkPath(filename, IidmXmlVersion::V1_0()), ImportOptions(properties));
     network.getLoad("LOAD").getExtension<powsybl::network::LoadFooExt>();
     POWSYBL_ASSERT_THROW(network.getLoad("LOAD").getExtension<powsybl::network::LoadBarExt>(), PowsyblException, "Extension powsybl::network::LoadBarExt not found");
     network.getLoad("LOAD2").getExtension<powsybl::network::LoadFooExt>();
 }
 
 BOOST_FIXTURE_TEST_CASE(checkReadNoExtension, test::ResourceFixture) {
-    const std::string& filename = "multiple-extensions.xml";
-    std::stringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_0()));
-
     stdcxx::Properties properties;
     properties.set(ImportOptions::EXTENSIONS_LIST, "");
 
-    Network network = Network::readXml(filename, stream, ImportOptions(properties));
+    Network network = Network::readXml(test::converter::RoundTrip::getVersionedNetworkPath("multiple-extensions.xml", IidmXmlVersion::V1_0()), ImportOptions(properties));
     POWSYBL_ASSERT_THROW(network.getLoad("LOAD").getExtension<powsybl::network::LoadFooExt>(), PowsyblException, "Extension powsybl::network::LoadFooExt not found");
     POWSYBL_ASSERT_THROW(network.getLoad("LOAD").getExtension<powsybl::network::LoadBarExt>(), PowsyblException, "Extension powsybl::network::LoadBarExt not found");
     POWSYBL_ASSERT_THROW(network.getLoad("LOAD2").getExtension<powsybl::network::LoadFooExt>(), PowsyblException, "Extension powsybl::network::LoadFooExt not found");
 }
 
 BOOST_FIXTURE_TEST_CASE(checkReadAllExtensions, test::ResourceFixture) {
-    const std::string& filename = "multiple-extensions.xml";
-    std::stringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, IidmXmlVersion::V1_0()));
-
     stdcxx::Properties properties;
     properties.set(ImportOptions::EXTENSIONS_LIST, "loadFoo,loadBar");
 
-    Network network = Network::readXml(filename, stream, ImportOptions(properties));
+    Network network = Network::readXml(test::converter::RoundTrip::getVersionedNetworkPath("multiple-extensions.xml", IidmXmlVersion::V1_0()), ImportOptions(properties));
     network.getLoad("LOAD").getExtension<powsybl::network::LoadFooExt>();
     network.getLoad("LOAD").getExtension<powsybl::network::LoadBarExt>();
     network.getLoad("LOAD2").getExtension<powsybl::network::LoadFooExt>();

--- a/test/iidm/extensions/LoadDetailTest.cpp
+++ b/test/iidm/extensions/LoadDetailTest.cpp
@@ -170,11 +170,12 @@ BOOST_FIXTURE_TEST_CASE(LoadDetailXmlSerializerTest, test::ResourceFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(LoadDetailXmlSerializerOldRefTest, test::ResourceFixture) {
-    Network network = Network::readXml(test::converter::RoundTrip::getVersionedNetwork("loadDetailOldRef.xml", converter::xml::IidmXmlVersion::V1_2()));
+    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork("loadDetailOldRef.xml", converter::xml::IidmXmlVersion::V1_2()));
+    Network network = Network::readXml("network.xiidm", stream);
     const std::string& refNetwork = test::converter::RoundTrip::getVersionedNetwork("loadDetailRef.xml", converter::xml::IidmXmlVersion::CURRENT_IIDM_XML_VERSION());
 
     std::stringstream ostream;
-    Network::writeXml(ostream, network);
+    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ostream, network);
     BOOST_CHECK_EQUAL(refNetwork, ostream.str());
 }
 

--- a/test/iidm/extensions/LoadDetailTest.cpp
+++ b/test/iidm/extensions/LoadDetailTest.cpp
@@ -171,8 +171,7 @@ BOOST_FIXTURE_TEST_CASE(LoadDetailXmlSerializerTest, test::ResourceFixture) {
 
 BOOST_FIXTURE_TEST_CASE(LoadDetailXmlSerializerOldRefTest, test::ResourceFixture) {
     const std::string& filename = "loadDetailOldRef.xml";
-    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, converter::xml::IidmXmlVersion::V1_2()));
-    Network network = Network::readXml(filename, stream);
+    Network network = Network::readXml(test::converter::RoundTrip::getVersionedNetworkPath(filename, converter::xml::IidmXmlVersion::V1_2()));
     const std::string& refNetwork = test::converter::RoundTrip::getVersionedNetwork("loadDetailRef.xml", converter::xml::IidmXmlVersion::CURRENT_IIDM_XML_VERSION());
 
     std::stringstream ostream;

--- a/test/iidm/extensions/LoadDetailTest.cpp
+++ b/test/iidm/extensions/LoadDetailTest.cpp
@@ -170,12 +170,13 @@ BOOST_FIXTURE_TEST_CASE(LoadDetailXmlSerializerTest, test::ResourceFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(LoadDetailXmlSerializerOldRefTest, test::ResourceFixture) {
-    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork("loadDetailOldRef.xml", converter::xml::IidmXmlVersion::V1_2()));
-    Network network = Network::readXml("network.xiidm", stream);
+    const std::string& filename = "loadDetailOldRef.xml";
+    std::istringstream stream(test::converter::RoundTrip::getVersionedNetwork(filename, converter::xml::IidmXmlVersion::V1_2()));
+    Network network = Network::readXml(filename, stream);
     const std::string& refNetwork = test::converter::RoundTrip::getVersionedNetwork("loadDetailRef.xml", converter::xml::IidmXmlVersion::CURRENT_IIDM_XML_VERSION());
 
     std::stringstream ostream;
-    Network::writeXml(stdcxx::format("%1%.xiidm", network.getId()), ostream, network);
+    Network::writeXml(filename, ostream, network);
     BOOST_CHECK_EQUAL(refNetwork, ostream.str());
 }
 

--- a/tools/benchmark/Benchmark.cpp
+++ b/tools/benchmark/Benchmark.cpp
@@ -109,25 +109,9 @@ int main(int argc, char** argv) {
         // Load the XIIDM extensions
         loadExtensions(vm[EXT_PATH].as<std::string>());
 
-        const auto& inputFile = vm[INPUT_FILE].as<std::string>();
-        std::ifstream inputStream(inputFile);
-        if (!inputStream.is_open()) {
-            std::cerr << stdcxx::format("Unable to open file '%1%' for reading", inputFile) << std::endl;
-            return EXIT_FAILURE;
-        }
+        const powsybl::iidm::Network& network = powsybl::iidm::Network::readXml(vm[INPUT_FILE].as<std::string>(), powsybl::iidm::converter::ImportOptions(options));
+        powsybl::iidm::Network::writeXml(vm[OUTPUT_FILE].as<std::string>(), network, powsybl::iidm::converter::ExportOptions(options));
 
-        const auto& outputFile = vm[OUTPUT_FILE].as<std::string>();
-        std::ofstream outputStream(outputFile);
-        if (!outputStream.is_open()) {
-            std::cerr << stdcxx::format("Unable to open file '%1%' for writing", outputFile) << std::endl;
-            return EXIT_FAILURE;
-        }
-
-        const powsybl::iidm::Network& network = powsybl::iidm::Network::readXml(inputStream, powsybl::iidm::converter::ImportOptions(options), powsybl::iidm::converter::FakeAnonymizer());
-        powsybl::iidm::Network::writeXml(outputStream, network, powsybl::iidm::converter::ExportOptions(options));
-
-        inputStream.close();
-        outputStream.close();
     } catch (const boost::program_options::error& e) {
         std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
         std::cerr << desc << std::endl;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
XML serialization API update.


**What is the current behavior?** *(You can also link to an open issue here)*
Update XML read/write API to prepare implementation of real anonymization (See PR #271) :
Functions available from public API of `Network` enabling to read/write do not pass filename which is needed so that CSV file can be guessed from input file like java Importers does.

**What is the new behavior (if this is a feature change)?**
Filename is always given when calling `Network::readXml` and `Network::writeXml` so that deanonymization can be done correctly.

⚠️ This is a really important API breaking change : 
 - the existing `Network::readXml(const std::string& networkStr)` has been removed
 - a new version `readXml(const boost::filesystem::path& path, const converter::ImportOptions& options = converter::ImportOptions())` is **silently called instead** because `boost::filesystem::path` constructor is not explicit 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
