### PR TITLE
Invalidate components managers when invalidate cache of NBVL

### DIFF
--- a/src/iidm/NodeBreakerVoltageLevel.cpp
+++ b/src/iidm/NodeBreakerVoltageLevel.cpp
@@ -337,7 +337,8 @@ void NodeBreakerVoltageLevel::invalidateCache() {
     m_variants.get().getCalculatedBusTopology().invalidateCache();
     m_variants.get().getCalculatedBusBreakerTopology().invalidateCache();
 
-    // TODO(mathbagu): invalidate the connected and synchronous components
+    getNetwork().getConnectedComponentsManager().invalidate();
+    getNetwork().getSynchronousComponentsManager().invalidate();
 }
 
 bool NodeBreakerVoltageLevel::isConnected(const Terminal& terminal) const {


### PR DESCRIPTION
⚠️ target branch to be checked ⚠️ 

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Synchronous and connected components is not invalidated when NBVL cache is invalidated


**What is the new behavior (if this is a feature change)?**
Synchronous and connected components is invalidated when NBVL cache is invalidated


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
