### PR TITLE
Fix CI (boost not avaible on github actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,9 @@ jobs:
           cscript configure.js compiler=msvc prefix=C:\thirdparties\libxml2-2.9.10 iconv=no
           nmake -f Makefile.msvc
           nmake -f Makefile.msvc install
-          wget -nv -O boost_1_72_0-msvc-14.2-64.exe https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe/download
-          boost_1_72_0-msvc-14.2-64.exe /dir="C:\thirdparties\boost-1.72.0" /sp- /verysilent /suppressmsgboxes /norestart
+          wget -nv -O boost-installer.exe https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe/download
+          echo "BOOST_INSTALL_DIR=C:\thirdparties\boost-1.72.0" >> $GITHUB_ENV
+          boost-installer.exe /dir="%BOOST_INSTALL_DIR%" /sp- /verysilent /suppressmsgboxes /norestart
 
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -78,7 +79,7 @@ jobs:
         run: >
           cmake -S %GITHUB_WORKSPACE% -B %GITHUB_WORKSPACE%\build-windows
           -DBUILD_EXAMPLES=ON
-          -DCMAKE_PREFIX_PATH=C:\thirdparties\boost-1.72.0;C:\thirdparties\libxml2-2.9.10
+          -DCMAKE_PREFIX_PATH=%BOOST_INSTALL_DIR%;C:\thirdparties\libxml2-2.9.10
 
       - name: Build
         shell: cmd
@@ -89,7 +90,7 @@ jobs:
       - name: Tests
         shell: cmd
         run: |
-          set PATH=%PATH%;C:\thirdparties\libxml2-2.9.10\bin;C:\thirdparties\boost-1.72.0\lib64-msvc-14.2;%GITHUB_WORKSPACE%\build-windows\src\Release;%GITHUB_WORKSPACE%\build-windows\src\test\Release
+          set PATH=%PATH%;C:\thirdparties\libxml2-2.9.10\bin;%BOOST_INSTALL_DIR%\lib64-msvc-14.2;%GITHUB_WORKSPACE%\build-windows\src\Release;%GITHUB_WORKSPACE%\build-windows\src\test\Release
           cmake --build %GITHUB_WORKSPACE%\build-windows --target RUN_TESTS --config Release --verbose
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
@@ -134,7 +135,6 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug
           -DCODE_COVERAGE=TRUE
           -DBUILD_EXAMPLES=ON
-          -DCMAKE_PREFIX_PATH=$BOOST_ROOT_1_72_0
 
       - name: Build
         run:  >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     steps:
+      - name: Pre-requisites
+        run: sudo apt-get install -y libboost-all-dev
+
       - name: Checkout sources
         uses: actions/checkout@v1
 
@@ -19,7 +22,6 @@ jobs:
           cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build-linux
           -DCMAKE_BUILD_TYPE=Release
           -DBUILD_EXAMPLES=ON
-          -DCMAKE_PREFIX_PATH=$BOOST_ROOT_1_72_0
 
       - name: Build
         run: cmake --build $GITHUB_WORKSPACE/build-linux --parallel 3
@@ -65,6 +67,8 @@ jobs:
           cscript configure.js compiler=msvc prefix=C:\thirdparties\libxml2-2.9.10 iconv=no
           nmake -f Makefile.msvc
           nmake -f Makefile.msvc install
+          wget -nv -O boost_1_72_0-msvc-14.2-64.exe https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe/download
+          boost_1_72_0-msvc-14.2-64.exe /dir="C:\thirdparties\boost-1.72.0" /sp- /verysilent /suppressmsgboxes /norestart
 
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -74,7 +78,7 @@ jobs:
         run: >
           cmake -S %GITHUB_WORKSPACE% -B %GITHUB_WORKSPACE%\build-windows
           -DBUILD_EXAMPLES=ON
-          -DCMAKE_PREFIX_PATH=%BOOST_ROOT_1_72_0%;C:\thirdparties\libxml2-2.9.10
+          -DCMAKE_PREFIX_PATH=C:\thirdparties\boost-1.72.0;C:\thirdparties\libxml2-2.9.10
 
       - name: Build
         shell: cmd
@@ -85,7 +89,7 @@ jobs:
       - name: Tests
         shell: cmd
         run: |
-          set PATH=%PATH%;C:\thirdparties\libxml2-2.9.10\bin;%BOOST_ROOT_1_72_0%\lib;%GITHUB_WORKSPACE%\build-windows\src\Release;%GITHUB_WORKSPACE%\build-windows\src\test\Release
+          set PATH=%PATH%;C:\thirdparties\libxml2-2.9.10\bin;C:\thirdparties\boost-1.72.0\lib64-msvc-14.2;%GITHUB_WORKSPACE%\build-windows\src\Release;%GITHUB_WORKSPACE%\build-windows\src\test\Release
           cmake --build %GITHUB_WORKSPACE%\build-windows --target RUN_TESTS --config Release --verbose
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
@@ -117,6 +121,9 @@ jobs:
           rm sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip
         env:
           SONAR_SCANNER_VERSION: 3.3.0.1492
+
+      - name: Install Boost
+        run: sudo apt-get install -y libboost-all-dev
 
       - name: Checkout sources
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     steps:
-      - name: Pre-requisites
-        run: sudo apt-get install -y libboost-all-dev
+      - name: Install Boost
+        run: sudo apt install -y libboost-all-dev
 
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -35,7 +35,7 @@ jobs:
     name: MacOS
     runs-on: macos-latest
     steps:
-      - name: Pre-requisites
+      - name: Install Boost
         run: brew install boost
 
       - name: Checkout sources
@@ -53,23 +53,31 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: 1
 
   windows:
+    env:
+      BOOST_ROOT: C:\thirdparties\boost-1.72.0
+      BOOST_URL: https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe/download
+      LIBXML2_ROOT: C:\thirdparties\libxml2-2.9.10
+      LIBXML2_URL: https://github.com/GNOME/libxml2/archive/v2.9.10.zip
     name: Windows
     runs-on: windows-latest
     steps:
-      - name: Pre-requisites
+      - name: Install LibXml2
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           choco install wget --no-progress
-          wget -nv https://github.com/GNOME/libxml2/archive/v2.9.10.zip
+          wget -nv %LIBXML2_URL%
           7z x v2.9.10.zip
           cd libxml2-2.9.10/win32
-          cscript configure.js compiler=msvc prefix=C:\thirdparties\libxml2-2.9.10 iconv=no
+          cscript configure.js compiler=msvc prefix=%LIBXML2_ROOT% iconv=no
           nmake -f Makefile.msvc
           nmake -f Makefile.msvc install
-          wget -nv -O boost-installer.exe https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe/download
-          echo "BOOST_INSTALL_DIR=C:\thirdparties\boost-1.72.0" >> $GITHUB_ENV
-          boost-installer.exe /dir="%BOOST_INSTALL_DIR%" /sp- /verysilent /suppressmsgboxes /norestart
+
+      - name: Install Boost
+        shell: cmd
+        run: |
+          wget -nv -O boost-installer.exe %BOOST_URL%
+          boost-installer.exe /dir=%BOOST_ROOT% /sp- /verysilent /suppressmsgboxes /norestart
 
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -79,7 +87,6 @@ jobs:
         run: >
           cmake -S %GITHUB_WORKSPACE% -B %GITHUB_WORKSPACE%\build-windows
           -DBUILD_EXAMPLES=ON
-          -DCMAKE_PREFIX_PATH=%BOOST_INSTALL_DIR%;C:\thirdparties\libxml2-2.9.10
 
       - name: Build
         shell: cmd
@@ -90,7 +97,7 @@ jobs:
       - name: Tests
         shell: cmd
         run: |
-          set PATH=%PATH%;C:\thirdparties\libxml2-2.9.10\bin;%BOOST_INSTALL_DIR%\lib64-msvc-14.2;%GITHUB_WORKSPACE%\build-windows\src\Release;%GITHUB_WORKSPACE%\build-windows\src\test\Release
+          set PATH=%PATH%;%LIBXML2_ROOT%\bin;%BOOST_ROOT%\lib64-msvc-14.2;%GITHUB_WORKSPACE%\build-windows\src\Release;%GITHUB_WORKSPACE%\build-windows\src\test\Release
           cmake --build %GITHUB_WORKSPACE%\build-windows --target RUN_TESTS --config Release --verbose
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
@@ -124,7 +131,7 @@ jobs:
           SONAR_SCANNER_VERSION: 3.3.0.1492
 
       - name: Install Boost
-        run: sudo apt-get install -y libboost-all-dev
+        run: sudo apt install -y libboost-all-dev
 
       - name: Checkout sources
         uses: actions/checkout@v1

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Boost
-        run: |
-          sudo apt install -y libboost-all-dev
+        run: sudo apt install -y libboost-all-dev
 
       - name: Install clang-tidy
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -9,10 +9,13 @@ jobs:
     name: clang-tidy
     runs-on: ubuntu-latest
     steps:
-      - name: Pre-requisites
+      - name: Install Boost
         run: |
-          sudo apt-get install -y libboost-all-dev
-          sudo apt-get install -y clang-tidy-9
+          sudo apt install -y libboost-all-dev
+
+      - name: Install clang-tidy
+        run: |
+          sudo apt install -y clang-tidy-9
           sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 100
 
       - name: Checkout sources

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -9,8 +9,9 @@ jobs:
     name: clang-tidy
     runs-on: ubuntu-latest
     steps:
-      - name: Install clang-tidy
+      - name: Pre-requisites
         run: |
+          sudo apt-get install -y libboost-all-dev
           sudo apt-get install -y clang-tidy-9
           sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 100
 


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Boost is not available on CI environments provided by github actions (https://github.com/actions/virtual-environments/issues/2667)



**What is the current behavior?** *(You can also link to an open issue here)*
CI is failing because boost is required and not available on environments


**What is the new behavior (if this is a feature change)?**
Boost is installed : 
 - From apt-get repository on ubuntu
 - From [official pre-built binaries](https://sourceforge.net/projects/boost/files/boost-binaries/) on windows


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
