### PR TITLE
Iso APIs: backport missing methods

### DIFF
--- a/extensions/entsoe/test/MergedXnodeTest.cpp
+++ b/extensions/entsoe/test/MergedXnodeTest.cpp
@@ -41,7 +41,7 @@ Network createNetwork() {
         .add();
     VoltageLevel& vl1 = s1.newVoltageLevel()
         .setId("VL1")
-        .setNominalVoltage(400)
+        .setNominalV(400)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl1.getBusBreakerView().newBus()
@@ -53,7 +53,7 @@ Network createNetwork() {
         .add();
     VoltageLevel& vl2 = s2.newVoltageLevel()
         .setId("VL2")
-        .setNominalVoltage(400)
+        .setNominalV(400)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl2.getBusBreakerView().newBus()

--- a/extensions/entsoe/test/XnodeTest.cpp
+++ b/extensions/entsoe/test/XnodeTest.cpp
@@ -40,7 +40,7 @@ Network createNetwork() {
         .add();
     VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
-        .setNominalVoltage(400)
+        .setNominalV(400)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl.getBusBreakerView().newBus()

--- a/extensions/iidm/test/CoordinatedReactiveControlTest.cpp
+++ b/extensions/iidm/test/CoordinatedReactiveControlTest.cpp
@@ -43,7 +43,7 @@ Network createNetwork() {
         .add();
     VoltageLevel& vlgen = p1.newVoltageLevel()
         .setId("VLGEN")
-        .setNominalVoltage(24.0)
+        .setNominalV(24.0)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     Bus& ngen = vlgen.getBusBreakerView().newBus()

--- a/extensions/iidm/test/VoltagePerReactivePowerControlTest.cpp
+++ b/extensions/iidm/test/VoltagePerReactivePowerControlTest.cpp
@@ -45,7 +45,7 @@ Network createStaticVarCompensatorTestNetwork() {
         .add();
     VoltageLevel& vl1 = s1.newVoltageLevel()
         .setId("VL1")
-        .setNominalVoltage(380)
+        .setNominalV(380)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl1.getBusBreakerView().newBus()
@@ -67,7 +67,7 @@ Network createStaticVarCompensatorTestNetwork() {
         .add();
     VoltageLevel& vl2 = s2.newVoltageLevel()
         .setId("VL2")
-        .setNominalVoltage(380)
+        .setNominalV(380)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl2.getBusBreakerView().newBus()

--- a/extensions/sld/test/BusbarSectionPositionTest.cpp
+++ b/extensions/sld/test/BusbarSectionPositionTest.cpp
@@ -43,7 +43,7 @@ Network createBusbarSectionNetwork() {
     VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();

--- a/include/powsybl/iidm/Bus.hpp
+++ b/include/powsybl/iidm/Bus.hpp
@@ -80,6 +80,10 @@ public:
 
     stdcxx::range<Load> getLoads();
 
+    double getP() const;
+
+    double getQ() const;
+
     stdcxx::const_range<ShuntCompensator> getShuntCompensators() const;
 
     stdcxx::range<ShuntCompensator> getShuntCompensators();

--- a/include/powsybl/iidm/HvdcLine.hpp
+++ b/include/powsybl/iidm/HvdcLine.hpp
@@ -39,7 +39,7 @@ public:  // Identifiable
     Network& getNetwork() override;
 
 public:
-    HvdcLine(Network& network, const std::string& id, const std::string& name, bool fictitious, double r, double nominalVoltage, double maxP,
+    HvdcLine(Network& network, const std::string& id, const std::string& name, bool fictitious, double r, double nominalV, double maxP,
              const ConvertersMode& convertersMode, double activePowerSetpoint, HvdcConverterStation& converterStation1, HvdcConverterStation& converterStation2);
 
     ~HvdcLine() noexcept override = default;
@@ -62,7 +62,7 @@ public:
 
     double getMaxP() const;
 
-    double getNominalVoltage() const;
+    double getNominalV() const;
 
     double getR() const;
 
@@ -74,7 +74,7 @@ public:
 
     HvdcLine& setMaxP(double maxP);
 
-    HvdcLine& setNominalVoltage(double nominalVoltage);
+    HvdcLine& setNominalV(double nominalV);
 
     HvdcLine& setR(double r);
 
@@ -98,7 +98,7 @@ private:
 
     double m_r;
 
-    double m_nominalVoltage;
+    double m_nominalV;
 
     double m_maxP;
 

--- a/include/powsybl/iidm/HvdcLineAdder.hpp
+++ b/include/powsybl/iidm/HvdcLineAdder.hpp
@@ -36,7 +36,7 @@ public:
 
     HvdcLineAdder& setMaxP(double maxP);
 
-    HvdcLineAdder& setNominalVoltage(double nominalVoltage);
+    HvdcLineAdder& setNominalV(double nominalVoltage);
 
     HvdcLineAdder& setR(double r);
 
@@ -64,7 +64,7 @@ private:
 
     double m_r = stdcxx::nan();
 
-    double m_nominalVoltage = stdcxx::nan();
+    double m_nominalV = stdcxx::nan();
 
     double m_maxP = stdcxx::nan();
 

--- a/include/powsybl/iidm/HvdcLineAdder.hpp
+++ b/include/powsybl/iidm/HvdcLineAdder.hpp
@@ -36,7 +36,7 @@ public:
 
     HvdcLineAdder& setMaxP(double maxP);
 
-    HvdcLineAdder& setNominalV(double nominalVoltage);
+    HvdcLineAdder& setNominalV(double nominalV);
 
     HvdcLineAdder& setR(double r);
 

--- a/include/powsybl/iidm/Network.hpp
+++ b/include/powsybl/iidm/Network.hpp
@@ -161,6 +161,8 @@ public:
 
     ConnectedComponentsManager& getConnectedComponentsManager();
 
+    std::set<Country> getCountries() const;
+
     unsigned long getCountryCount() const;
 
     const DanglingLine& getDanglingLine(const std::string& id) const;

--- a/include/powsybl/iidm/VoltageLevel.hpp
+++ b/include/powsybl/iidm/VoltageLevel.hpp
@@ -126,7 +126,7 @@ public:
 
     virtual NodeBreakerView& getNodeBreakerView() = 0;
 
-    double getNominalVoltage() const;
+    double getNominalV() const;
 
     unsigned long getShuntCompensatorCount() const;
 
@@ -180,13 +180,13 @@ public:
 
     VoltageLevel& setLowVoltageLimit(double lowVoltageLimit);
 
-    VoltageLevel& setNominalVoltage(double nominalVoltage);
+    VoltageLevel& setNominalV(double nominalV);
 
     void visitEquipments(TopologyVisitor& visitor) const;
 
 protected:
     VoltageLevel(const std::string& id, const std::string& name, bool fictitious, Substation& substation,
-                 double nominalVoltage, double lowVoltageLimit, double highVoltageLimit);
+                 double nominalV, double lowVoltageLimit, double highVoltageLimit);
 
     virtual stdcxx::const_range<Terminal> getTerminals() const = 0;
 
@@ -202,7 +202,7 @@ private:
 
     double m_lowVoltageLimit;
 
-    double m_nominalVoltage;
+    double m_nominalV;
 };
 
 }  // namespace iidm

--- a/include/powsybl/iidm/VoltageLevelAdder.hpp
+++ b/include/powsybl/iidm/VoltageLevelAdder.hpp
@@ -30,7 +30,7 @@ public:
 
     VoltageLevelAdder& setLowVoltageLimit(double lowVoltageLimit);
 
-    VoltageLevelAdder& setNominalVoltage(double nominalVoltage);
+    VoltageLevelAdder& setNominalV(double nominalV);
 
     VoltageLevelAdder& setTopologyKind(const TopologyKind& topologyKind);
 
@@ -54,7 +54,7 @@ private:
 
     double m_lowVoltageLimit = stdcxx::nan();
 
-    double m_nominalVoltage = stdcxx::nan();
+    double m_nominalV = stdcxx::nan();
 
     stdcxx::optional<TopologyKind> m_topologyKind;
 

--- a/src/iidm/Bus.cpp
+++ b/src/iidm/Bus.cpp
@@ -141,8 +141,6 @@ double Bus::getQ() const {
         const Connectable& connectable = terminal.getConnectable();
         switch (connectable.getType()) {
             case ConnectableType::BUSBAR_SECTION:
-            case ConnectableType::SHUNT_COMPENSATOR:
-            case ConnectableType::STATIC_VAR_COMPENSATOR:
             case ConnectableType::LINE:
             case ConnectableType::TWO_WINDINGS_TRANSFORMER:
             case ConnectableType::THREE_WINDINGS_TRANSFORMER:
@@ -152,6 +150,8 @@ double Bus::getQ() const {
             case ConnectableType::GENERATOR:
             case ConnectableType::BATTERY:
             case ConnectableType::LOAD:
+            case ConnectableType::SHUNT_COMPENSATOR:
+            case ConnectableType::STATIC_VAR_COMPENSATOR:
             case ConnectableType::HVDC_CONVERTER_STATION:
                 if (!std::isnan(terminal.getQ())) {
                     q += terminal.getQ();

--- a/src/iidm/Bus.cpp
+++ b/src/iidm/Bus.cpp
@@ -126,7 +126,7 @@ double Bus::getP() const {
                 }
                 break;
             default:
-                throw new AssertionError(stdcxx::format("Unexpected connectable type: %1%", connectable.getType()));
+                throw AssertionError(stdcxx::format("Unexpected connectable type: %1%", connectable.getType()));
         }
     }
     return p;
@@ -158,7 +158,7 @@ double Bus::getQ() const {
                 }
                 break;
             default:
-                throw new AssertionError(stdcxx::format("Unexpected connectable type: %1%", connectable.getType()));
+                throw AssertionError(stdcxx::format("Unexpected connectable type: %1%", connectable.getType()));
         }
     }
     return q;

--- a/src/iidm/Bus.cpp
+++ b/src/iidm/Bus.cpp
@@ -100,6 +100,70 @@ Network& Bus::getNetwork() {
     return getVoltageLevel().getNetwork();
 }
 
+double Bus::getP() const {
+    if (getConnectedTerminalCount() == 0) {
+        return stdcxx::nan();
+    }
+    double p = 0;
+    for (const Terminal& terminal : getConnectedTerminals()) {
+        const Connectable& connectable = terminal.getConnectable();
+        switch (connectable.getType()) {
+            case ConnectableType::BUSBAR_SECTION:
+            case ConnectableType::SHUNT_COMPENSATOR:
+            case ConnectableType::STATIC_VAR_COMPENSATOR:
+            case ConnectableType::LINE:
+            case ConnectableType::TWO_WINDINGS_TRANSFORMER:
+            case ConnectableType::THREE_WINDINGS_TRANSFORMER:
+            case ConnectableType::DANGLING_LINE:
+                // skip
+                break;
+            case ConnectableType::GENERATOR:
+            case ConnectableType::BATTERY:
+            case ConnectableType::LOAD:
+            case ConnectableType::HVDC_CONVERTER_STATION:
+                if (!std::isnan(terminal.getP())) {
+                    p += terminal.getP();
+                }
+                break;
+            default:
+                throw new AssertionError(stdcxx::format("Unexpected connectable type: %1%", connectable.getType()));
+        }
+    }
+    return p;
+}
+
+double Bus::getQ() const {
+    if (getConnectedTerminalCount() == 0) {
+        return stdcxx::nan();
+    }
+    double q = 0;
+    for (const Terminal& terminal : getConnectedTerminals()) {
+        const Connectable& connectable = terminal.getConnectable();
+        switch (connectable.getType()) {
+            case ConnectableType::BUSBAR_SECTION:
+            case ConnectableType::SHUNT_COMPENSATOR:
+            case ConnectableType::STATIC_VAR_COMPENSATOR:
+            case ConnectableType::LINE:
+            case ConnectableType::TWO_WINDINGS_TRANSFORMER:
+            case ConnectableType::THREE_WINDINGS_TRANSFORMER:
+            case ConnectableType::DANGLING_LINE:
+                // skip
+                break;
+            case ConnectableType::GENERATOR:
+            case ConnectableType::BATTERY:
+            case ConnectableType::LOAD:
+            case ConnectableType::HVDC_CONVERTER_STATION:
+                if (!std::isnan(terminal.getQ())) {
+                    q += terminal.getQ();
+                }
+                break;
+            default:
+                throw new AssertionError(stdcxx::format("Unexpected connectable type: %1%", connectable.getType()));
+        }
+    }
+    return q;
+}
+
 stdcxx::const_range<ShuntCompensator> Bus::getShuntCompensators() const {
     return getAll<ShuntCompensator>();
 }

--- a/src/iidm/BusBreakerVoltageLevel.cpp
+++ b/src/iidm/BusBreakerVoltageLevel.cpp
@@ -23,8 +23,8 @@ namespace powsybl {
 namespace iidm {
 
 BusBreakerVoltageLevel::BusBreakerVoltageLevel(const std::string& id, const std::string& name, bool fictitious, Substation& substation,
-                                               double nominalVoltage, double lowVoltageLimit, double highVoltagelimit) :
-    VoltageLevel(id, name, fictitious, substation, nominalVoltage, lowVoltageLimit, highVoltagelimit),
+                                               double nominalV, double lowVoltageLimit, double highVoltagelimit) :
+    VoltageLevel(id, name, fictitious, substation, nominalV, lowVoltageLimit, highVoltagelimit),
     m_variants(*this, [this]() { return stdcxx::make_unique<bus_breaker_voltage_level::VariantImpl>(*this); }),
     m_busBreakerView(*this),
     m_busView(*this) {

--- a/src/iidm/BusBreakerVoltageLevel.hpp
+++ b/src/iidm/BusBreakerVoltageLevel.hpp
@@ -57,7 +57,7 @@ public: // VoltageLevel
 
 public:
     BusBreakerVoltageLevel(const std::string& id, const std::string& name, bool fictitious, Substation& substation,
-                           double nominalVoltage, double lowVoltageLimit, double highVoltagelimit);
+                           double nominalV, double lowVoltageLimit, double highVoltagelimit);
 
     ~BusBreakerVoltageLevel() noexcept override = default;
 

--- a/src/iidm/HvdcLine.cpp
+++ b/src/iidm/HvdcLine.cpp
@@ -15,13 +15,13 @@ namespace powsybl {
 
 namespace iidm {
 
-HvdcLine::HvdcLine(Network& network, const std::string& id, const std::string& name, bool fictitious, double r, double nominalVoltage, double maxP,
+HvdcLine::HvdcLine(Network& network, const std::string& id, const std::string& name, bool fictitious, double r, double nominalV, double maxP,
                    const ConvertersMode& convertersMode, double activePowerSetpoint, HvdcConverterStation& converterStation1, HvdcConverterStation& converterStation2) :
     Identifiable(id, name, fictitious),
     m_converterStation1(attach(converterStation1)),
     m_converterStation2(attach(converterStation2)),
     m_r(checkR(*this, r)),
-    m_nominalVoltage(checkNominalVoltage(*this, nominalVoltage)),
+    m_nominalV(checkNominalVoltage(*this, nominalV)),
     m_maxP(checkHvdcMaxP(*this, maxP)),
     m_convertersMode(network.getVariantManager().getVariantArraySize(), checkConvertersMode(*this, convertersMode)),
     m_activePowerSetpoint(network.getVariantManager().getVariantArraySize(), checkHvdcActivePowerSetpoint(*this, activePowerSetpoint)) {
@@ -99,8 +99,8 @@ Network& HvdcLine::getNetwork() {
     return const_cast<Network&>(static_cast<const HvdcLine*>(this)->getNetwork());
 }
 
-double HvdcLine::getNominalVoltage() const {
-    return m_nominalVoltage;
+double HvdcLine::getNominalV() const {
+    return m_nominalV;
 }
 
 double HvdcLine::getR() const {
@@ -150,8 +150,8 @@ HvdcLine& HvdcLine::setMaxP(double maxP) {
     return *this;
 }
 
-HvdcLine& HvdcLine::setNominalVoltage(double nominalVoltage) {
-    m_nominalVoltage = checkNominalVoltage(*this, nominalVoltage);
+HvdcLine& HvdcLine::setNominalV(double nominalV) {
+    m_nominalV = checkNominalVoltage(*this, nominalV);
 
     return *this;
 }

--- a/src/iidm/HvdcLineAdder.cpp
+++ b/src/iidm/HvdcLineAdder.cpp
@@ -26,14 +26,14 @@ HvdcLine& HvdcLineAdder::add() {
     checkR(*this, m_r);
     checkOptional(*this, m_convertersMode, "converter mode is invalid");
     checkConvertersMode(*this, *m_convertersMode);
-    checkNominalVoltage(*this, m_nominalVoltage);
+    checkNominalVoltage(*this, m_nominalV);
     checkHvdcActivePowerSetpoint(*this, m_activePowerSetpoint);
     checkHvdcMaxP(*this, m_maxP);
 
     HvdcConverterStation& converterStation1 = getConverterStation(m_converterStationId1, 1U);
     HvdcConverterStation& converterStation2 = getConverterStation(m_converterStationId2, 2U);
 
-    std::unique_ptr<HvdcLine> ptrHvdcLine = stdcxx::make_unique<HvdcLine>(getNetwork(), checkAndGetUniqueId(), getName(), isFictitious(), m_r, m_nominalVoltage, m_maxP, *m_convertersMode, m_activePowerSetpoint,
+    std::unique_ptr<HvdcLine> ptrHvdcLine = stdcxx::make_unique<HvdcLine>(getNetwork(), checkAndGetUniqueId(), getName(), isFictitious(), m_r, m_nominalV, m_maxP, *m_convertersMode, m_activePowerSetpoint,
                                                                           converterStation1, converterStation2);
     auto& line = m_network.checkAndAdd<HvdcLine>(std::move(ptrHvdcLine));
 
@@ -89,8 +89,8 @@ HvdcLineAdder& HvdcLineAdder::setMaxP(double maxP) {
     return *this;
 }
 
-HvdcLineAdder& HvdcLineAdder::setNominalVoltage(double nominalVoltage) {
-    m_nominalVoltage = nominalVoltage;
+HvdcLineAdder& HvdcLineAdder::setNominalV(double nominalV) {
+    m_nominalV = nominalV;
     return *this;
 }
 

--- a/src/iidm/Network.cpp
+++ b/src/iidm/Network.cpp
@@ -206,16 +206,19 @@ ConnectedComponentsManager& Network::getConnectedComponentsManager() {
     return m_variants.get().getConnectedComponentsManager();
 }
 
-unsigned long Network::getCountryCount() const {
-    std::unordered_set<Country, stdcxx::hash<Country>> countries;
+std::set<Country> Network::getCountries() const {
+    std::set<Country> countries;
     for (const auto& substation : getSubstations()) {
         const stdcxx::optional<Country>& country = substation.getCountry();
         if (country) {
             countries.emplace(*country);
         }
     }
+    return countries;
+}
 
-    return countries.size();
+unsigned long Network::getCountryCount() const {
+    return getCountries().size();
 }
 
 const DanglingLine& Network::getDanglingLine(const std::string& id) const {

--- a/src/iidm/NodeBreakerVoltageLevel.cpp
+++ b/src/iidm/NodeBreakerVoltageLevel.cpp
@@ -20,8 +20,8 @@ namespace powsybl {
 namespace iidm {
 
 NodeBreakerVoltageLevel::NodeBreakerVoltageLevel(const std::string& id, const std::string& name, bool fictitious, Substation& substation,
-                                                 double nominalVoltage, double lowVoltageLimit, double highVoltagelimit) :
-    VoltageLevel(id, name, fictitious, substation, nominalVoltage, lowVoltageLimit, highVoltagelimit),
+                                                 double nominalV, double lowVoltageLimit, double highVoltagelimit) :
+    VoltageLevel(id, name, fictitious, substation, nominalV, lowVoltageLimit, highVoltagelimit),
     m_busNamingStrategy(*this),
     m_variants(*this, [this]() { return stdcxx::make_unique<node_breaker_voltage_level::VariantImpl>(*this); }),
     m_nodeBreakerView(*this),

--- a/src/iidm/NodeBreakerVoltageLevel.hpp
+++ b/src/iidm/NodeBreakerVoltageLevel.hpp
@@ -65,7 +65,7 @@ public: // VoltageLevel
 
 public:
     NodeBreakerVoltageLevel(const std::string& id, const std::string& name, bool fictitious, Substation& substation,
-                            double nominalVoltage, double lowVoltageLimit, double highVoltagelimit);
+                            double nominalV, double lowVoltageLimit, double highVoltagelimit);
 
     ~NodeBreakerVoltageLevel() noexcept override = default;
 

--- a/src/iidm/VoltageLevel.cpp
+++ b/src/iidm/VoltageLevel.cpp
@@ -32,14 +32,14 @@ namespace powsybl {
 namespace iidm {
 
 VoltageLevel::VoltageLevel(const std::string& id, const std::string& name, bool fictitious, Substation& substation,
-                           double nominalVoltage, double lowVoltageLimit, double highVoltageLimit) :
+                           double nominalV, double lowVoltageLimit, double highVoltageLimit) :
     Container(id, name, fictitious, Container::Type::VOLTAGE_LEVEL),
     m_substation(substation),
     m_highVoltageLimit(highVoltageLimit),
     m_lowVoltageLimit(lowVoltageLimit),
-    m_nominalVoltage(nominalVoltage) {
+    m_nominalV(nominalV) {
 
-    checkNominalVoltage(*this, m_nominalVoltage);
+    checkNominalVoltage(*this, m_nominalV);
     checkVoltageLimits(*this, m_lowVoltageLimit, m_highVoltageLimit);
 }
 
@@ -119,8 +119,8 @@ Network& VoltageLevel::getNetwork() {
     return getSubstation().getNetwork();
 }
 
-double VoltageLevel::getNominalVoltage() const {
-    return m_nominalVoltage;
+double VoltageLevel::getNominalV() const {
+    return m_nominalV;
 }
 
 unsigned long VoltageLevel::getShuntCompensatorCount() const {
@@ -217,8 +217,8 @@ VoltageLevel& VoltageLevel::setLowVoltageLimit(double lowVoltageLimit) {
     return *this;
 }
 
-VoltageLevel& VoltageLevel::setNominalVoltage(double nominalVoltage) {
-    m_nominalVoltage = checkNominalVoltage(*this, nominalVoltage);
+VoltageLevel& VoltageLevel::setNominalV(double nominalV) {
+    m_nominalV = checkNominalVoltage(*this, nominalV);
     return *this;
 }
 

--- a/src/iidm/VoltageLevelAdder.cpp
+++ b/src/iidm/VoltageLevelAdder.cpp
@@ -24,7 +24,7 @@ VoltageLevelAdder::VoltageLevelAdder(Substation& substation) :
 
 VoltageLevel& VoltageLevelAdder::add() {
     // TODO(thiebarr) : check that there are not another voltage level with same base voltage
-    checkNominalVoltage(*this, m_nominalVoltage);
+    checkNominalVoltage(*this, m_nominalV);
     checkVoltageLimits(*this, m_lowVoltageLimit, m_highVoltageLimit);
     checkOptional(*this, m_topologyKind, "TopologyKind is not set");
 
@@ -32,12 +32,12 @@ VoltageLevel& VoltageLevelAdder::add() {
     switch (*m_topologyKind) {
         case TopologyKind::NODE_BREAKER:
             voltageLevel = stdcxx::ref<VoltageLevel>(getNetwork().checkAndAdd<NodeBreakerVoltageLevel>(
-                stdcxx::make_unique<NodeBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), isFictitious(), m_substation, m_nominalVoltage, m_lowVoltageLimit, m_highVoltageLimit)));
+                stdcxx::make_unique<NodeBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), isFictitious(), m_substation, m_nominalV, m_lowVoltageLimit, m_highVoltageLimit)));
             break;
 
         case TopologyKind::BUS_BREAKER:
             voltageLevel = stdcxx::ref<VoltageLevel>(getNetwork().checkAndAdd<BusBreakerVoltageLevel>(
-                stdcxx::make_unique<BusBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), isFictitious(), m_substation, m_nominalVoltage, m_lowVoltageLimit, m_highVoltageLimit)));
+                stdcxx::make_unique<BusBreakerVoltageLevel>(checkAndGetUniqueId(), getName(), isFictitious(), m_substation, m_nominalV, m_lowVoltageLimit, m_highVoltageLimit)));
             break;
 
         default:
@@ -72,8 +72,8 @@ VoltageLevelAdder& VoltageLevelAdder::setLowVoltageLimit(double lowVoltageLimit)
     return *this;
 }
 
-VoltageLevelAdder& VoltageLevelAdder::setNominalVoltage(double nominalVoltage) {
-    m_nominalVoltage = nominalVoltage;
+VoltageLevelAdder& VoltageLevelAdder::setNominalV(double nominalV) {
+    m_nominalV = nominalV;
     return *this;
 }
 

--- a/src/iidm/converter/xml/HvdcLineXml.cpp
+++ b/src/iidm/converter/xml/HvdcLineXml.cpp
@@ -39,7 +39,7 @@ HvdcLine& HvdcLineXml::readRootElementAttributes(HvdcLineAdder& adder, NetworkXm
     const std::string& converterStation1 = context.getReader().getAttributeValue(CONVERTER_STATION1);
     const std::string& converterStation2 = context.getReader().getAttributeValue(CONVERTER_STATION2);
     return adder.setR(r)
-        .setNominalVoltage(nominalV) // called setNominalV() in Java code
+        .setNominalV(nominalV)
         .setConvertersMode(convertersMode)
         .setActivePowerSetpoint(activePowerSetpoint)
         .setMaxP(maxP)
@@ -56,7 +56,7 @@ void HvdcLineXml::readSubElements(HvdcLine& line, NetworkXmlReaderContext& conte
 
 void HvdcLineXml::writeRootElementAttributes(const HvdcLine& line, const Network& /*network*/, NetworkXmlWriterContext& context) const {
     context.getWriter().writeAttribute(R, line.getR());
-    context.getWriter().writeAttribute(NOMINAL_V, line.getNominalVoltage());
+    context.getWriter().writeAttribute(NOMINAL_V, line.getNominalV());
     context.getWriter().writeAttribute(CONVERTERS_MODE, Enum::toString(line.getConvertersMode()));
     context.getWriter().writeAttribute(ACTIVE_POWER_SETPOINT, line.getActivePowerSetpoint());
     context.getWriter().writeAttribute(MAX_P, line.getMaxP());

--- a/src/iidm/converter/xml/VoltageLevelXml.cpp
+++ b/src/iidm/converter/xml/VoltageLevelXml.cpp
@@ -109,11 +109,11 @@ void VoltageLevelXml::readNodeBreakerTopology(VoltageLevel& voltageLevel, Networ
 }
 
 VoltageLevel& VoltageLevelXml::readRootElementAttributes(VoltageLevelAdder& adder, NetworkXmlReaderContext& context) const {
-    auto nominalVoltage = context.getReader().getAttributeValue<double>(NOMINAL_V);
+    auto nominalV = context.getReader().getAttributeValue<double>(NOMINAL_V);
     double lowVoltageLimit = context.getReader().getOptionalAttributeValue(LOW_VOLTAGE_LIMIT, stdcxx::nan());
     double highVoltageLimit = context.getReader().getOptionalAttributeValue(HIGH_VOLTAGE_LIMIT, stdcxx::nan());
     const auto& topologyKing = Enum::fromString<TopologyKind>(context.getReader().getAttributeValue(TOPOLOGY_KIND));
-    return adder.setNominalVoltage(nominalVoltage)
+    return adder.setNominalV(nominalV)
                 .setLowVoltageLimit(lowVoltageLimit)
                 .setHighVoltageLimit(highVoltageLimit)
                 .setTopologyKind(topologyKing)
@@ -263,7 +263,7 @@ void VoltageLevelXml::writeNodeBreakerTopologyInternalConnections(const VoltageL
 }
 
 void VoltageLevelXml::writeRootElementAttributes(const VoltageLevel& voltageLevel, const Substation& /*substation*/, NetworkXmlWriterContext& context) const {
-    context.getWriter().writeAttribute(NOMINAL_V, voltageLevel.getNominalVoltage());
+    context.getWriter().writeAttribute(NOMINAL_V, voltageLevel.getNominalV());
     context.getWriter().writeOptionalAttribute(LOW_VOLTAGE_LIMIT, voltageLevel.getLowVoltageLimit());
     context.getWriter().writeOptionalAttribute(HIGH_VOLTAGE_LIMIT, voltageLevel.getHighVoltageLimit());
     const TopologyLevel& topologyLevel = getMinTopologyLevel(voltageLevel.getTopologyKind(), context.getOptions().getTopologyLevel());

--- a/src/network/BatteryNetworkFactory.cpp
+++ b/src/network/BatteryNetworkFactory.cpp
@@ -48,12 +48,12 @@ iidm::Network BatteryNetworkFactory::create() {
     // 2 VoltageLevels
     iidm::VoltageLevel& vlgen = p1.newVoltageLevel()
         .setId("VLGEN")
-        .setNominalVoltage(400)
+        .setNominalV(400)
         .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
         .add();
     iidm::VoltageLevel& vlbat = p2.newVoltageLevel()
         .setId("VLBAT")
-        .setNominalVoltage(400)
+        .setNominalV(400)
         .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
         .add();
 

--- a/src/network/EurostagFactory.cpp
+++ b/src/network/EurostagFactory.cpp
@@ -38,22 +38,22 @@ iidm::Network EurostagFactory::createTutorial1Network() {
         .add();
     iidm::VoltageLevel& vlgen = p1.newVoltageLevel()
         .setId("VLGEN")
-        .setNominalVoltage(24.0)
+        .setNominalV(24.0)
         .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
         .add();
     iidm::VoltageLevel& vlhv1 = p1.newVoltageLevel()
         .setId("VLHV1")
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
         .add();
     iidm::VoltageLevel& vlhv2 = p2.newVoltageLevel()
         .setId("VLHV2")
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
         .add();
     iidm::VoltageLevel& vlload = p2.newVoltageLevel()
         .setId("VLLOAD")
-        .setNominalVoltage(150.0)
+        .setNominalV(150.0)
         .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
         .add();
     iidm::Bus& ngen = vlgen.getBusBreakerView().newBus()

--- a/src/network/FictitiousSwitchFactory.cpp
+++ b/src/network/FictitiousSwitchFactory.cpp
@@ -60,7 +60,7 @@ iidm::Network FictitiousSwitchFactory::create() {
         .add();
     iidm::VoltageLevel& vlC = s.newVoltageLevel()
         .setId("C")
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(0.0)
         .setTopologyKind(iidm::TopologyKind::NODE_BREAKER)
         .add();
@@ -76,7 +76,7 @@ iidm::Network FictitiousSwitchFactory::create() {
 
     iidm::VoltageLevel& vlN = s.newVoltageLevel()
         .setId("N")
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(220.0)
         .setHighVoltageLimit(245.00002)
         .setTopologyKind(iidm::TopologyKind::NODE_BREAKER)

--- a/src/network/FourSubstationsNodeBreakerFactory.cpp
+++ b/src/network/FourSubstationsNodeBreakerFactory.cpp
@@ -73,7 +73,7 @@ iidm::Network FourSubstationsNodeBreakerFactory::create() {
             .add();
     iidm::VoltageLevel& s1vl1 = s1.newVoltageLevel()
             .setId("S1VL1")
-            .setNominalVoltage(225.0)
+            .setNominalV(225.0)
             .setLowVoltageLimit(220.0)
             .setHighVoltageLimit(240.0)
             .setTopologyKind(iidm::TopologyKind::NODE_BREAKER)
@@ -85,7 +85,7 @@ iidm::Network FourSubstationsNodeBreakerFactory::create() {
             .add();
     iidm::VoltageLevel& s1vl2 = s1.newVoltageLevel()
             .setId("S1VL2")
-            .setNominalVoltage(400.0)
+            .setNominalV(400.0)
             .setLowVoltageLimit(390.0)
             .setHighVoltageLimit(440.0)
             .setTopologyKind(iidm::TopologyKind::NODE_BREAKER)
@@ -107,7 +107,7 @@ iidm::Network FourSubstationsNodeBreakerFactory::create() {
             .add();
     iidm::VoltageLevel& s2vl1 = s2.newVoltageLevel()
             .setId("S2VL1")
-            .setNominalVoltage(400.0)
+            .setNominalV(400.0)
             .setLowVoltageLimit(390.0)
             .setHighVoltageLimit(440.0)
             .setTopologyKind(iidm::TopologyKind::NODE_BREAKER)
@@ -124,7 +124,7 @@ iidm::Network FourSubstationsNodeBreakerFactory::create() {
             .add();
     iidm::VoltageLevel& s3vl1 = s3.newVoltageLevel()
             .setId("S3VL1")
-            .setNominalVoltage(400.0)
+            .setNominalV(400.0)
             .setLowVoltageLimit(390.0)
             .setHighVoltageLimit(440.0)
             .setTopologyKind(iidm::TopologyKind::NODE_BREAKER)
@@ -141,7 +141,7 @@ iidm::Network FourSubstationsNodeBreakerFactory::create() {
             .add();
     iidm::VoltageLevel& s4vl1 = s4.newVoltageLevel()
             .setId("S4VL1")
-            .setNominalVoltage(400.0)
+            .setNominalV(400.0)
             .setLowVoltageLimit(390.0)
             .setHighVoltageLimit(440.0)
             .setTopologyKind(iidm::TopologyKind::NODE_BREAKER)
@@ -469,7 +469,7 @@ iidm::Network FourSubstationsNodeBreakerFactory::create() {
             .setConverterStationId1("VSC1")
             .setConverterStationId2("VSC2")
             .setR(1)
-            .setNominalVoltage(400)
+            .setNominalV(400)
             .setConvertersMode(iidm::HvdcLine::ConvertersMode::SIDE_1_RECTIFIER_SIDE_2_INVERTER)
             .setMaxP(300.0)
             .setActivePowerSetpoint(10)
@@ -593,7 +593,7 @@ iidm::Network FourSubstationsNodeBreakerFactory::create() {
             .setConverterStationId1("LCC1")
             .setConverterStationId2("LCC2")
             .setR(1)
-            .setNominalVoltage(400)
+            .setNominalV(400)
             .setConvertersMode(iidm::HvdcLine::ConvertersMode::SIDE_1_RECTIFIER_SIDE_2_INVERTER)
             .setMaxP(300.0)
             .setActivePowerSetpoint(80)

--- a/src/network/MultipleExtensionsTestNetworkFactory.cpp
+++ b/src/network/MultipleExtensionsTestNetworkFactory.cpp
@@ -29,7 +29,7 @@ iidm::Network MultipleExtensionsTestNetworkFactory::create() {
     iidm::VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
         .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(20.0F)
+        .setNominalV(20.0F)
         .setLowVoltageLimit(15.0F)
         .setHighVoltageLimit(25.0F)
         .add();

--- a/src/network/ThreeWindingsTransformerNetworkFactory.cpp
+++ b/src/network/ThreeWindingsTransformerNetworkFactory.cpp
@@ -38,7 +38,7 @@ iidm::Network ThreeWindingsTransformerNetworkFactory::create() {
         .add();
     iidm::VoltageLevel& vl1 = substation.newVoltageLevel()
         .setId("VL_132")
-        .setNominalVoltage(132.0)
+        .setNominalV(132.0)
         .setLowVoltageLimit(118.8)
         .setHighVoltageLimit(145.2)
         .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
@@ -59,7 +59,7 @@ iidm::Network ThreeWindingsTransformerNetworkFactory::create() {
 
     iidm::VoltageLevel& vl2 = substation.newVoltageLevel()
         .setId("VL_33")
-        .setNominalVoltage(33.0)
+        .setNominalV(33.0)
         .setLowVoltageLimit(29.7)
         .setHighVoltageLimit(36.3)
         .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)
@@ -80,7 +80,7 @@ iidm::Network ThreeWindingsTransformerNetworkFactory::create() {
 
     iidm::VoltageLevel& vl3 = substation.newVoltageLevel()
         .setId("VL_11")
-        .setNominalVoltage(11.0)
+        .setNominalV(11.0)
         .setLowVoltageLimit(9.9)
         .setHighVoltageLimit(12.1)
         .setTopologyKind(iidm::TopologyKind::BUS_BREAKER)

--- a/test/iidm/AliasesTest.cpp
+++ b/test/iidm/AliasesTest.cpp
@@ -37,7 +37,7 @@ static Network createNetwork() {
         .add();
     VoltageLevel& voltageLevel1 = substation1.newVoltageLevel()
         .setId("voltageLevel1")
-        .setNominalVoltage(400)
+        .setNominalV(400)
         .setTopologyKind(TopologyKind::NODE_BREAKER)
         .add();
     VoltageLevel::NodeBreakerView& topology1 = voltageLevel1.getNodeBreakerView();

--- a/test/iidm/BatteryTest.cpp
+++ b/test/iidm/BatteryTest.cpp
@@ -36,7 +36,7 @@ Network createBatteryTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();

--- a/test/iidm/BusBreakerVoltageLevelTest.cpp
+++ b/test/iidm/BusBreakerVoltageLevelTest.cpp
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(CalculatedBusTopologyTest) {
     VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(CalculatedBusTopologyTest) {
     VoltageLevel& vl2 = s.newVoltageLevel()
         .setId("VL2")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
     VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -410,7 +410,7 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
     VoltageLevel& vl2 = s.newVoltageLevel()
         .setId("VL2")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();

--- a/test/iidm/BusTest.cpp
+++ b/test/iidm/BusTest.cpp
@@ -59,7 +59,7 @@ Network create() {
 
     VoltageLevel& vl1 = s.newVoltageLevel()
         .setId("VL1")
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
 
@@ -69,7 +69,7 @@ Network create() {
 
     VoltageLevel& vl2 = s.newVoltageLevel()
         .setId("VL2")
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
 
@@ -79,7 +79,7 @@ Network create() {
 
     VoltageLevel& vl3 = s.newVoltageLevel()
         .setId("VL3")
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
 
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(testSetterGetter) {
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .setId("bbVL")
         .setName("bbVL_name")
-        .setNominalVoltage(200.0)
+        .setNominalV(200.0)
         .add();
     // ConfiguredBus
     Bus& bus = voltageLevel.getBusBreakerView()

--- a/test/iidm/BusTest.cpp
+++ b/test/iidm/BusTest.cpp
@@ -40,6 +40,7 @@
 #include <powsybl/iidm/converter/xml/IidmXmlVersion.hpp>
 #include <powsybl/network/EurostagFactory.hpp>
 #include <powsybl/stdcxx/range.hpp>
+#include <powsybl/test/AssertionUtils.hpp>
 #include <powsybl/test/ResourceFixture.hpp>
 #include <powsybl/test/converter/RoundTrip.hpp>
 
@@ -90,6 +91,71 @@ Network create() {
 }
 
 BOOST_AUTO_TEST_SUITE(BusTestSuite)
+
+BOOST_AUTO_TEST_CASE(testSetterGetter) {
+    Network network("test", "test");
+    Substation& substation = network.newSubstation()
+        .setCountry(Country::AF)
+        .setTso("tso")
+        .setName("sub")
+        .setId("subId")
+        .add();
+    VoltageLevel& voltageLevel = substation.newVoltageLevel()
+        .setTopologyKind(TopologyKind::BUS_BREAKER)
+        .setId("bbVL")
+        .setName("bbVL_name")
+        .setNominalVoltage(200.0)
+        .add();
+    // ConfiguredBus
+    Bus& bus = voltageLevel.getBusBreakerView()
+        .newBus()
+        .setName("bus1Name")
+        .setId("bus1")
+        .add();
+
+    BOOST_CHECK_EQUAL("bus1", network.getBusBreakerView().getBus("bus1").get().getId());
+    BOOST_CHECK_EQUAL("bus1", bus.getId());
+    BOOST_CHECK_EQUAL("bus1Name", bus.getNameOrId());
+
+    LccConverterStation& lccConverterStation = voltageLevel.newLccConverterStation()
+        .setId("lcc")
+        .setName("lcc")
+        .setBus("bus1")
+        .setLossFactor(0.011)
+        .setPowerFactor(0.5)
+        .setConnectableBus("bus1")
+        .add();
+    VscConverterStation& vscConverterStation = voltageLevel.newVscConverterStation()
+        .setId("vsc")
+        .setName("vsc")
+        .setBus("bus1")
+        .setLossFactor(0.011)
+        .setVoltageRegulatorOn(false)
+        .setReactivePowerSetpoint(1.0)
+        .setConnectableBus("bus1")
+        .add();
+    BOOST_CHECK_EQUAL(HvdcConverterStation::HvdcType::LCC, lccConverterStation.getHvdcType());
+    BOOST_CHECK_EQUAL(HvdcConverterStation::HvdcType::VSC, vscConverterStation.getHvdcType());
+    double p1 = 1.0;
+    double q1 = 2.0;
+    double p2 = 10.0;
+    double q2 = 20.0;
+    lccConverterStation.getTerminal().setP(p1);
+    lccConverterStation.getTerminal().setQ(q1);
+    vscConverterStation.getTerminal().setP(p2);
+    vscConverterStation.getTerminal().setQ(q2);
+
+    BOOST_CHECK(stdcxx::areSame(voltageLevel, bus.getVoltageLevel()));
+    BOOST_CHECK(stdcxx::areSame(network, bus.getNetwork()));
+    POWSYBL_ASSERT_THROW(bus.setV(-1.0), PowsyblException, "Bus 'bus1': voltage cannot be < 0");
+    bus.setV(200.0);
+    BOOST_CHECK_CLOSE(200.0, bus.getV(), std::numeric_limits<double>::epsilon());
+    bus.setAngle(30.0);
+    BOOST_CHECK_CLOSE(30.0, bus.getAngle(), std::numeric_limits<double>::epsilon());
+
+    BOOST_CHECK_CLOSE(p1 + p2, bus.getP(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(q1 + q2, bus.getQ(), std::numeric_limits<double>::epsilon());
+}
 
 BOOST_AUTO_TEST_CASE(range_batteries) {
     Network network = create();

--- a/test/iidm/ComponentsTest.cpp
+++ b/test/iidm/ComponentsTest.cpp
@@ -35,7 +35,7 @@ Network createComponentsTestNetworkBB() {
     VoltageLevel& vl1 = substation.newVoltageLevel()
         .setId("VL1")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .add();
 
     Bus& vl1Bus1 = vl1.getBusBreakerView().newBus()
@@ -52,7 +52,7 @@ Network createComponentsTestNetworkBB() {
     VoltageLevel& vl2 = substation.newVoltageLevel()
         .setId("VL2")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .add();
 
     Bus& vl2Bus1 = vl2.getBusBreakerView().newBus()
@@ -69,7 +69,7 @@ Network createComponentsTestNetworkBB() {
     VoltageLevel& vl3 = substation.newVoltageLevel()
         .setId("VL3")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(90.0)
+        .setNominalV(90.0)
         .add();
 
     Bus& vl3Bus1 = vl3.getBusBreakerView().newBus()
@@ -117,7 +117,7 @@ Network createComponentsTestNetworkBB() {
     VoltageLevel& vl4 = substation2.newVoltageLevel()
         .setId("VL4")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .add();
 
     Bus& vl4Bus1 = vl4.getBusBreakerView().newBus()
@@ -134,7 +134,7 @@ Network createComponentsTestNetworkBB() {
     VoltageLevel& vl5 = substation2.newVoltageLevel()
         .setId("VL5")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .add();
 
     Bus& vl5Bus1 = vl5.getBusBreakerView().newBus()
@@ -183,7 +183,7 @@ Network createComponentsTestNetworkBB() {
     VoltageLevel& vl6 = substation3.newVoltageLevel()
         .setId("VL6")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .add();
 
     Bus& vl6Bus1 = vl6.getBusBreakerView().newBus()
@@ -242,7 +242,7 @@ Network createComponentsTestNetworkBB() {
     VoltageLevel& vl7 = substation4.newVoltageLevel()
         .setId("VL7")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .add();
 
     Bus& vl7Bus1 = vl7.getBusBreakerView().newBus()
@@ -277,7 +277,7 @@ Network createComponentsTestNetworkBB() {
     VoltageLevel& vl8 = substation4.newVoltageLevel()
         .setId("VL8")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .add();
 
     Bus& vl8Bus1 = vl8.getBusBreakerView().newBus()
@@ -298,7 +298,7 @@ Network createComponentsTestNetworkBB() {
     VoltageLevel& vl9 = substation5.newVoltageLevel()
         .setId("VL9")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .add();
 
     Bus& vl9Bus1 = vl9.getBusBreakerView().newBus()
@@ -329,7 +329,7 @@ Network createComponentsTestNetworkBB() {
     VoltageLevel& vl10 = substation5.newVoltageLevel()
         .setId("VL10")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .add();
 
     Bus& vl10Bus1 = vl10.getBusBreakerView().newBus()
@@ -369,7 +369,7 @@ Network createComponentsTestNetworkNB() {
     VoltageLevel& vl1 = substation.newVoltageLevel()
         .setId("VL1")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .add();
 
      vl1.newLoad()
@@ -390,7 +390,7 @@ Network createComponentsTestNetworkNB() {
     VoltageLevel& vl2 = substation.newVoltageLevel()
         .setId("VL2")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .add();
 
     vl2.newLoad()
@@ -419,7 +419,7 @@ Network createComponentsTestNetworkNB() {
     VoltageLevel& vl3 = substation.newVoltageLevel()
         .setId("VL3")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(90.0)
+        .setNominalV(90.0)
         .add();
 
     vl3.newLoad()
@@ -472,7 +472,7 @@ Network createComponentsTestNetworkNB() {
     VoltageLevel& vl4 = substation2.newVoltageLevel()
         .setId("VL4")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .add();
 
     vl4.newLoad()
@@ -501,7 +501,7 @@ Network createComponentsTestNetworkNB() {
     VoltageLevel& vl5 = substation2.newVoltageLevel()
         .setId("VL5")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .add();
 
     vl5.newLoad()
@@ -562,7 +562,7 @@ Network createComponentsTestNetworkNB() {
     VoltageLevel& vl6 = substation3.newVoltageLevel()
         .setId("VL6")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .add();
 
     vl6.newLoad()
@@ -635,7 +635,7 @@ Network createComponentsTestNetworkNB() {
     VoltageLevel& vl7 = substation4.newVoltageLevel()
         .setId("VL7")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .add();
 
     vl7.newLoad()
@@ -684,7 +684,7 @@ Network createComponentsTestNetworkNB() {
     VoltageLevel& vl8 = substation4.newVoltageLevel()
         .setId("VL8")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .add();
 
     vl8.newLoad()
@@ -709,7 +709,7 @@ Network createComponentsTestNetworkNB() {
     VoltageLevel& vl9 = substation5.newVoltageLevel()
         .setId("VL9")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .add();
 
     vl9.newLoad()
@@ -744,7 +744,7 @@ Network createComponentsTestNetworkNB() {
     VoltageLevel& vl10 = substation5.newVoltageLevel()
         .setId("VL10")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .add();
 
     vl10.newLoad()
@@ -791,7 +791,7 @@ Network createMultiConnectedComponentsNetwork() {
             .add();
     VoltageLevel& vl1 = s1.newVoltageLevel()
             .setId("B")
-            .setNominalVoltage(225.0)
+            .setNominalV(225.0)
             .setLowVoltageLimit(0.0)
             .setTopologyKind(TopologyKind::NODE_BREAKER)
             .add();
@@ -822,7 +822,7 @@ Network createMultiConnectedComponentsNetwork() {
             .add();
     VoltageLevel& vl2 = s2.newVoltageLevel()
             .setId("G")
-            .setNominalVoltage(225.0)
+            .setNominalV(225.0)
             .setLowVoltageLimit(0.0)
             .setTopologyKind(TopologyKind::NODE_BREAKER)
             .add();
@@ -891,7 +891,7 @@ Network createNetworkWithHvdcLine() {
             .add();
     VoltageLevel& vl1 = s1.newVoltageLevel()
             .setId("VL1")
-            .setNominalVoltage(400)
+            .setNominalV(400)
             .setTopologyKind(TopologyKind::BUS_BREAKER)
             .add();
     vl1.getBusBreakerView().newBus()
@@ -903,7 +903,7 @@ Network createNetworkWithHvdcLine() {
             .add();
     VoltageLevel& vl2 = s2.newVoltageLevel()
             .setId("VL2")
-            .setNominalVoltage(400)
+            .setNominalV(400)
             .setTopologyKind(TopologyKind::NODE_BREAKER)
             .add();
     vl2.getNodeBreakerView().newBusbarSection()

--- a/test/iidm/ComponentsTest.cpp
+++ b/test/iidm/ComponentsTest.cpp
@@ -270,7 +270,7 @@ Network createComponentsTestNetworkBB() {
         .setConverterStationId1("LCC1")
         .setConverterStationId2("LCC2")
         .setMaxP(12.0)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setR(14.0)
         .add();
 
@@ -677,7 +677,7 @@ Network createComponentsTestNetworkNB() {
         .setConverterStationId1("VSC1")
         .setConverterStationId2("VSC2")
         .setMaxP(12.0)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setR(14.0)
         .add();
 
@@ -969,7 +969,7 @@ Network createNetworkWithHvdcLine() {
             .setConverterStationId1("C1")
             .setConverterStationId2("C2")
             .setR(1)
-            .setNominalVoltage(400)
+            .setNominalV(400)
             .setConvertersMode(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER)
             .setMaxP(300.0)
             .setActivePowerSetpoint(280)

--- a/test/iidm/CurrentLimitsTest.cpp
+++ b/test/iidm/CurrentLimitsTest.cpp
@@ -40,7 +40,7 @@ Network createCurrentLimitsTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -53,7 +53,7 @@ Network createCurrentLimitsTestNetwork() {
         .setId("VL2")
         .setName("VL2_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();
@@ -73,7 +73,7 @@ Network createCurrentLimitsTestNetwork() {
         .setId("VL3")
         .setName("VL3_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -86,7 +86,7 @@ Network createCurrentLimitsTestNetwork() {
         .setId("VL4")
         .setName("VL4_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();

--- a/test/iidm/DanglingLineTest.cpp
+++ b/test/iidm/DanglingLineTest.cpp
@@ -33,7 +33,7 @@ Network createDanglingLineTestNetwork(bool withGeneration) {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();

--- a/test/iidm/GeneratorTest.cpp
+++ b/test/iidm/GeneratorTest.cpp
@@ -36,7 +36,7 @@ Network createGeneratorTestNetwork() {
     VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .setFictitious(false)

--- a/test/iidm/HvdcLineTest.cpp
+++ b/test/iidm/HvdcLineTest.cpp
@@ -112,7 +112,7 @@ Network createHvdcLineTestNetwork() {
         .setConverterStationId1("LCC1")
         .setConverterStationId2("LCC2")
         .setMaxP(12.0)
-        .setNominalVoltage(13.0)
+        .setNominalV(13.0)
         .setR(14.0)
         .add();
 
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(adder) {
     adder.setConvertersMode(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER);
 
     POWSYBL_ASSERT_THROW(adder.add(), ValidationException, "hvdcLine 'HVDC1': Nominal voltage is undefined");
-    adder.setNominalVoltage(30.0);
+    adder.setNominalV(30.0);
 
     POWSYBL_ASSERT_THROW(adder.add(), ValidationException, "hvdcLine 'HVDC1': invalid value (nan) for active power setpoint");
     adder.setActivePowerSetpoint(40.0);
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
     BOOST_CHECK_EQUAL("LCC2", hvdc.getConverterStation2().get().getId());
     BOOST_CHECK_CLOSE(12.0, hvdc.getMaxP(), std::numeric_limits<double>::epsilon());
-    BOOST_CHECK_CLOSE(13.0, hvdc.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(13.0, hvdc.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(14.0, hvdc.getR(), std::numeric_limits<double>::epsilon());
     BOOST_TEST(stdcxx::areSame(network, hvdc.getNetwork()));
 }
@@ -220,9 +220,9 @@ BOOST_AUTO_TEST_CASE(integrity) {
     BOOST_CHECK_CLOSE(200.0, hvdc.getMaxP(), std::numeric_limits<double>::epsilon());
     POWSYBL_ASSERT_THROW(hvdc.setMaxP(stdcxx::nan()), ValidationException, "hvdcLine 'HVDC1': invalid value (nan) for maximum P");
 
-    BOOST_TEST(stdcxx::areSame(hvdc, hvdc.setNominalVoltage(300.0)));
-    BOOST_CHECK_CLOSE(300.0, hvdc.getNominalVoltage(), std::numeric_limits<double>::epsilon());
-    POWSYBL_ASSERT_THROW(hvdc.setNominalVoltage(stdcxx::nan()), ValidationException, "hvdcLine 'HVDC1': Nominal voltage is undefined");
+    BOOST_TEST(stdcxx::areSame(hvdc, hvdc.setNominalV(300.0)));
+    BOOST_CHECK_CLOSE(300.0, hvdc.getNominalV(), std::numeric_limits<double>::epsilon());
+    POWSYBL_ASSERT_THROW(hvdc.setNominalV(stdcxx::nan()), ValidationException, "hvdcLine 'HVDC1': Nominal voltage is undefined");
 
     BOOST_TEST(stdcxx::areSame(hvdc, hvdc.setR(400.0)));
     BOOST_CHECK_CLOSE(400.0, hvdc.getR(), std::numeric_limits<double>::epsilon());
@@ -257,9 +257,9 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
     BOOST_CHECK_EQUAL("LCC2", hvdc.getConverterStation2().get().getId());
     BOOST_CHECK_CLOSE(12.0, hvdc.getMaxP(), std::numeric_limits<double>::epsilon());
-    BOOST_CHECK_CLOSE(13.0, hvdc.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(13.0, hvdc.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(14.0, hvdc.getR(), std::numeric_limits<double>::epsilon());
-    hvdc.setActivePowerSetpoint(100.0).setR(200.0).setMaxP(300.0).setConvertersMode(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER).setNominalVoltage(400.0);
+    hvdc.setActivePowerSetpoint(100.0).setR(200.0).setMaxP(300.0).setConvertersMode(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER).setNominalV(400.0);
 
     BOOST_CHECK_EQUAL("HVDC1", hvdc.getId());
     BOOST_CHECK_CLOSE(100.0, hvdc.getActivePowerSetpoint(), std::numeric_limits<double>::epsilon());
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
     BOOST_CHECK_EQUAL("LCC2", hvdc.getConverterStation2().get().getId());
     BOOST_CHECK_CLOSE(300.0, hvdc.getMaxP(), std::numeric_limits<double>::epsilon());
-    BOOST_CHECK_CLOSE(400.0, hvdc.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(400.0, hvdc.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(200.0, hvdc.getR(), std::numeric_limits<double>::epsilon());
 
     network.getVariantManager().setWorkingVariant("s2");
@@ -277,9 +277,9 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
     BOOST_CHECK_EQUAL("LCC2", hvdc.getConverterStation2().get().getId());
     BOOST_CHECK_CLOSE(300.0, hvdc.getMaxP(), std::numeric_limits<double>::epsilon());
-    BOOST_CHECK_CLOSE(400.0, hvdc.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(400.0, hvdc.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(200.0, hvdc.getR(), std::numeric_limits<double>::epsilon());
-    hvdc.setActivePowerSetpoint(150.0).setR(250.0).setMaxP(350.0).setConvertersMode(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER).setNominalVoltage(450.0);
+    hvdc.setActivePowerSetpoint(150.0).setR(250.0).setMaxP(350.0).setConvertersMode(HvdcLine::ConvertersMode::SIDE_1_INVERTER_SIDE_2_RECTIFIER).setNominalV(450.0);
 
     BOOST_CHECK_EQUAL("HVDC1", hvdc.getId());
     BOOST_CHECK_CLOSE(150.0, hvdc.getActivePowerSetpoint(), std::numeric_limits<double>::epsilon());
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
     BOOST_CHECK_EQUAL("LCC2", hvdc.getConverterStation2().get().getId());
     BOOST_CHECK_CLOSE(350.0, hvdc.getMaxP(), std::numeric_limits<double>::epsilon());
-    BOOST_CHECK_CLOSE(450.0, hvdc.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(450.0, hvdc.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(250.0, hvdc.getR(), std::numeric_limits<double>::epsilon());
 
     network.getVariantManager().setWorkingVariant(VariantManager::getInitialVariantId());
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
     BOOST_CHECK_EQUAL("LCC2", hvdc.getConverterStation2().get().getId());
     BOOST_CHECK_CLOSE(350.0, hvdc.getMaxP(), std::numeric_limits<double>::epsilon());
-    BOOST_CHECK_CLOSE(450.0, hvdc.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(450.0, hvdc.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(250.0, hvdc.getR(), std::numeric_limits<double>::epsilon());
 
     network.getVariantManager().removeVariant("s1");
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE(multivariant) {
     BOOST_CHECK_EQUAL("LCC1", hvdc.getConverterStation1().get().getId());
     BOOST_CHECK_EQUAL("LCC2", hvdc.getConverterStation2().get().getId());
     BOOST_CHECK_CLOSE(350.0, hvdc.getMaxP(), std::numeric_limits<double>::epsilon());
-    BOOST_CHECK_CLOSE(450.0, hvdc.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(450.0, hvdc.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(250.0, hvdc.getR(), std::numeric_limits<double>::epsilon());
 
     network.getVariantManager().removeVariant("s3");

--- a/test/iidm/HvdcLineTest.cpp
+++ b/test/iidm/HvdcLineTest.cpp
@@ -35,7 +35,7 @@ Network createHvdcLineTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -75,7 +75,7 @@ Network createHvdcLineTestNetwork() {
         .setId("VL2")
         .setName("VL2_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();

--- a/test/iidm/LineTest.cpp
+++ b/test/iidm/LineTest.cpp
@@ -36,7 +36,7 @@ Network createLineTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -49,7 +49,7 @@ Network createLineTestNetwork() {
         .setId("VL2")
         .setName("VL2_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();
@@ -69,7 +69,7 @@ Network createLineTestNetwork() {
         .setId("VL3")
         .setName("VL3_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -82,7 +82,7 @@ Network createLineTestNetwork() {
         .setId("VL4")
         .setName("VL4_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();

--- a/test/iidm/NetworkFactory.cpp
+++ b/test/iidm/NetworkFactory.cpp
@@ -34,7 +34,7 @@ Network createHvdcConverterStationTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -79,7 +79,7 @@ Network createNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -102,7 +102,7 @@ Network createNetwork() {
         .setId("VL2")
         .setName("VL2_NAME")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();
@@ -120,7 +120,7 @@ Terminal& getTerminalFromNetwork2() {
         VoltageLevel& vl = s.newVoltageLevel()
             .setId("VL")
             .setTopologyKind(TopologyKind::NODE_BREAKER)
-            .setNominalVoltage(400.0)
+            .setNominalV(400.0)
             .setLowVoltageLimit(380.0)
             .setHighVoltageLimit(420.0)
             .add();

--- a/test/iidm/NetworkTest.cpp
+++ b/test/iidm/NetworkTest.cpp
@@ -373,11 +373,6 @@ BOOST_AUTO_TEST_CASE(fictitious) {
     BOOST_CHECK(!network.isFictitious());
 }
 
-std::ostream& operator<<(std::ostream& stream, const Country& country) {
-    stream << Enum::toString(country);
-    return stream;
-}
-
 BOOST_AUTO_TEST_CASE(country) {
     Network network = createTestNetwork();
 
@@ -385,7 +380,7 @@ BOOST_AUTO_TEST_CASE(country) {
     BOOST_CHECK_EQUAL(2, network.getCountryCount());
 
     const std::set<Country>& countries = { Country::ES, Country::FR };
-    BOOST_CHECK(countries ==  network.getCountries());
+    BOOST_CHECK(countries == network.getCountries());
 
     network.getSubstation("S2").setCountry(stdcxx::optional<Country>());
     BOOST_CHECK_EQUAL(1, network.getCountryCount());

--- a/test/iidm/NetworkTest.cpp
+++ b/test/iidm/NetworkTest.cpp
@@ -47,7 +47,7 @@ Network createTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -60,7 +60,7 @@ Network createTestNetwork() {
         .setId("VL2")
         .setName("VL2_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();
@@ -96,7 +96,7 @@ Network createTestNetwork() {
         .setId("VL3")
         .setName("VL3_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -147,7 +147,7 @@ Network createTestNetwork() {
         .setId("VL4")
         .setName("VL4_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();
@@ -246,7 +246,7 @@ Network createTestNodeBreakerNetwork() {
         .setId("VL5")
         .setName("VL5_NAME")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();

--- a/test/iidm/NetworkTest.cpp
+++ b/test/iidm/NetworkTest.cpp
@@ -10,6 +10,7 @@
 #include <powsybl/iidm/Bus.hpp>
 #include <powsybl/iidm/DanglingLine.hpp>
 #include <powsybl/iidm/DanglingLineAdder.hpp>
+#include <powsybl/iidm/Enum.hpp>
 #include <powsybl/iidm/Line.hpp>
 #include <powsybl/iidm/LineAdder.hpp>
 #include <powsybl/iidm/Load.hpp>
@@ -372,11 +373,19 @@ BOOST_AUTO_TEST_CASE(fictitious) {
     BOOST_CHECK(!network.isFictitious());
 }
 
+std::ostream& operator<<(std::ostream& stream, const Country& country) {
+    stream << Enum::toString(country);
+    return stream;
+}
+
 BOOST_AUTO_TEST_CASE(country) {
     Network network = createTestNetwork();
 
     BOOST_CHECK_EQUAL(4, network.getSubstationCount());
     BOOST_CHECK_EQUAL(2, network.getCountryCount());
+
+    const std::set<Country>& countries = { Country::ES, Country::FR };
+    BOOST_CHECK(countries ==  network.getCountries());
 
     network.getSubstation("S2").setCountry(stdcxx::optional<Country>());
     BOOST_CHECK_EQUAL(1, network.getCountryCount());

--- a/test/iidm/NodeBreakerVoltageLevelTest.cpp
+++ b/test/iidm/NodeBreakerVoltageLevelTest.cpp
@@ -41,7 +41,7 @@ Network createCalculatedBusSwitchTestNetwork() {
     VoltageLevel& vl = s1.newVoltageLevel()
         .setId("B")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(0.0)
         .setHighVoltageLimit(250.0)
         .add();
@@ -75,7 +75,7 @@ Network createCalculatedBusSwitchTestNetwork() {
     VoltageLevel& vl2 = s2.newVoltageLevel()
         .setId("G")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(0.0)
         .setHighVoltageLimit(250.0)
         .add();
@@ -144,7 +144,7 @@ Network createCalculatedBusSwitchTestNetwork() {
     VoltageLevel& vl3 = s3.newVoltageLevel()
         .setId("VL")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -189,7 +189,7 @@ void createNetwork(Network& network) {
         .add();
     VoltageLevel& vl = s.newVoltageLevel()
         .setId(S5_10K_V)
-        .setNominalVoltage(10.0)
+        .setNominalV(10.0)
         .setTopologyKind(TopologyKind::NODE_BREAKER)
         .add();
     vl.getNodeBreakerView().newBusbarSection()
@@ -257,7 +257,7 @@ void createNetwork(Network& network) {
         .add();
     s4.newVoltageLevel()
     .setId("S4 10kV")
-    .setNominalVoltage(10.0)
+    .setNominalV(10.0)
     .setTopologyKind(TopologyKind::NODE_BREAKER)
     .add();
     network.newLine()
@@ -564,7 +564,7 @@ BOOST_AUTO_TEST_CASE(calculatedBusBreakerTopology) {
     VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -614,7 +614,7 @@ BOOST_AUTO_TEST_CASE(calculatedBusBreakerTopology) {
     VoltageLevel& vl2 = s.newVoltageLevel()
         .setId("VL2")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -742,7 +742,7 @@ BOOST_AUTO_TEST_CASE(CalculatedBusTopology) {
     VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -789,7 +789,7 @@ BOOST_AUTO_TEST_CASE(CalculatedBusTopology) {
     VoltageLevel& vl2 = s.newVoltageLevel()
         .setId("VL2")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -859,7 +859,7 @@ BOOST_AUTO_TEST_CASE(CalculatedBusTopology2) {
     VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .add();
 
     auto& l1 = vl.newLoad()
@@ -884,7 +884,7 @@ BOOST_AUTO_TEST_CASE(CalculatedBusTopology3) {
     VoltageLevel& vl1 = s1.newVoltageLevel()
         .setId("VL")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(1.0)
+        .setNominalV(1.0)
         .add();
 
     vl1.getNodeBreakerView().newBusbarSection()
@@ -998,7 +998,7 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
         .setId("VL")
         .setName("VL_name")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -1067,7 +1067,7 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
     VoltageLevel& vl2 = s.newVoltageLevel()
         .setId("VL2")
         .setTopologyKind(TopologyKind::NODE_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -1089,7 +1089,7 @@ BOOST_AUTO_TEST_CASE(TerminalTest) {
     VoltageLevel& vl3 = s.newVoltageLevel()
         .setId("VL3")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(400.0)
+        .setNominalV(400.0)
         .setLowVoltageLimit(380.0)
         .setHighVoltageLimit(420.0)
         .add();

--- a/test/iidm/PhaseTapChangerTest.cpp
+++ b/test/iidm/PhaseTapChangerTest.cpp
@@ -43,7 +43,7 @@ Network createPhaseTapChangerTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -66,7 +66,7 @@ Network createPhaseTapChangerTestNetwork() {
         .setId("VL2")
         .setName("VL2_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();
@@ -96,7 +96,7 @@ Network createPhaseTapChangerTestNetwork() {
         .setId("VL3")
         .setName("VL3_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -109,7 +109,7 @@ Network createPhaseTapChangerTestNetwork() {
         .setId("VL4")
         .setName("VL4_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();

--- a/test/iidm/RatioTapChangerTest.cpp
+++ b/test/iidm/RatioTapChangerTest.cpp
@@ -43,7 +43,7 @@ Network createRatioTapChangerTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -66,7 +66,7 @@ Network createRatioTapChangerTestNetwork() {
         .setId("VL2")
         .setName("VL2_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();
@@ -96,7 +96,7 @@ Network createRatioTapChangerTestNetwork() {
         .setId("VL3")
         .setName("VL3_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -109,7 +109,7 @@ Network createRatioTapChangerTestNetwork() {
         .setId("VL4")
         .setName("VL4_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();

--- a/test/iidm/ShuntCompensatorTest.cpp
+++ b/test/iidm/ShuntCompensatorTest.cpp
@@ -37,7 +37,7 @@ Network createShuntCompensatorTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();

--- a/test/iidm/StaticVarCompensatorTest.cpp
+++ b/test/iidm/StaticVarCompensatorTest.cpp
@@ -36,7 +36,7 @@ Network createStaticVarCompensatorTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -69,7 +69,7 @@ Network createSvcNetwork() {
         .add();
     VoltageLevel& vl1 = s1.newVoltageLevel()
         .setId("VL1")
-        .setNominalVoltage(380)
+        .setNominalV(380)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl1.getBusBreakerView().newBus()
@@ -91,7 +91,7 @@ Network createSvcNetwork() {
         .add();
     VoltageLevel& vl2 = s2.newVoltageLevel()
         .setId("VL2")
-        .setNominalVoltage(380)
+        .setNominalV(380)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl2.getBusBreakerView().newBus()

--- a/test/iidm/SubstationTest.cpp
+++ b/test/iidm/SubstationTest.cpp
@@ -37,7 +37,7 @@ Network createSubstationTransformerCountTestNetwork() {
          .setId("VL1")
          .setName("VL1_NAME")
          .setTopologyKind(TopologyKind::BUS_BREAKER)
-         .setNominalVoltage(380.0)
+         .setNominalV(380.0)
          .setLowVoltageLimit(340.0)
          .setHighVoltageLimit(420.0)
          .add();
@@ -50,7 +50,7 @@ Network createSubstationTransformerCountTestNetwork() {
          .setId("VL2")
          .setName("VL2_NAME")
          .setTopologyKind(TopologyKind::BUS_BREAKER)
-         .setNominalVoltage(225.0)
+         .setNominalV(225.0)
          .setLowVoltageLimit(200.0)
          .setHighVoltageLimit(260.0)
          .add();
@@ -63,7 +63,7 @@ Network createSubstationTransformerCountTestNetwork() {
          .setId("VL3")
          .setName("VL3_NAME")
          .setTopologyKind(TopologyKind::BUS_BREAKER)
-         .setNominalVoltage(380.0)
+         .setNominalV(380.0)
          .setLowVoltageLimit(340.0)
          .setHighVoltageLimit(420.0)
          .add();
@@ -83,7 +83,7 @@ Network createSubstationTransformerCountTestNetwork() {
          .setId("VL4")
          .setName("VL4_NAME")
          .setTopologyKind(TopologyKind::BUS_BREAKER)
-         .setNominalVoltage(225.0)
+         .setNominalV(225.0)
          .setLowVoltageLimit(200.0)
          .setHighVoltageLimit(260.0)
          .add();

--- a/test/iidm/ThreeWindingsTransformerTest.cpp
+++ b/test/iidm/ThreeWindingsTransformerTest.cpp
@@ -47,7 +47,7 @@ Network createThreeWindingsTransformerTestNetwork() {
          .setId("VL1")
          .setName("VL1_NAME")
          .setTopologyKind(TopologyKind::BUS_BREAKER)
-         .setNominalVoltage(380.0)
+         .setNominalV(380.0)
          .setLowVoltageLimit(340.0)
          .setHighVoltageLimit(420.0)
          .add();
@@ -70,7 +70,7 @@ Network createThreeWindingsTransformerTestNetwork() {
          .setId("VL2")
          .setName("VL2_NAME")
          .setTopologyKind(TopologyKind::BUS_BREAKER)
-         .setNominalVoltage(225.0)
+         .setNominalV(225.0)
          .setLowVoltageLimit(200.0)
          .setHighVoltageLimit(260.0)
          .add();
@@ -93,7 +93,7 @@ Network createThreeWindingsTransformerTestNetwork() {
          .setId("VL3")
          .setName("VL3_NAME")
          .setTopologyKind(TopologyKind::BUS_BREAKER)
-         .setNominalVoltage(380.0)
+         .setNominalV(380.0)
          .setLowVoltageLimit(340.0)
          .setHighVoltageLimit(420.0)
          .add();
@@ -113,7 +113,7 @@ Network createThreeWindingsTransformerTestNetwork() {
          .setId("VL4")
          .setName("VL4_NAME")
          .setTopologyKind(TopologyKind::BUS_BREAKER)
-         .setNominalVoltage(225.0)
+         .setNominalV(225.0)
          .setLowVoltageLimit(200.0)
          .setHighVoltageLimit(260.0)
          .add();

--- a/test/iidm/TieLineTest.cpp
+++ b/test/iidm/TieLineTest.cpp
@@ -36,7 +36,7 @@ Network createTieLineTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -49,7 +49,7 @@ Network createTieLineTestNetwork() {
         .setId("VL2")
         .setName("VL2_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();
@@ -69,7 +69,7 @@ Network createTieLineTestNetwork() {
         .setId("VL3")
         .setName("VL3_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -82,7 +82,7 @@ Network createTieLineTestNetwork() {
         .setId("VL4")
         .setName("VL4_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();

--- a/test/iidm/TwoWindingsTransformerTest.cpp
+++ b/test/iidm/TwoWindingsTransformerTest.cpp
@@ -42,7 +42,7 @@ Network createTwoWindingsTransformerTestNetwork() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -65,7 +65,7 @@ Network createTwoWindingsTransformerTestNetwork() {
         .setId("VL2")
         .setName("VL2_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();
@@ -95,7 +95,7 @@ Network createTwoWindingsTransformerTestNetwork() {
         .setId("VL3")
         .setName("VL3_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -108,7 +108,7 @@ Network createTwoWindingsTransformerTestNetwork() {
         .setId("VL4")
         .setName("VL4_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(225.0)
+        .setNominalV(225.0)
         .setLowVoltageLimit(200.0)
         .setHighVoltageLimit(260.0)
         .add();

--- a/test/iidm/VoltageLevelTest.cpp
+++ b/test/iidm/VoltageLevelTest.cpp
@@ -42,7 +42,7 @@ Network createLineTestNetwork2() {
         .setId("VL1")
         .setName("VL1_NAME")
         .setTopologyKind(TopologyKind::BUS_BREAKER)
-        .setNominalVoltage(380.0)
+        .setNominalV(380.0)
         .setLowVoltageLimit(340.0)
         .setHighVoltageLimit(420.0)
         .add();
@@ -86,13 +86,13 @@ BOOST_AUTO_TEST_CASE(constructor) {
     BOOST_CHECK_EQUAL(TopologyKind::BUS_BREAKER, vl1.getTopologyKind());
     BOOST_CHECK_CLOSE(340, vl1.getLowVoltageLimit(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(420, vl1.getHighVoltageLimit(), std::numeric_limits<double>::epsilon());
-    BOOST_CHECK_CLOSE(380, vl1.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(380, vl1.getNominalV(), std::numeric_limits<double>::epsilon());
 
     Substation& s1 = network.getSubstation("S1");
     VoltageLevelAdder adder = s1.newVoltageLevel().setId("VL1");
     POWSYBL_ASSERT_THROW(adder.add(), ValidationException, "Voltage level 'VL1': Nominal voltage is undefined");
 
-    adder.setNominalVoltage(50).setLowVoltageLimit(-100);
+    adder.setNominalV(50).setLowVoltageLimit(-100);
     POWSYBL_ASSERT_THROW(adder.add(), ValidationException, "Voltage level 'VL1': Low voltage limit is < 0");
 
     adder.setLowVoltageLimit(100).setHighVoltageLimit(-10);
@@ -126,15 +126,15 @@ BOOST_AUTO_TEST_CASE(integrity) {
     POWSYBL_ASSERT_THROW(network.getVoltageLevel("LOAD1"), PowsyblException, "Identifiable 'LOAD1' is not a powsybl::iidm::VoltageLevel");
 
     VoltageLevel& vl1 = network.getVoltageLevel("VL1");
-    BOOST_CHECK_EQUAL(380, vl1.getNominalVoltage());
+    BOOST_CHECK_EQUAL(380, vl1.getNominalV());
     BOOST_CHECK_EQUAL(340, vl1.getLowVoltageLimit());
     BOOST_CHECK_EQUAL(420, vl1.getHighVoltageLimit());
 
-    POWSYBL_ASSERT_THROW(vl1.setNominalVoltage(-10), ValidationException, "Voltage level 'VL1': Nominal voltage is <= 0");
-    POWSYBL_ASSERT_THROW(vl1.setNominalVoltage(0), ValidationException, "Voltage level 'VL1': Nominal voltage is <= 0");
-    POWSYBL_ASSERT_THROW(vl1.setNominalVoltage(stdcxx::nan()), ValidationException, "Voltage level 'VL1': Nominal voltage is undefined");
-    BOOST_TEST(stdcxx::areSame(vl1, vl1.setNominalVoltage(100)));
-    BOOST_CHECK_EQUAL(100, vl1.getNominalVoltage());
+    POWSYBL_ASSERT_THROW(vl1.setNominalV(-10), ValidationException, "Voltage level 'VL1': Nominal voltage is <= 0");
+    POWSYBL_ASSERT_THROW(vl1.setNominalV(0), ValidationException, "Voltage level 'VL1': Nominal voltage is <= 0");
+    POWSYBL_ASSERT_THROW(vl1.setNominalV(stdcxx::nan()), ValidationException, "Voltage level 'VL1': Nominal voltage is undefined");
+    BOOST_TEST(stdcxx::areSame(vl1, vl1.setNominalV(100)));
+    BOOST_CHECK_EQUAL(100, vl1.getNominalV());
 
     POWSYBL_ASSERT_THROW(vl1.setLowVoltageLimit(-10), ValidationException, "Voltage level 'VL1': Low voltage limit is < 0");
     POWSYBL_ASSERT_THROW(vl1.setLowVoltageLimit(440), ValidationException, "Voltage level 'VL1': Inconsistent voltage limit range [440, 420]");

--- a/test/iidm/converter/xml/LinesRoundTripTest.cpp
+++ b/test/iidm/converter/xml/LinesRoundTripTest.cpp
@@ -38,7 +38,7 @@ Network createDlGenerationLinear() {
         .add();
     VoltageLevel& voltageLevel = substation.newVoltageLevel()
         .setId("VL")
-        .setNominalVoltage(100.0)
+        .setNominalV(100.0)
         .setLowVoltageLimit(80.0)
         .setHighVoltageLimit(120.0)
         .setTopologyKind(TopologyKind::BUS_BREAKER)

--- a/test/iidm/converter/xml/ShuntCompensatorRoundTripTest.cpp
+++ b/test/iidm/converter/xml/ShuntCompensatorRoundTripTest.cpp
@@ -42,7 +42,7 @@ Network createNonLinear() {
         .add();
     VoltageLevel& vl1 = s1.newVoltageLevel()
         .setId("VL1")
-        .setNominalVoltage(380)
+        .setNominalV(380)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl1.getBusBreakerView().newBus()
@@ -55,7 +55,7 @@ Network createNonLinear() {
         .add();
     VoltageLevel& vl2 = s2.newVoltageLevel()
         .setId("VL2")
-        .setNominalVoltage(220)
+        .setNominalV(220)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl2.getBusBreakerView().newBus()

--- a/test/iidm/extensions/LoadDetailTest.cpp
+++ b/test/iidm/extensions/LoadDetailTest.cpp
@@ -36,7 +36,7 @@ Network createNetwork() {
         .add();
     VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
-        .setNominalVoltage(400)
+        .setNominalV(400)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl.getBusBreakerView().newBus()

--- a/test/iidm/extensions/SlackTerminalTest.cpp
+++ b/test/iidm/extensions/SlackTerminalTest.cpp
@@ -38,7 +38,7 @@ Network createBusBreakerNetwork() {
         .add();
     VoltageLevel& vl = s.newVoltageLevel()
         .setId("VL")
-        .setNominalVoltage(400)
+        .setNominalV(400)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl.getBusBreakerView().newBus()
@@ -58,7 +58,7 @@ Network createBusBreakerNetwork() {
         .add();
     VoltageLevel& vl1 = s.newVoltageLevel()
         .setId("VL1")
-        .setNominalVoltage(400)
+        .setNominalV(400)
         .setTopologyKind(TopologyKind::BUS_BREAKER)
         .add();
     vl1.getBusBreakerView().newBus()

--- a/test/network/EurostagFactoryTest.cpp
+++ b/test/network/EurostagFactoryTest.cpp
@@ -79,28 +79,28 @@ BOOST_AUTO_TEST_CASE(createTutorial1NetworkTest) {
     BOOST_CHECK_EQUAL_COLLECTIONS(expected2.cbegin(), expected2.cend(), actual2.cbegin(), actual2.cend());
 
     const auto& vlGen = network.getVoltageLevel("VLGEN");
-    BOOST_CHECK_CLOSE(24.0, vlGen.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(24.0, vlGen.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_TEST(std::isnan(vlGen.getLowVoltageLimit()));
     BOOST_TEST(std::isnan(vlGen.getHighVoltageLimit()));
     BOOST_CHECK_EQUAL(iidm::TopologyKind::BUS_BREAKER, vlGen.getTopologyKind());
     BOOST_CHECK_EQUAL(2UL, vlGen.getConnectableCount());
 
     const auto& vlHv1 = network.getVoltageLevel("VLHV1");
-    BOOST_CHECK_CLOSE(380.0, vlHv1.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(380.0, vlHv1.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_TEST(std::isnan(vlHv1.getLowVoltageLimit()));
     BOOST_TEST(std::isnan(vlHv1.getHighVoltageLimit()));
     BOOST_CHECK_EQUAL(iidm::TopologyKind::BUS_BREAKER, vlHv1.getTopologyKind());
     BOOST_CHECK_EQUAL(3UL, vlHv1.getConnectableCount());
 
     const auto& vlHv2 = network.getVoltageLevel("VLHV2");
-    BOOST_CHECK_CLOSE(380.0, vlHv2.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(380.0, vlHv2.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_TEST(std::isnan(vlHv2.getLowVoltageLimit()));
     BOOST_TEST(std::isnan(vlHv2.getHighVoltageLimit()));
     BOOST_CHECK_EQUAL(iidm::TopologyKind::BUS_BREAKER, vlHv2.getTopologyKind());
     BOOST_CHECK_EQUAL(3UL, vlHv2.getConnectableCount());
 
     const auto& vlLoad = network.getVoltageLevel("VLLOAD");
-    BOOST_CHECK_CLOSE(150.0, vlLoad.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(150.0, vlLoad.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_TEST(std::isnan(vlLoad.getLowVoltageLimit()));
     BOOST_TEST(std::isnan(vlLoad.getHighVoltageLimit()));
     BOOST_CHECK_EQUAL(iidm::TopologyKind::BUS_BREAKER, vlLoad.getTopologyKind());
@@ -298,28 +298,28 @@ BOOST_AUTO_TEST_CASE(createWithCurrentLimitsTest) {
     BOOST_CHECK_EQUAL_COLLECTIONS(expected2.cbegin(), expected2.cend(), actual2.cbegin(), actual2.cend());
 
     const auto& vlGen = network.getVoltageLevel("VLGEN");
-    BOOST_CHECK_CLOSE(24.0, vlGen.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(24.0, vlGen.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_TEST(std::isnan(vlGen.getLowVoltageLimit()));
     BOOST_TEST(std::isnan(vlGen.getHighVoltageLimit()));
     BOOST_CHECK_EQUAL(iidm::TopologyKind::BUS_BREAKER, vlGen.getTopologyKind());
     BOOST_CHECK_EQUAL(3UL, vlGen.getConnectableCount());
 
     const auto& vlHv1 = network.getVoltageLevel("VLHV1");
-    BOOST_CHECK_CLOSE(380.0, vlHv1.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(380.0, vlHv1.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(400.0, vlHv1.getLowVoltageLimit(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(500.0, vlHv1.getHighVoltageLimit(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(iidm::TopologyKind::BUS_BREAKER, vlHv1.getTopologyKind());
     BOOST_CHECK_EQUAL(3UL, vlHv1.getConnectableCount());
 
     const auto& vlHv2 = network.getVoltageLevel("VLHV2");
-    BOOST_CHECK_CLOSE(380.0, vlHv2.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(380.0, vlHv2.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(300.0, vlHv2.getLowVoltageLimit(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(500.0, vlHv2.getHighVoltageLimit(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_EQUAL(iidm::TopologyKind::BUS_BREAKER, vlHv2.getTopologyKind());
     BOOST_CHECK_EQUAL(3UL, vlHv2.getConnectableCount());
 
     const auto& vlLoad = network.getVoltageLevel("VLLOAD");
-    BOOST_CHECK_CLOSE(150.0, vlLoad.getNominalVoltage(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(150.0, vlLoad.getNominalV(), std::numeric_limits<double>::epsilon());
     BOOST_TEST(std::isnan(vlLoad.getLowVoltageLimit()));
     BOOST_TEST(std::isnan(vlLoad.getHighVoltageLimit()));
     BOOST_CHECK_EQUAL(iidm::TopologyKind::BUS_BREAKER, vlLoad.getTopologyKind());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#230 only backport **missing and relevant** methods
`VoltageLevel::traverse` will be added in a separated PR.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
