### PR TITLE
Fix multiple extension add

### DIFF
--- a/extensions/entsoe/test/EntsoeAreaTest.cpp
+++ b/extensions/entsoe/test/EntsoeAreaTest.cpp
@@ -39,6 +39,21 @@ Network createNetwork() {
     return network;
 }
 
+BOOST_AUTO_TEST_CASE(checkMultipleAdd) {
+    Network network("test", "test");
+    network.setCaseDate(stdcxx::DateTime::parse("2016-06-27T12:27:58.535+02:00"));
+    Substation& substation = network.newSubstation()
+        .setId("S")
+        .setCountry(Country::FR)
+        .add();
+
+    substation.newExtension<EntsoeAreaAdder>().withCode(EntsoeGeographicalCode::FR).add();
+    substation.newExtension<EntsoeAreaAdder>().withCode(EntsoeGeographicalCode::BE).add();
+
+    auto& extension = substation.getExtension<EntsoeArea>();
+    BOOST_CHECK(static_cast<int>(EntsoeGeographicalCode::BE) == static_cast<int>(extension.getCode()));
+}
+
 BOOST_AUTO_TEST_CASE(EntsoeAreaConstructor) {
     Network network = createNetwork();
     Substation& substation = network.getSubstation("S");

--- a/src/iidm/Extendable.cpp
+++ b/src/iidm/Extendable.cpp
@@ -28,6 +28,8 @@ Extendable::Extendable(Extendable&& extendable) noexcept :
 
 void Extendable::addExtension(std::unique_ptr<Extension>&& extension) {
     extension->setExtendable(*this);
+    m_extensionsByName.erase(extension->getName());
+    m_extensionsByType.erase(extension->getType());
     auto it = m_extensionsByName.emplace(std::make_pair(extension->getName(), std::move(extension)));
 
     std::reference_wrapper<Extension> refExtension = *it.first->second;

--- a/src/iidm/Extendable.cpp
+++ b/src/iidm/Extendable.cpp
@@ -27,12 +27,18 @@ Extendable::Extendable(Extendable&& extendable) noexcept :
 }
 
 void Extendable::addExtension(std::unique_ptr<Extension>&& extension) {
-    extension->setExtendable(*this);
-    m_extensionsByName.erase(extension->getName());
-    m_extensionsByType.erase(extension->getType());
-    auto it = m_extensionsByName.emplace(std::make_pair(extension->getName(), std::move(extension)));
+    auto it = m_extensionsByName.find(extension->getName());
+    if (it != m_extensionsByName.end()) {
+        // Clean the existing extension
+        it->second->setExtendable(stdcxx::ref<Extendable>());
+        m_extensionsByName.erase(extension->getName());
+        m_extensionsByType.erase(extension->getType());
+    }
 
-    std::reference_wrapper<Extension> refExtension = *it.first->second;
+    extension->setExtendable(*this);
+    auto newIt = m_extensionsByName.emplace(std::make_pair(extension->getName(), std::move(extension)));
+
+    std::reference_wrapper<Extension> refExtension = *newIt.first->second;
     m_extensionsByType.emplace(std::make_pair(refExtension.get().getType(), refExtension));
 }
 


### PR DESCRIPTION
⚠️ Target branch to be checked

Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When 2 extensions of the same type are added to an Extendable, the extension of the given type always remain the first added.

Reproduction case:
```
    Network network("test", "test");
    network.setCaseDate(stdcxx::DateTime::parse("2016-06-27T12:27:58.535+02:00"));
    Substation& substation = network.newSubstation()
        .setId("S")
        .setCountry(Country::FR)
        .add();

    substation.newExtension<EntsoeAreaAdder>().withCode(EntsoeGeographicalCode::FR).add();
    substation.newExtension<EntsoeAreaAdder>().withCode(EntsoeGeographicalCode::BE).add();

    auto& extension = substation.getExtension<EntsoeArea>();
    BOOST_CHECK(static_cast<int>(EntsoeGeographicalCode::BE) == static_cast<int>(extension.getCode()));
```

**What is the new behavior (if this is a feature change)?**
When 2 extensions of the same type are added to an Extendable, the extension of the given type replaces the previous one.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
