### PR TITLE
Add OperationalLimitsOwner

### DIFF
--- a/include/powsybl/iidm/ActivePowerLimits.hpp
+++ b/include/powsybl/iidm/ActivePowerLimits.hpp
@@ -19,7 +19,7 @@ public:  // LoadingLimits
     const LimitType& getLimitType() const override;
 
 public:
-    ActivePowerLimits(OperationalLimitsHolder& owner, double permanentLimit, const TemporaryLimits& temporaryLimits);
+    ActivePowerLimits(OperationalLimitsOwner& owner, double permanentLimit, const TemporaryLimits& temporaryLimits);
 
     ActivePowerLimits(const ActivePowerLimits&) = default;
 

--- a/include/powsybl/iidm/ActivePowerLimitsAdder.hpp
+++ b/include/powsybl/iidm/ActivePowerLimitsAdder.hpp
@@ -20,7 +20,7 @@ public:  // OperationalLimitsAdder
     ActivePowerLimits& add() override;
 
 public:
-    explicit ActivePowerLimitsAdder(OperationalLimitsHolder& owner);
+    explicit ActivePowerLimitsAdder(OperationalLimitsOwner& owner);
 
     ActivePowerLimitsAdder(const ActivePowerLimitsAdder&) = default;
 

--- a/include/powsybl/iidm/ApparentPowerLimits.hpp
+++ b/include/powsybl/iidm/ApparentPowerLimits.hpp
@@ -19,7 +19,7 @@ public:  // LoadingLimits
     const LimitType& getLimitType() const override;
 
 public:
-    ApparentPowerLimits(OperationalLimitsHolder& owner, double permanentLimit, const TemporaryLimits& temporaryLimits);
+    ApparentPowerLimits(OperationalLimitsOwner& owner, double permanentLimit, const TemporaryLimits& temporaryLimits);
 
     ApparentPowerLimits(const ApparentPowerLimits&) = default;
 

--- a/include/powsybl/iidm/ApparentPowerLimitsAdder.hpp
+++ b/include/powsybl/iidm/ApparentPowerLimitsAdder.hpp
@@ -20,7 +20,7 @@ public:  // OperationalLimitsAdder
     ApparentPowerLimits& add() override;
 
 public:
-    explicit ApparentPowerLimitsAdder(OperationalLimitsHolder& owner);
+    explicit ApparentPowerLimitsAdder(OperationalLimitsOwner& owner);
 
     ApparentPowerLimitsAdder(const ApparentPowerLimitsAdder&) = default;
 

--- a/include/powsybl/iidm/CurrentLimits.hpp
+++ b/include/powsybl/iidm/CurrentLimits.hpp
@@ -24,7 +24,7 @@ public:  // OperationalLimits
     const LimitType& getLimitType() const override;
 
 public:
-    CurrentLimits(OperationalLimitsHolder& owner, double permanentLimit, const TemporaryLimits& temporaryLimits);
+    CurrentLimits(OperationalLimitsOwner& owner, double permanentLimit, const TemporaryLimits& temporaryLimits);
 
     CurrentLimits(const CurrentLimits&) = default;
 

--- a/include/powsybl/iidm/CurrentLimitsAdder.hpp
+++ b/include/powsybl/iidm/CurrentLimitsAdder.hpp
@@ -20,7 +20,7 @@ public:  // OperationalLimitsAdder
     CurrentLimits& add() override;
 
 public:
-    explicit CurrentLimitsAdder(OperationalLimitsHolder& owner);
+    explicit CurrentLimitsAdder(OperationalLimitsOwner& owner);
 
     CurrentLimitsAdder(const CurrentLimitsAdder&) = default;
 

--- a/include/powsybl/iidm/LoadingLimits.hpp
+++ b/include/powsybl/iidm/LoadingLimits.hpp
@@ -21,7 +21,7 @@ namespace powsybl {
 
 namespace iidm {
 
-class OperationalLimitsHolder;
+class OperationalLimitsOwner;
 
 class LoadingLimits : public OperationalLimits {
 public:
@@ -52,7 +52,7 @@ public:
     using TemporaryLimits = std::map<unsigned long, TemporaryLimit, std::greater<unsigned long> >;
 
 public:
-    LoadingLimits(OperationalLimitsHolder& owner, double permanentLimit, const TemporaryLimits& temporaryLimits);
+    LoadingLimits(OperationalLimitsOwner& owner, double permanentLimit, const TemporaryLimits& temporaryLimits);
 
     LoadingLimits(const LoadingLimits&) = default;
 

--- a/include/powsybl/iidm/LoadingLimitsAdder.hpp
+++ b/include/powsybl/iidm/LoadingLimitsAdder.hpp
@@ -17,14 +17,14 @@ namespace powsybl {
 
 namespace iidm {
 
-class OperationalLimitsHolder;
+class OperationalLimitsOwner;
 
 template <typename L, typename A>
 class LoadingLimitsAdder : public OperationalLimitsAdder<L> {
 public:
     class TemporaryLimitAdder {
     public:
-        TemporaryLimitAdder(OperationalLimitsHolder& owner, LoadingLimitsAdder<L, A>& parent);
+        TemporaryLimitAdder(OperationalLimitsOwner& owner, LoadingLimitsAdder<L, A>& parent);
 
         LoadingLimitsAdder<L, A>& endTemporaryLimit();
 
@@ -42,7 +42,7 @@ public:
         void checkAndGetUniqueName();
 
     private:
-        OperationalLimitsHolder& m_owner;
+        OperationalLimitsOwner& m_owner;
 
         LoadingLimitsAdder<L, A>& m_parent;
 
@@ -58,7 +58,7 @@ public:
     };
 
 public:
-    explicit LoadingLimitsAdder(OperationalLimitsHolder& owner);
+    explicit LoadingLimitsAdder(OperationalLimitsOwner& owner);
 
     LoadingLimitsAdder(const LoadingLimitsAdder&) = default;
 
@@ -86,7 +86,7 @@ protected:
     const LoadingLimits::TemporaryLimits& getTemporaryLimits() const;
 
 protected:
-    OperationalLimitsHolder& m_owner;
+    OperationalLimitsOwner& m_owner;
 
 private:
     LoadingLimitsAdder<L, A>& addTemporaryLimit(const std::string& name, double value, unsigned long acceptableDuration, bool fictitious);

--- a/include/powsybl/iidm/LoadingLimitsAdder.hxx
+++ b/include/powsybl/iidm/LoadingLimitsAdder.hxx
@@ -14,7 +14,7 @@
 
 #include <boost/range/adaptor/map.hpp>
 
-#include <powsybl/iidm/OperationalLimitsHolder.hpp>
+#include <powsybl/iidm/OperationalLimitsOwner.hpp>
 #include <powsybl/iidm/ValidationException.hpp>
 #include <powsybl/iidm/ValidationUtils.hpp>
 #include <powsybl/logging/Logger.hpp>
@@ -25,7 +25,7 @@ namespace powsybl {
 namespace iidm {
 
 template <typename L, typename A>
-LoadingLimitsAdder<L, A>::TemporaryLimitAdder::TemporaryLimitAdder(OperationalLimitsHolder& owner, LoadingLimitsAdder<L, A>& parent) :
+LoadingLimitsAdder<L, A>::TemporaryLimitAdder::TemporaryLimitAdder(OperationalLimitsOwner& owner, LoadingLimitsAdder<L, A>& parent) :
     m_owner(owner),
     m_parent(parent) {
 }
@@ -92,7 +92,7 @@ typename LoadingLimitsAdder<L, A>::TemporaryLimitAdder& LoadingLimitsAdder<L, A>
 }
 
 template <typename L, typename A>
-LoadingLimitsAdder<L, A>::LoadingLimitsAdder(OperationalLimitsHolder& owner) :
+LoadingLimitsAdder<L, A>::LoadingLimitsAdder(OperationalLimitsOwner& owner) :
     m_owner(owner) {
 }
 

--- a/include/powsybl/iidm/OperationalLimits.hpp
+++ b/include/powsybl/iidm/OperationalLimits.hpp
@@ -14,11 +14,11 @@ namespace powsybl {
 
 namespace iidm {
 
-class OperationalLimitsHolder;
+class OperationalLimitsOwner;
 
 class OperationalLimits {
 public:
-    explicit OperationalLimits(OperationalLimitsHolder& owner);
+    explicit OperationalLimits(OperationalLimitsOwner& owner);
 
     OperationalLimits(const OperationalLimits&) = default;
 
@@ -35,7 +35,7 @@ public:
     void remove();
 
 protected:
-    OperationalLimitsHolder& m_owner;
+    OperationalLimitsOwner& m_owner;
 };
 
 }  // namespace iidm

--- a/include/powsybl/iidm/OperationalLimitsHolder.hpp
+++ b/include/powsybl/iidm/OperationalLimitsHolder.hpp
@@ -14,6 +14,7 @@
 
 #include <powsybl/iidm/LimitType.hpp>
 #include <powsybl/iidm/OperationalLimits.hpp>
+#include <powsybl/iidm/OperationalLimitsOwner.hpp>
 #include <powsybl/iidm/Validable.hpp>
 #include <powsybl/stdcxx/range.hpp>
 #include <powsybl/stdcxx/reference.hpp>
@@ -28,9 +29,12 @@ class CurrentLimitsAdder;
 class FlowsLimitsHolder;
 class Identifiable;
 
-class OperationalLimitsHolder : public Validable {
+class OperationalLimitsHolder : public OperationalLimitsOwner {
 public:  // Validable
     std::string getMessageHeader() const override;
+
+public:  // OperationalLimitsOwner
+    stdcxx::Reference<OperationalLimits> setOperationalLimits(const LimitType& limitType, std::unique_ptr<OperationalLimits>&& operationalLimits) override;
 
 public:
     OperationalLimitsHolder(Identifiable& identifiable, std::string&& attributeName);
@@ -63,9 +67,6 @@ public:
     ApparentPowerLimitsAdder newApparentPowerLimits();
 
     CurrentLimitsAdder newCurrentLimits();
-
-    template <typename T>
-    stdcxx::Reference<T> setOperationalLimits(const LimitType& limitType, std::unique_ptr<T>&& operationalLimits);
 
 private:
     friend class FlowsLimitsHolder;

--- a/include/powsybl/iidm/OperationalLimitsHolder.hxx
+++ b/include/powsybl/iidm/OperationalLimitsHolder.hxx
@@ -36,17 +36,6 @@ stdcxx::Reference<T> OperationalLimitsHolder::getOperationalLimits(const LimitTy
     return stdcxx::ref(const_cast<const OperationalLimitsHolder*>(this)->getOperationalLimits<const T>(type));
 }
 
-template <typename T>
-stdcxx::Reference<T> OperationalLimitsHolder::setOperationalLimits(const LimitType& limitType, std::unique_ptr<T>&& operationalLimits) {
-    if (!operationalLimits) {
-        m_operationalLimits.erase(limitType);
-    } else {
-        m_operationalLimits[limitType] = std::move(operationalLimits);
-        return stdcxx::ref<T>(dynamic_cast<T&>(*m_operationalLimits.find(limitType)->second));
-    }
-    return stdcxx::ref<T>();
-}
-
 }  // namespace iidm
 
 }  // namespace powsybl

--- a/include/powsybl/iidm/OperationalLimitsOwner.hpp
+++ b/include/powsybl/iidm/OperationalLimitsOwner.hpp
@@ -28,7 +28,7 @@ public:
 
     OperationalLimitsOwner(OperationalLimitsOwner&&) noexcept = default;
 
-    virtual ~OperationalLimitsOwner() noexcept = default;
+    ~OperationalLimitsOwner() noexcept override = default;
 
     OperationalLimitsOwner& operator=(const OperationalLimitsOwner&) = default;
 

--- a/include/powsybl/iidm/OperationalLimitsOwner.hpp
+++ b/include/powsybl/iidm/OperationalLimitsOwner.hpp
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef POWSYBL_IIDM_OPERATIONALLIMITSOWNER_HPP
+#define POWSYBL_IIDM_OPERATIONALLIMITSOWNER_HPP
+
+#include <memory>
+
+#include <powsybl/iidm/LimitType.hpp>
+#include <powsybl/iidm/Validable.hpp>
+#include <powsybl/stdcxx/reference.hpp>
+
+namespace powsybl {
+
+namespace iidm {
+
+class OperationalLimits;
+
+class OperationalLimitsOwner : public Validable {
+public:
+    virtual stdcxx::Reference<OperationalLimits> setOperationalLimits(const LimitType& limitType, std::unique_ptr<OperationalLimits>&& operationalLimits) = 0;
+};
+
+}  // namespace iidm
+
+}  // namespace powsybl
+
+#endif  // POWSYBL_IIDM_OPERATIONALLIMITSOWNER_HPP

--- a/include/powsybl/iidm/OperationalLimitsOwner.hpp
+++ b/include/powsybl/iidm/OperationalLimitsOwner.hpp
@@ -22,6 +22,18 @@ class OperationalLimits;
 
 class OperationalLimitsOwner : public Validable {
 public:
+    OperationalLimitsOwner() = default;
+
+    OperationalLimitsOwner(const OperationalLimitsOwner&) = default;
+
+    OperationalLimitsOwner(OperationalLimitsOwner&&) noexcept = default;
+
+    virtual ~OperationalLimitsOwner() noexcept = default;
+
+    OperationalLimitsOwner& operator=(const OperationalLimitsOwner&) = default;
+
+    OperationalLimitsOwner& operator=(OperationalLimitsOwner&&) noexcept = default;
+
     virtual stdcxx::Reference<OperationalLimits> setOperationalLimits(const LimitType& limitType, std::unique_ptr<OperationalLimits>&& operationalLimits) = 0;
 };
 

--- a/src/iidm/ActivePowerLimits.cpp
+++ b/src/iidm/ActivePowerLimits.cpp
@@ -13,7 +13,7 @@ namespace powsybl {
 
 namespace iidm {
 
-ActivePowerLimits::ActivePowerLimits(OperationalLimitsHolder& owner, double permanentLimit, const TemporaryLimits& temporaryLimits) :
+ActivePowerLimits::ActivePowerLimits(OperationalLimitsOwner& owner, double permanentLimit, const TemporaryLimits& temporaryLimits) :
     LoadingLimits(owner, permanentLimit, temporaryLimits) {
 }
 

--- a/src/iidm/ActivePowerLimitsAdder.cpp
+++ b/src/iidm/ActivePowerLimitsAdder.cpp
@@ -13,13 +13,14 @@ namespace powsybl {
 
 namespace iidm {
 
-ActivePowerLimitsAdder::ActivePowerLimitsAdder(OperationalLimitsHolder& owner) :
+ActivePowerLimitsAdder::ActivePowerLimitsAdder(OperationalLimitsOwner& owner) :
     LoadingLimitsAdder(owner) {
 }
 
 ActivePowerLimits& ActivePowerLimitsAdder::add() {
     checkLoadingLimits();
-    return m_owner.setOperationalLimits(LimitType::ACTIVE_POWER, stdcxx::make_unique<ActivePowerLimits>(m_owner, getPermanentLimit(), getTemporaryLimits())).get();
+    auto limit = m_owner.setOperationalLimits(LimitType::ACTIVE_POWER, stdcxx::make_unique<ActivePowerLimits>(m_owner, getPermanentLimit(), getTemporaryLimits()));
+    return static_cast<ActivePowerLimits&>(limit.get());
 }
 
 }  // namespace iidm

--- a/src/iidm/ApparentPowerLimits.cpp
+++ b/src/iidm/ApparentPowerLimits.cpp
@@ -13,7 +13,7 @@ namespace powsybl {
 
 namespace iidm {
 
-ApparentPowerLimits::ApparentPowerLimits(OperationalLimitsHolder& owner, double permanentLimit, const TemporaryLimits& temporaryLimits) :
+ApparentPowerLimits::ApparentPowerLimits(OperationalLimitsOwner& owner, double permanentLimit, const TemporaryLimits& temporaryLimits) :
     LoadingLimits(owner, permanentLimit, temporaryLimits) {
 }
 

--- a/src/iidm/ApparentPowerLimitsAdder.cpp
+++ b/src/iidm/ApparentPowerLimitsAdder.cpp
@@ -11,13 +11,14 @@ namespace powsybl {
 
 namespace iidm {
 
-ApparentPowerLimitsAdder::ApparentPowerLimitsAdder(OperationalLimitsHolder& owner) :
+ApparentPowerLimitsAdder::ApparentPowerLimitsAdder(OperationalLimitsOwner& owner) :
     LoadingLimitsAdder(owner) {
 }
 
 ApparentPowerLimits& ApparentPowerLimitsAdder::add() {
     checkLoadingLimits();
-    return m_owner.setOperationalLimits(LimitType::APPARENT_POWER, stdcxx::make_unique<ApparentPowerLimits>(m_owner, getPermanentLimit(), getTemporaryLimits())).get();
+    auto limit = m_owner.setOperationalLimits(LimitType::APPARENT_POWER, stdcxx::make_unique<ApparentPowerLimits>(m_owner, getPermanentLimit(), getTemporaryLimits()));
+    return static_cast<ApparentPowerLimits&>(limit.get());
 }
 
 }  // namespace iidm

--- a/src/iidm/CurrentLimits.cpp
+++ b/src/iidm/CurrentLimits.cpp
@@ -13,7 +13,7 @@ namespace powsybl {
 
 namespace iidm {
 
-CurrentLimits::CurrentLimits(OperationalLimitsHolder& owner, double permanentLimit, const LoadingLimits::TemporaryLimits& temporaryLimits) :
+CurrentLimits::CurrentLimits(OperationalLimitsOwner& owner, double permanentLimit, const LoadingLimits::TemporaryLimits& temporaryLimits) :
     LoadingLimits(owner, permanentLimit, temporaryLimits) {
 }
 

--- a/src/iidm/CurrentLimitsAdder.cpp
+++ b/src/iidm/CurrentLimitsAdder.cpp
@@ -14,13 +14,14 @@ namespace powsybl {
 
 namespace iidm {
 
-CurrentLimitsAdder::CurrentLimitsAdder(OperationalLimitsHolder& owner) :
+CurrentLimitsAdder::CurrentLimitsAdder(OperationalLimitsOwner& owner) :
     LoadingLimitsAdder(owner) {
 }
 
 CurrentLimits& CurrentLimitsAdder::add() {
     checkLoadingLimits();
-    return m_owner.setOperationalLimits(LimitType::CURRENT, stdcxx::make_unique<CurrentLimits>(m_owner, getPermanentLimit(), getTemporaryLimits())).get();
+    auto limit = m_owner.setOperationalLimits(LimitType::CURRENT, stdcxx::make_unique<CurrentLimits>(m_owner, getPermanentLimit(), getTemporaryLimits()));
+    return static_cast<CurrentLimits&>(limit.get());
 }
 
 }  // namespace iidm

--- a/src/iidm/LoadingLimits.cpp
+++ b/src/iidm/LoadingLimits.cpp
@@ -39,7 +39,7 @@ bool LoadingLimits::TemporaryLimit::isFictitious() const {
     return m_isFictitious;
 }
 
-LoadingLimits::LoadingLimits(OperationalLimitsHolder& owner, double permanentLimit, const TemporaryLimits& temporaryLimits) :
+LoadingLimits::LoadingLimits(OperationalLimitsOwner& owner, double permanentLimit, const TemporaryLimits& temporaryLimits) :
     OperationalLimits(owner),
     m_permanentLimit(permanentLimit),
     m_temporaryLimits(temporaryLimits) {

--- a/src/iidm/OperationalLimits.cpp
+++ b/src/iidm/OperationalLimits.cpp
@@ -13,7 +13,7 @@ namespace powsybl {
 
 namespace iidm {
 
-OperationalLimits::OperationalLimits(OperationalLimitsHolder& owner) :
+OperationalLimits::OperationalLimits(OperationalLimitsOwner& owner) :
     m_owner(owner) {
 }
 

--- a/src/iidm/OperationalLimitsHolder.cpp
+++ b/src/iidm/OperationalLimitsHolder.cpp
@@ -56,6 +56,16 @@ void OperationalLimitsHolder::setIdentifiable(Identifiable& identifiable) {
     m_identifiable = identifiable;
 }
 
+stdcxx::Reference<OperationalLimits> OperationalLimitsHolder::setOperationalLimits(const LimitType& limitType, std::unique_ptr<OperationalLimits>&& operationalLimits) {
+    if (!operationalLimits) {
+        m_operationalLimits.erase(limitType);
+    } else {
+        m_operationalLimits[limitType] = std::move(operationalLimits);
+        return stdcxx::ref(*m_operationalLimits.find(limitType)->second);
+    }
+    return stdcxx::ref<OperationalLimits>();
+}
+
 }  // namespace iidm
 
 }  // namespace powsybl


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Add `OperationalLimitsOwner` interface which is inherited by concrete `OperationalLimitsHolder`. This interface may be needed to avoir using `OperationalLimitsHolder` which enabled to store every kind of `OperationalLimits`


**What is the current behavior?** *(You can also link to an open issue here)*
Both Java classes `OperationalLimitsOwner` and `OperationalLimitsHolder` are merged in `OperationalLimitsHolder`.


**What is the new behavior (if this is a feature change)?**
`OperationalLimitsHolder` implements the "interface" `OperationalLimitsOwner`. The `LoadingLimitsAdder` and its subclasses use the `OperationalLimitsOwner` interface to do their job.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
