### PR TITLE
Throw a comprehensive exception when a terminal ref of a busbar section on is written in bus-breaker or bus-branch (#295)

### DIFF
--- a/src/iidm/converter/xml/TerminalRefXml.cpp
+++ b/src/iidm/converter/xml/TerminalRefXml.cpp
@@ -59,9 +59,9 @@ void TerminalRefXml::writeTerminalRef(const Terminal& terminal, NetworkXmlWriter
     if (!context.getFilter().test(c)) {
         throw PowsyblException(stdcxx::format("Oups, terminal ref point to a filtered equipment %1%", c.get().getId()));
     }
-    if (terminal.getVoltageLevel().getTopologyKind() == TopologyKind::NODE_BREAKER
-        && context.getOptions().getTopologyLevel() != TopologyLevel::NODE_BREAKER
-        && stdcxx::isInstanceOf<BusbarSection>(terminal.getConnectable())) {
+    if (terminal.getVoltageLevel().getTopologyKind() == TopologyKind::NODE_BREAKER &&
+            context.getOptions().getTopologyLevel() != TopologyLevel::NODE_BREAKER &&
+            stdcxx::isInstanceOf<BusbarSection>(terminal.getConnectable())) {
         throw PowsyblException(stdcxx::format("Terminal ref should not point to a busbar section (here %1%). Try to export in node-breaker or delete this terminal ref.", terminal.getConnectable().get().getId()));
     }
     writer.writeStartElement(nsPrefix, elementName);

--- a/test/iidm/NodeBreakerVoltageLevelTest.cpp
+++ b/test/iidm/NodeBreakerVoltageLevelTest.cpp
@@ -1231,9 +1231,10 @@ BOOST_AUTO_TEST_CASE(NbkComprehensiveErrorMessage) {
     stdcxx::Properties properties;
     properties.set(converter::ExportOptions::TOPOLOGY_LEVEL, "NODE_BREAKER");
 
+    std::stringstream ss;
+
     // make sure no error is thrown while exporting to NODE_BREAKER topology
     BOOST_CHECK_NO_THROW({
-         std::stringstream ss;
          Network::writeXml("network.xiidm", ss, network, converter::ExportOptions(properties));
          Network::readXml("network.xiidm", ss);
     });

--- a/test/iidm/NodeBreakerVoltageLevelTest.cpp
+++ b/test/iidm/NodeBreakerVoltageLevelTest.cpp
@@ -19,8 +19,10 @@
 #include <powsybl/iidm/Network.hpp>
 #include <powsybl/iidm/Substation.hpp>
 #include <powsybl/iidm/Switch.hpp>
+#include <powsybl/iidm/TwoWindingsTransformer.hpp>
 #include <powsybl/iidm/VoltageLevel.hpp>
 #include <powsybl/iidm/VoltageLevelAdder.hpp>
+#include <powsybl/network/FourSubstationsNodeBreakerFactory.hpp>
 
 #include <powsybl/test/AssertionUtils.hpp>
 
@@ -1218,6 +1220,27 @@ BOOST_AUTO_TEST_CASE(issue318_invalidateCache) {
 
     // Without the fix, this call throws an exception (ArrayIndexOutOfBoundsException), but an invalid reference is expected
     BOOST_CHECK(!bbs2.getTerminal().getBusView().getBus());
+}
+
+BOOST_AUTO_TEST_CASE(NbkComprehensiveErrorMessage) {
+    Network network = powsybl::network::FourSubstationsNodeBreakerFactory::create();
+    BusbarSection& busbarSection = network.getBusbarSection("S1VL2_BBS1");
+    TwoWindingsTransformer& twt = network.getTwoWindingsTransformer("TWT");
+    twt.getPhaseTapChanger().setRegulationTerminal(stdcxx::ref(busbarSection.getTerminal()));
+
+    stdcxx::Properties properties;
+    properties.set(converter::ExportOptions::TOPOLOGY_LEVEL, "NODE_BREAKER");
+
+    // make sure no error is thrown while exporting to NODE_BREAKER topology
+    BOOST_CHECK_NO_THROW({
+         std::stringstream ss;
+         Network::writeXml("network.xiidm", ss, network, converter::ExportOptions(properties));
+         Network::readXml("network.xiidm", ss);
+    });
+
+    // make sure an error is thrown when exporting to BUS_BREAKER topology (see #295)
+    properties.set(converter::ExportOptions::TOPOLOGY_LEVEL, "BUS_BREAKER");
+    POWSYBL_ASSERT_THROW(Network::writeXml("network.xiidm", ss, network, converter::ExportOptions(properties)), PowsyblException, "Terminal ref should not point to a busbar section (here S1VL2_BBS1). Try to export in node-breaker or delete this terminal ref.");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#295 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
