### PR TITLE
Fix NodeBreakerVoltageLevel::getMaximumNodeIndex() (#398)

### DIFF
--- a/include/powsybl/iidm/VoltageLevelViews.hpp
+++ b/include/powsybl/iidm/VoltageLevelViews.hpp
@@ -121,7 +121,7 @@ public:
 
     virtual stdcxx::const_range<InternalConnection> getInternalConnections() const = 0;
 
-    virtual unsigned long getMaximumNodeIndex() const = 0;
+    virtual long getMaximumNodeIndex() const = 0;
 
     virtual unsigned long getNode1(const std::string& switchId) const = 0;
 

--- a/src/iidm/NodeBreakerVoltageLevel.cpp
+++ b/src/iidm/NodeBreakerVoltageLevel.cpp
@@ -248,7 +248,7 @@ unsigned long NodeBreakerVoltageLevel::getInternalConnectionCount() const {
     return std::count(std::begin(switches), std::end(switches), stdcxx::ref<Switch>());
 }
 
-unsigned long NodeBreakerVoltageLevel::getMaximumNodeIndex() const {
+long NodeBreakerVoltageLevel::getMaximumNodeIndex() const {
     return m_graph.getVertexCapacity() - 1;
 }
 

--- a/src/iidm/NodeBreakerVoltageLevel.hpp
+++ b/src/iidm/NodeBreakerVoltageLevel.hpp
@@ -48,7 +48,7 @@ public: // VoltageLevel
      *
      * @return the highest index of used nodes.
      */
-    unsigned long getMaximumNodeIndex() const;
+    long getMaximumNodeIndex() const;
 
     const NodeBreakerView& getNodeBreakerView() const override;
 

--- a/src/iidm/NodeBreakerVoltageLevelViews.cpp
+++ b/src/iidm/NodeBreakerVoltageLevelViews.cpp
@@ -193,7 +193,7 @@ stdcxx::const_range<NodeBreakerViewImpl::InternalConnection> NodeBreakerViewImpl
     return m_voltageLevel.getGraph().getEdges() | boost::adaptors::filtered(filter) | boost::adaptors::transformed(mapper);
 }
 
-unsigned long NodeBreakerViewImpl::getMaximumNodeIndex() const {
+long NodeBreakerViewImpl::getMaximumNodeIndex() const {
     return m_voltageLevel.getMaximumNodeIndex();
 }
 

--- a/src/iidm/NodeBreakerVoltageLevelViews.hpp
+++ b/src/iidm/NodeBreakerVoltageLevelViews.hpp
@@ -32,7 +32,7 @@ public: // NodeBreakerView
 
     stdcxx::const_range<InternalConnection> getInternalConnections() const override;
 
-    unsigned long getMaximumNodeIndex() const override;
+    long getMaximumNodeIndex() const override;
 
     unsigned long getNode1(const std::string& switchId) const override;
 

--- a/test/iidm/NodeBreakerVoltageLevelTest.cpp
+++ b/test/iidm/NodeBreakerVoltageLevelTest.cpp
@@ -1244,6 +1244,74 @@ BOOST_AUTO_TEST_CASE(NbkComprehensiveErrorMessage) {
     POWSYBL_ASSERT_THROW(Network::writeXml("network.xiidm", ss, network, converter::ExportOptions(properties)), PowsyblException, "Terminal ref should not point to a busbar section (here S1VL2_BBS1). Try to export in node-breaker or delete this terminal ref.");
 }
 
+BOOST_AUTO_TEST_CASE(getMaximumNodeIndexTest) {
+    Network network("test", "test");
+
+    Substation& substation = network.newSubstation()
+        .setId("S1")
+        .add();
+
+    VoltageLevel& vl1 = substation.newVoltageLevel()
+        .setId("VL1")
+        .setTopologyKind(TopologyKind::NODE_BREAKER)
+        .setNominalV(380.0)
+        .add();
+
+    vl1.newLoad()
+        .setId("LOAD1")
+        .setNode(0)
+        .setP0(50.0)
+        .setQ0(40.0)
+        .add();
+
+    vl1.getNodeBreakerView().newBreaker()
+        .setId("SWB1")
+        .setNode1(0)
+        .setNode2(1)
+        .setRetained(false)
+        .setOpen(false)
+        .add();
+    BOOST_CHECK_EQUAL(1, vl1.getNodeBreakerView().getMaximumNodeIndex());
+
+    VoltageLevel& vl2 = substation.newVoltageLevel()
+        .setId("VL2")
+        .setTopologyKind(TopologyKind::NODE_BREAKER)
+        .setNominalV(225.0)
+        .add();
+
+    vl2.newLoad()
+        .setId("LOAD2")
+        .setNode(0)
+        .setP0(60.0)
+        .setQ0(70.0)
+        .add();
+
+    vl2.getNodeBreakerView().newBreaker()
+        .setId("SWB2")
+        .setNode1(0)
+        .setNode2(1)
+        .setRetained(false)
+        .setOpen(false)
+        .add();
+
+    vl2.getNodeBreakerView().newBreaker()
+        .setId("SWB3")
+        .setNode1(1)
+        .setNode2(12)
+        .setRetained(false)
+        .setOpen(false)
+        .add();
+
+    BOOST_CHECK_EQUAL(12, vl2.getNodeBreakerView().getMaximumNodeIndex());
+
+    VoltageLevel& vl3 = substation.newVoltageLevel()
+        .setId("VL3")
+        .setTopologyKind(TopologyKind::NODE_BREAKER)
+        .setNominalV(225.0)
+        .add();
+    BOOST_CHECK_EQUAL(-1, vl3.getNodeBreakerView().getMaximumNodeIndex());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace iidm


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Closes #398 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
