### PR TITLE
Removed useless std::cout in test

### DIFF
--- a/extensions/sld/test/ConnectablePositionTest.cpp
+++ b/extensions/sld/test/ConnectablePositionTest.cpp
@@ -42,8 +42,6 @@ BOOST_AUTO_TEST_CASE(ConnectablePositionConstructor) {
     ConnectablePosition::Feeder feeder2("feeder2", 2, ConnectablePosition::Direction::TOP);
     ConnectablePosition::Feeder feeder3("feeder3", 3, ConnectablePosition::Direction::BOTTOM);
 
-    std::cout << "BOTTOM = " << ConnectablePosition::Direction::BOTTOM << std::endl;
-
     BOOST_CHECK_EQUAL("feeder3", feeder3.getName());
     BOOST_CHECK_EQUAL(3, feeder3.getOrder());
     BOOST_CHECK_EQUAL(static_cast<int>(ConnectablePosition::Direction::BOTTOM), static_cast<int>(feeder3.getDirection()));


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Removal of a std::cout usage in sld tests


**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
