### PR TITLE
Allow bPerSection to be equals to zero in ShuntCompensator linear model (#336)

### DIFF
--- a/include/powsybl/iidm/ValidationUtils.hpp
+++ b/include/powsybl/iidm/ValidationUtils.hpp
@@ -42,7 +42,7 @@ double checkBmax(const Validable& validable, double bMax);
 
 double checkBmin(const Validable& validable, double bMin);
 
-double checkbPerSection(const Validable& validable, double bPerSection);
+double checkBPerSection(const Validable& validable, double bPerSection);
 
 const HvdcLine::ConvertersMode& checkConvertersMode(const Validable& validable, const HvdcLine::ConvertersMode& converterMode);
 
@@ -57,8 +57,6 @@ double checkG2(const Validable& validable, double g2);
 double checkHvdcActivePowerSetpoint(const Validable& validable, double activePowerSetpoint);
 
 double checkHvdcMaxP(const Validable& validable, double maxP);
-
-double checkLinearBPerSection(const Validable& validable, double bPerSection);
 
 const LoadType& checkLoadType(const Validable& validable, const LoadType& loadType);
 

--- a/src/iidm/ShuntCompensatorLinearModel.cpp
+++ b/src/iidm/ShuntCompensatorLinearModel.cpp
@@ -62,7 +62,7 @@ const ShuntCompensatorModelType& ShuntCompensatorLinearModel::getType() const {
 }
 
 ShuntCompensatorLinearModel& ShuntCompensatorLinearModel::setBPerSection(double bPerSection) {
-    checkLinearBPerSection(m_shuntCompensator, bPerSection);
+    checkBPerSection(m_shuntCompensator, bPerSection);
     m_bPerSection = bPerSection;
     return *this;
 }

--- a/src/iidm/ShuntCompensatorLinearModelAdder.cpp
+++ b/src/iidm/ShuntCompensatorLinearModelAdder.cpp
@@ -24,7 +24,7 @@ ShuntCompensatorLinearModelAdder::ShuntCompensatorLinearModelAdder(ShuntCompensa
 }
 
 iidm::ShuntCompensatorAdder& ShuntCompensatorLinearModelAdder::add() {
-    checkLinearBPerSection(m_parent, m_bPerSection);
+    checkBPerSection(m_parent, m_bPerSection);
     checkMaximumSectionCount(m_parent, m_maximumSectionCount);
     m_parent.setShuntCompensatorModelBuilder(stdcxx::move_to_unique(this));
     return m_parent;

--- a/src/iidm/ShuntCompensatorNonLinearModelAdder.cpp
+++ b/src/iidm/ShuntCompensatorNonLinearModelAdder.cpp
@@ -29,7 +29,7 @@ ShuntCompensatorNonLinearModelAdder::SectionAdder::SectionAdder(ShuntCompensator
 }
 
 ShuntCompensatorNonLinearModelAdder& ShuntCompensatorNonLinearModelAdder::SectionAdder::endSection() {
-    checkbPerSection(m_parent.getShuntCompensatorAdder(), m_b);
+    checkBPerSection(m_parent.getShuntCompensatorAdder(), m_b);
     if (std::isnan(m_g)) {
         if (m_parent.getSectionAdders().empty()) {
             m_g = 0.0;

--- a/src/iidm/ValidationUtils.cpp
+++ b/src/iidm/ValidationUtils.cpp
@@ -92,7 +92,7 @@ double checkBmin(const Validable& validable, double bMin) {
     return bMin;
 }
 
-double checkbPerSection(const Validable& validable, double bPerSection) {
+double checkBPerSection(const Validable& validable, double bPerSection) {
     if (std::isnan(bPerSection)) {
         throw ValidationException(validable, "susceptance per section is invalid");
     }
@@ -157,14 +157,6 @@ double checkHvdcMaxP(const Validable& validable, double maxP) {
         throw createInvalidValueException(validable, maxP, "maximum P");
     }
     return maxP;
-}
-
-double checkLinearBPerSection(const Validable& validable, double bPerSection) {
-    checkbPerSection(validable, bPerSection);
-    if (stdcxx::isEqual(bPerSection, 0.0)) {
-        throw ValidationException(validable, "susceptance per section is equal to zero");
-    }
-    return bPerSection;
 }
 
 unsigned long checkMaximumSectionCount(const Validable& validable, const stdcxx::optional<unsigned long>& maximumSectionCount) {

--- a/test/iidm/ShuntCompensatorTest.cpp
+++ b/test/iidm/ShuntCompensatorTest.cpp
@@ -78,9 +78,6 @@ BOOST_AUTO_TEST_CASE(adder) {
 
     ShuntCompensatorAdder::ShuntCompensatorLinearModelAdder linearModel = adder.newLinearModel();
     POWSYBL_ASSERT_THROW(linearModel.add(), PowsyblException, "Shunt compensator 'SHUNT1': susceptance per section is invalid");
-    linearModel.setBPerSection(0.0);
-
-    POWSYBL_ASSERT_THROW(linearModel.add(), PowsyblException, "Shunt compensator 'SHUNT1': susceptance per section is equal to zero");
     linearModel.setBPerSection(0.25);
 
     POWSYBL_ASSERT_THROW(linearModel.add(), PowsyblException, "Shunt compensator 'SHUNT1': the maximum number of section is not set");
@@ -255,7 +252,8 @@ BOOST_AUTO_TEST_CASE(integrity) {
     BOOST_CHECK_CLOSE(100.0, shunt.getModel<ShuntCompensatorLinearModel>().getBPerSection(), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(200.0, shunt.getB(), std::numeric_limits<double>::epsilon());
     POWSYBL_ASSERT_THROW(shunt.getModel<ShuntCompensatorLinearModel>().setBPerSection(stdcxx::nan()), ValidationException, "Shunt compensator 'SHUNT1': susceptance per section is invalid");
-    POWSYBL_ASSERT_THROW(shunt.getModel<ShuntCompensatorLinearModel>().setBPerSection(0.0), ValidationException, "Shunt compensator 'SHUNT1': susceptance per section is equal to zero");
+    BOOST_CHECK_NO_THROW(shunt.getModel<ShuntCompensatorLinearModel>().setBPerSection(0.0));
+    shunt.getModel<ShuntCompensatorLinearModel>().setBPerSection(100.0);
 
     BOOST_TEST(stdcxx::areSame(shunt.getModel<ShuntCompensatorLinearModel>(), shunt.getModel<ShuntCompensatorLinearModel>().setGPerSection(120.0)));
     BOOST_CHECK_CLOSE(120.0, shunt.getModel<ShuntCompensatorLinearModel>().getGPerSection(), std::numeric_limits<double>::epsilon());


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Closes #336 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
