### PR TITLE
Fix friendship handling for private extension contructor

### DIFF
--- a/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/EntsoeArea.hpp
+++ b/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/EntsoeArea.hpp
@@ -42,8 +42,7 @@ private:  // Extension
 private:
     EntsoeArea(Substation& substation, const EntsoeGeographicalCode& code);
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class EntsoeAreaAdder;
 
 private:
     EntsoeGeographicalCode m_code;

--- a/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/MergedXnode.hpp
+++ b/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/MergedXnode.hpp
@@ -77,8 +77,7 @@ private:
     MergedXnode(Line& line, double rdp, double xdp, double xnodeP1, double xnodeQ1, double xnodeP2, double xnodeQ2,
                 const std::string& line1Name, const std::string& line2Name, const std::string& code);
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class MergedXnodeAdder;
 
 private:
     double m_rdp; // r divider position 1 -> 2

--- a/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/Xnode.hpp
+++ b/extensions/entsoe/include/powsybl/iidm/extensions/entsoe/Xnode.hpp
@@ -39,8 +39,7 @@ private:  // Extension
 private:
     Xnode(DanglingLine& dl, const std::string& code);
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class XnodeAdder;
 
 private:
     std::string m_code;

--- a/extensions/entsoe/src/EntsoeAreaAdder.cpp
+++ b/extensions/entsoe/src/EntsoeAreaAdder.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<Extension> EntsoeAreaAdder::createExtension(Extendable& extendab
         throw PowsyblException(stdcxx::format("code is undefined"));
     }
     if (stdcxx::isInstanceOf<Substation>(extendable)) {
-        return stdcxx::make_unique<EntsoeArea>(dynamic_cast<Substation&>(extendable), *m_code);
+        return std::unique_ptr<EntsoeArea>(new EntsoeArea(dynamic_cast<Substation&>(extendable), *m_code));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Substation>()));
 }

--- a/extensions/entsoe/src/MergedXnodeAdder.cpp
+++ b/extensions/entsoe/src/MergedXnodeAdder.cpp
@@ -24,7 +24,7 @@ MergedXnodeAdder::MergedXnodeAdder(Extendable& extendable) :
 
 std::unique_ptr<Extension> MergedXnodeAdder::createExtension(Extendable& extendable) {
     if (stdcxx::isInstanceOf<Line>(extendable)) {
-        return stdcxx::make_unique<MergedXnode>(dynamic_cast<Line&>(extendable), m_rdp, m_xdp, m_xnodeP1, m_xnodeQ1, m_xnodeP2, m_xnodeQ2, m_line1Name, m_line2Name, m_code);
+        return std::unique_ptr<MergedXnode>(new MergedXnode(dynamic_cast<Line&>(extendable), m_rdp, m_xdp, m_xnodeP1, m_xnodeQ1, m_xnodeP2, m_xnodeQ2, m_line1Name, m_line2Name, m_code));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Line>()));
 }

--- a/extensions/entsoe/src/XnodeAdder.cpp
+++ b/extensions/entsoe/src/XnodeAdder.cpp
@@ -27,7 +27,7 @@ XnodeAdder::XnodeAdder(Extendable& extendable) :
 
 std::unique_ptr<Extension> XnodeAdder::createExtension(Extendable& extendable) {
     if (stdcxx::isInstanceOf<DanglingLine>(extendable)) {
-        return stdcxx::make_unique<Xnode>(dynamic_cast<DanglingLine&>(extendable), m_code);
+        return std::unique_ptr<Xnode>(new Xnode(dynamic_cast<DanglingLine&>(extendable), m_code));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<DanglingLine>()));
 }

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/ActivePowerControl.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/ActivePowerControl.hpp
@@ -46,8 +46,7 @@ private:
 
     ActivePowerControl(Generator& generator, bool participate, double droop);
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class ActivePowerControlAdder;
 
 private:
     bool m_participate;

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/CoordinatedReactiveControl.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/CoordinatedReactiveControl.hpp
@@ -42,8 +42,7 @@ private:
 private:
     CoordinatedReactiveControl(Generator& generator, double qPercent);
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class CoordinatedReactiveControlAdder;
 
 private:
     double m_qPercent;

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/HvdcAngleDroopActivePowerControl.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/HvdcAngleDroopActivePowerControl.hpp
@@ -50,8 +50,7 @@ private:
 private:
     HvdcAngleDroopActivePowerControl(HvdcLine& hvdcLine, double p0, double droop, bool enabled);
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class HvdcAngleDroopActivePowerControlAdder;
 
 private:
     /**

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/HvdcOperatorActivePowerRange.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/HvdcOperatorActivePowerRange.hpp
@@ -45,8 +45,7 @@ private:
 private:
     HvdcOperatorActivePowerRange(HvdcLine& hvdcLine, double oprFromCS1toCS2, double oprFromCS2toCS1);
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class HvdcOperatorActivePowerRangeAdder;
 
 private:
     /**

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/ThreeWindingsTransformerPhaseAngleClock.hpp
@@ -43,8 +43,7 @@ private:
 
     unsigned long checkPhaseAngleClock(unsigned long phaseAngleClock) const;
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class ThreeWindingsTransformerPhaseAngleClockAdder;
 
 private:
     unsigned long m_phaseAngleClockLeg2;

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/TwoWindingsTransformerPhaseAngleClock.hpp
@@ -39,8 +39,7 @@ private:
 
     unsigned long checkPhaseAngleClock(unsigned long phaseAngleClock) const;
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class TwoWindingsTransformerPhaseAngleClockAdder;
 
 private:
     unsigned long m_phaseAngleClock;

--- a/extensions/iidm/include/powsybl/iidm/extensions/iidm/VoltagePerReactivePowerControl.hpp
+++ b/extensions/iidm/include/powsybl/iidm/extensions/iidm/VoltagePerReactivePowerControl.hpp
@@ -53,8 +53,7 @@ private:
 
     double checkSlope(double slope);
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class VoltagePerReactivePowerControlAdder;
 
 private:
     double m_slope;

--- a/extensions/iidm/src/ActivePowerControlAdder.cpp
+++ b/extensions/iidm/src/ActivePowerControlAdder.cpp
@@ -26,10 +26,10 @@ ActivePowerControlAdder::ActivePowerControlAdder(Extendable& extendable) :
 
 std::unique_ptr<Extension> ActivePowerControlAdder::createExtension(Extendable& extendable) {
     if (stdcxx::isInstanceOf<Battery>(extendable)) {
-        return stdcxx::make_unique<ActivePowerControl>(dynamic_cast<Battery&>(extendable), m_participate, m_droop);
+        return std::unique_ptr<ActivePowerControl>(new ActivePowerControl(dynamic_cast<Battery&>(extendable), m_participate, m_droop));
     }
     if (stdcxx::isInstanceOf<Generator>(extendable)) {
-        return stdcxx::make_unique<ActivePowerControl>(dynamic_cast<Generator&>(extendable), m_participate, m_droop);
+        return std::unique_ptr<ActivePowerControl>(new ActivePowerControl(dynamic_cast<Generator&>(extendable), m_participate, m_droop));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% or %3% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Battery>(), stdcxx::demangle<Generator>()));
 }

--- a/extensions/iidm/src/CoordinatedReactiveControlAdder.cpp
+++ b/extensions/iidm/src/CoordinatedReactiveControlAdder.cpp
@@ -24,7 +24,7 @@ CoordinatedReactiveControlAdder::CoordinatedReactiveControlAdder(Extendable& ext
 
 std::unique_ptr<Extension> CoordinatedReactiveControlAdder::createExtension(Extendable& extendable) {
     if (stdcxx::isInstanceOf<Generator>(extendable)) {
-        return stdcxx::make_unique<CoordinatedReactiveControl>(dynamic_cast<Generator&>(extendable), m_qPercent);
+        return std::unique_ptr<CoordinatedReactiveControl>(new CoordinatedReactiveControl(dynamic_cast<Generator&>(extendable), m_qPercent));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Generator>()));
 }

--- a/extensions/iidm/src/HvdcAngleDroopActivePowerControlAdder.cpp
+++ b/extensions/iidm/src/HvdcAngleDroopActivePowerControlAdder.cpp
@@ -24,7 +24,7 @@ HvdcAngleDroopActivePowerControlAdder::HvdcAngleDroopActivePowerControlAdder(Ext
 
 std::unique_ptr<Extension> HvdcAngleDroopActivePowerControlAdder::createExtension(Extendable& extendable) {
     if (stdcxx::isInstanceOf<HvdcLine>(extendable)) {
-        return stdcxx::make_unique<HvdcAngleDroopActivePowerControl>(dynamic_cast<HvdcLine&>(extendable), m_p0, m_droop, m_enabled);
+        return std::unique_ptr<HvdcAngleDroopActivePowerControl>(new HvdcAngleDroopActivePowerControl(dynamic_cast<HvdcLine&>(extendable), m_p0, m_droop, m_enabled));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<HvdcLine>()));
 }

--- a/extensions/iidm/src/HvdcOperatorActivePowerRangeAdder.cpp
+++ b/extensions/iidm/src/HvdcOperatorActivePowerRangeAdder.cpp
@@ -26,7 +26,7 @@ HvdcOperatorActivePowerRangeAdder::HvdcOperatorActivePowerRangeAdder(Extendable&
 
 std::unique_ptr<Extension> HvdcOperatorActivePowerRangeAdder::createExtension(Extendable& extendable) {
     if (stdcxx::isInstanceOf<HvdcLine>(extendable)) {
-        return stdcxx::make_unique<HvdcOperatorActivePowerRange>(dynamic_cast<HvdcLine&>(extendable), m_oprFromCS1toCS2, m_oprFromCS2toCS1);
+        return std::unique_ptr<HvdcOperatorActivePowerRange>(new HvdcOperatorActivePowerRange(dynamic_cast<HvdcLine&>(extendable), m_oprFromCS1toCS2, m_oprFromCS2toCS1));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<HvdcLine>()));
 }

--- a/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClockAdder.cpp
+++ b/extensions/iidm/src/ThreeWindingsTransformerPhaseAngleClockAdder.cpp
@@ -30,7 +30,7 @@ std::unique_ptr<Extension> ThreeWindingsTransformerPhaseAngleClockAdder::createE
         throw PowsyblException(stdcxx::format("Undefined value for phaseAngleClockLeg3"));
     }
     if (stdcxx::isInstanceOf<ThreeWindingsTransformer>(extendable)) {
-        return stdcxx::make_unique<ThreeWindingsTransformerPhaseAngleClock>(dynamic_cast<ThreeWindingsTransformer&>(extendable), *m_phaseAngleClockLeg2, *m_phaseAngleClockLeg3);
+        return std::unique_ptr<ThreeWindingsTransformerPhaseAngleClock>(new ThreeWindingsTransformerPhaseAngleClock(dynamic_cast<ThreeWindingsTransformer&>(extendable), *m_phaseAngleClockLeg2, *m_phaseAngleClockLeg3));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<ThreeWindingsTransformer>()));
 }

--- a/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClockAdder.cpp
+++ b/extensions/iidm/src/TwoWindingsTransformerPhaseAngleClockAdder.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<Extension> TwoWindingsTransformerPhaseAngleClockAdder::createExt
         throw PowsyblException(stdcxx::format("Undefined value for phaseAngleClock"));
     }
     if (stdcxx::isInstanceOf<TwoWindingsTransformer>(extendable)) {
-        return stdcxx::make_unique<TwoWindingsTransformerPhaseAngleClock>(dynamic_cast<TwoWindingsTransformer&>(extendable), *m_phaseAngleClock);
+        return std::unique_ptr<TwoWindingsTransformerPhaseAngleClock>(new TwoWindingsTransformerPhaseAngleClock(dynamic_cast<TwoWindingsTransformer&>(extendable), *m_phaseAngleClock));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<TwoWindingsTransformer>()));
 }

--- a/extensions/iidm/src/VoltagePerReactivePowerControlAdder.cpp
+++ b/extensions/iidm/src/VoltagePerReactivePowerControlAdder.cpp
@@ -26,7 +26,7 @@ VoltagePerReactivePowerControlAdder::VoltagePerReactivePowerControlAdder(Extenda
 
 std::unique_ptr<Extension> VoltagePerReactivePowerControlAdder::createExtension(Extendable& extendable) {
     if (stdcxx::isInstanceOf<StaticVarCompensator>(extendable)) {
-        return stdcxx::make_unique<VoltagePerReactivePowerControl>(dynamic_cast<StaticVarCompensator&>(extendable), m_slope);
+        return std::unique_ptr<VoltagePerReactivePowerControl>(new VoltagePerReactivePowerControl(dynamic_cast<StaticVarCompensator&>(extendable), m_slope));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<StaticVarCompensator>()));
 }

--- a/extensions/sld/include/powsybl/iidm/extensions/sld/BusbarSectionPosition.hpp
+++ b/extensions/sld/include/powsybl/iidm/extensions/sld/BusbarSectionPosition.hpp
@@ -41,8 +41,7 @@ private:  // Extension
 private:
     BusbarSectionPosition(BusbarSection& busbarSection, unsigned long busbarIndex, unsigned long sectionIndex);
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class BusbarSectionPositionAdder;
 
 private:
     unsigned long m_busbarIndex;

--- a/extensions/sld/include/powsybl/iidm/extensions/sld/ConnectablePosition.hpp
+++ b/extensions/sld/include/powsybl/iidm/extensions/sld/ConnectablePosition.hpp
@@ -86,8 +86,7 @@ private:
 private:
     ConnectablePosition(Connectable& connectable, const OptionalFeeder& feeder, const OptionalFeeder& feeder1, const OptionalFeeder& feeder2, const OptionalFeeder& feeder3);
 
-    template <typename B, typename D, typename, typename... Args>
-    friend std::unique_ptr<B> stdcxx::make_unique(Args&&... args);
+    friend class ConnectablePositionAdder;
 
 private:
     OptionalFeeder m_feeder;

--- a/extensions/sld/src/BusbarSectionPositionAdder.cpp
+++ b/extensions/sld/src/BusbarSectionPositionAdder.cpp
@@ -32,7 +32,7 @@ std::unique_ptr<Extension> BusbarSectionPositionAdder::createExtension(Extendabl
         throw PowsyblException("Undefined value for section index");
     }
     if (stdcxx::isInstanceOf<BusbarSection>(extendable)) {
-        return stdcxx::make_unique<BusbarSectionPosition>(dynamic_cast<BusbarSection&>(extendable), *m_busbarIndex, *m_sectionIndex);
+        return std::unique_ptr<BusbarSectionPosition>(new BusbarSectionPosition(dynamic_cast<BusbarSection&>(extendable), *m_busbarIndex, *m_sectionIndex));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<BusbarSection>()));
 }

--- a/extensions/sld/src/ConnectablePositionAdder.cpp
+++ b/extensions/sld/src/ConnectablePositionAdder.cpp
@@ -58,7 +58,7 @@ ConnectablePositionAdder::ConnectablePositionAdder(Extendable& extendable) :
 
 std::unique_ptr<Extension> ConnectablePositionAdder::createExtension(Extendable& extendable) {
     if (stdcxx::isInstanceOf<Connectable>(extendable)) {
-        return stdcxx::make_unique<ConnectablePosition>(dynamic_cast<Connectable&>(extendable), m_feeder, m_feeder1, m_feeder2, m_feeder3);
+        return std::unique_ptr<ConnectablePosition>(new ConnectablePosition(dynamic_cast<Connectable&>(extendable), m_feeder, m_feeder1, m_feeder2, m_feeder3));
     }
     throw AssertionError(stdcxx::format("Unexpected extendable type: %1% (%2% expected)", stdcxx::demangle(extendable), stdcxx::demangle<Connectable>()));
 }


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
In PR #355, the extension constructors are now private so that user can only add them by using the extension adder. To be able to call it, we decided to make `stdcxx::make_unique` friend of the extensions classes. But it is not possible to restrict friendship for templated methods, so the generic stdcxx::make_unique method can call constructors.. So the PR !355 does not fix issue #342 because it is possible to instanciate the extension from anywhere.

This PR enables to fix this #342 by making the extension adder friend of the extension, even if it adds many direct calls to `new` which may make sonar angry...





**What is the current behavior?** *(You can also link to an open issue here)*
The extension constructors are private but they can be instanciated from anywhere, like it was when their constructor were public.


**What is the new behavior (if this is a feature change)?**
Extensions can only be instanciated by using associated adder;


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
