### PR TITLE
Fix CI: invoke apt-get update before installing boost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Boost
-        run: sudo apt update -y && sudo apt install -y libboost-all-dev
+        run: sudo apt-get update -y && sudo apt-get install -y libboost-all-dev
 
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -131,7 +131,7 @@ jobs:
           SONAR_SCANNER_VERSION: 3.3.0.1492
 
       - name: Install Boost
-        run: sudo apt update -y && sudo apt install -y libboost-all-dev
+        run: sudo apt-get update -y && sudo apt-get install -y libboost-all-dev
 
       - name: Checkout sources
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Boost
-        run: sudo apt-get update -y && sudo apt-get install -y libboost-all-dev
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libboost-all-dev
 
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -131,7 +133,9 @@ jobs:
           SONAR_SCANNER_VERSION: 3.3.0.1492
 
       - name: Install Boost
-        run: sudo apt-get update -y && sudo apt-get install -y libboost-all-dev
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libboost-all-dev
 
       - name: Checkout sources
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Boost
-        run: sudo apt install -y libboost-all-dev
+        run: sudo apt update -y && sudo apt install -y libboost-all-dev
 
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -131,7 +131,7 @@ jobs:
           SONAR_SCANNER_VERSION: 3.3.0.1492
 
       - name: Install Boost
-        run: sudo apt install -y libboost-all-dev
+        run: sudo apt update -y && sudo apt install -y libboost-all-dev
 
       - name: Checkout sources
         uses: actions/checkout@v1

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Boost
-        run: sudo apt-get update -y && sudo apt-get install -y libboost-all-dev
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libboost-all-dev
 
       - name: Install clang-tidy
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Boost
-        run: sudo apt update -y && sudo apt install -y libboost-all-dev
+        run: sudo apt-get update -y && sudo apt-get install -y libboost-all-dev
 
       - name: Install clang-tidy
         run: |
-          sudo apt install -y clang-tidy-9
+          sudo apt-get install -y clang-tidy-9
           sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 100
 
       - name: Checkout sources

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Boost
-        run: sudo apt install -y libboost-all-dev
+        run: sudo apt update -y && sudo apt install -y libboost-all-dev
 
       - name: Install clang-tidy
         run: |


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix CI

**What is the current behavior?** *(You can also link to an open issue here)*
CI is not OK because apt- repository is not up-to-date on ubuntu images



**What is the new behavior (if this is a feature change)?**
CI is OK.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
