### PR TITLE
Bug fix in MergedBus : getConnectedTerminalCount did not use the connected terminals but all (#333)

### DIFF
--- a/src/iidm/MergedBus.cpp
+++ b/src/iidm/MergedBus.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 
 #include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/numeric.hpp>
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/Terminal.hpp>
@@ -66,12 +67,11 @@ stdcxx::Reference<Component> MergedBus::getConnectedComponent() {
 unsigned long MergedBus::getConnectedTerminalCount() const {
     checkValidity();
 
-    unsigned long count = 0;
-    for (const auto& it : m_buses) {
-        count += it.get().getConnectedTerminalCount();
-    }
+    const auto& mapper = [](const std::reference_wrapper<ConfiguredBus>& bus) {
+        return bus.get().getConnectedTerminalCount();
+    };
 
-    return count;
+    return boost::accumulate(m_buses | boost::adaptors::transformed(mapper), 0);
 }
 
 stdcxx::const_range<Terminal> MergedBus::getConnectedTerminals() const {

--- a/src/iidm/MergedBus.cpp
+++ b/src/iidm/MergedBus.cpp
@@ -11,7 +11,6 @@
 #include <cmath>
 
 #include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/numeric.hpp>
 
 #include <powsybl/PowsyblException.hpp>
 #include <powsybl/iidm/Terminal.hpp>
@@ -67,11 +66,12 @@ stdcxx::Reference<Component> MergedBus::getConnectedComponent() {
 unsigned long MergedBus::getConnectedTerminalCount() const {
     checkValidity();
 
-    const auto& mapper = [](const std::reference_wrapper<ConfiguredBus>& bus) {
-        return bus.get().getConnectedTerminalCount();
-    };
+    unsigned long count = 0;
+    for (const auto& it : m_buses) {
+        count += it.get().getConnectedTerminalCount();
+    }
 
-    return boost::accumulate(m_buses | boost::adaptors::transformed(mapper), 0);
+    return count;
 }
 
 stdcxx::const_range<Terminal> MergedBus::getConnectedTerminals() const {


### PR DESCRIPTION
⚠️ To be discussed : this issue was already OK in C++, I just added tests that where added in Java PR (https://github.com/powsybl/powsybl-core/pull/1647), but it may not be relevant...

Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#333 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
