### PR TITLE
Improve error message while reading terminal ref with invalid identifiable (#338)

### DIFF
--- a/src/iidm/converter/xml/TerminalRefXml.cpp
+++ b/src/iidm/converter/xml/TerminalRefXml.cpp
@@ -31,7 +31,11 @@ namespace converter {
 namespace xml {
 
 Terminal& TerminalRefXml::readTerminalRef(Network& network, const std::string& id, const std::string& side) {
-    auto& identifiable = network.get<Identifiable>(id);
+    const auto& identifiableRef = network.find<Identifiable>(id);
+    if (!identifiableRef) {
+        throw PowsyblException(stdcxx::format("Terminal reference identifiable not found: '%1%'", id));
+    }
+    auto& identifiable = identifiableRef.get();
     if (stdcxx::isInstanceOf<Injection>(identifiable)) {
         return dynamic_cast<Injection&>(identifiable).getTerminal();
     }
@@ -43,7 +47,7 @@ Terminal& TerminalRefXml::readTerminalRef(Network& network, const std::string& i
         return twt.getTerminal(Enum::fromString<ThreeWindingsTransformer::Side>(side));
     }
 
-    throw AssertionError(stdcxx::format("Unexpected Identifiable instance: %1%", stdcxx::demangle(identifiable)));
+    throw PowsyblException(stdcxx::format("Unexpected terminal reference identifiable instance: %1%", stdcxx::demangle(identifiable)));
 }
 
 void TerminalRefXml::writeTerminalRef(const Terminal& terminal, NetworkXmlWriterContext& context, const std::string& elementName) {

--- a/test/iidm/converter/xml/TerminalRefTest.cpp
+++ b/test/iidm/converter/xml/TerminalRefTest.cpp
@@ -29,7 +29,7 @@ BOOST_FIXTURE_TEST_CASE(TerminalRef, test::ResourceFixture) {
 
 BOOST_FIXTURE_TEST_CASE(TerminalRefNotFoundTest, test::ResourceFixture) {
     const auto& filePath = test::converter::RoundTrip::getVersionedNetworkPath("terminalRefNotFound.xml", IidmXmlVersion::V1_5());
-    POWSYBL_ASSERT_THROW(Network::readXml(filePath), PowsyblException, "Terminal reference identifiable not found: '\?\?\?\?'");
+    POWSYBL_ASSERT_THROW(Network::readXml(filePath), PowsyblException, "Terminal reference identifiable not found: 'UNKNOWN'");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/iidm/converter/xml/TerminalRefTest.cpp
+++ b/test/iidm/converter/xml/TerminalRefTest.cpp
@@ -7,6 +7,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <powsybl/PowsyblException.hpp>
+#include <powsybl/iidm/Network.hpp>
+#include <powsybl/test/AssertionUtils.hpp>
 #include <powsybl/test/ResourceFixture.hpp>
 #include <powsybl/test/converter/RoundTrip.hpp>
 
@@ -22,6 +25,11 @@ BOOST_AUTO_TEST_SUITE(XmlRoundTrip)
 
 BOOST_FIXTURE_TEST_CASE(TerminalRef, test::ResourceFixture) {
     test::converter::RoundTrip::roundTripVersionedXmlTest("terminalRef.xml", IidmXmlVersion::all());
+}
+
+BOOST_FIXTURE_TEST_CASE(TerminalRefNotFoundTest, test::ResourceFixture) {
+    const auto& filePath = test::converter::RoundTrip::getVersionedNetworkPath("terminalRefNotFound.xml", IidmXmlVersion::V1_5());
+    POWSYBL_ASSERT_THROW(Network::readXml(filePath), PowsyblException, "Terminal reference identifiable not found: '\?\?\?\?'");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/resources/V1_5/terminalRefNotFound.xml
+++ b/test/resources/V1_5/terminalRefNotFound.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_5" id="terminalRefNotFound" caseDate="2014-11-08T19:00:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="S1" country="FR" tso="RTE">
+        <iidm:voltageLevel id="VL6" nominalV="225.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="VL61" v="237.973694" angle="-9.06182098"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="100.0" targetV="225.0" targetQ="0.0" bus="VL61" connectableBus="VL61">
+                <iidm:regulatingTerminal id="????"/>
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>

--- a/test/resources/V1_5/terminalRefNotFound.xml
+++ b/test/resources/V1_5/terminalRefNotFound.xml
@@ -6,7 +6,7 @@
                 <iidm:bus id="VL61" v="237.973694" angle="-9.06182098"/>
             </iidm:busBreakerTopology>
             <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="100.0" targetV="225.0" targetQ="0.0" bus="VL61" connectableBus="VL61">
-                <iidm:regulatingTerminal id="????"/>
+                <iidm:regulatingTerminal id="UNKNOWN"/>
                 <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
             </iidm:generator>
         </iidm:voltageLevel>


### PR DESCRIPTION
In C++, the old error was :
```
"Unable to find to the identifiable '????'"
```

It is now the same as in java : 
```
Terminal reference identifiable not found: '????'
```

Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Closes #338


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
