### PR TITLE
Fix stdcxx::ref(std::unique_ptr) and stdcxx::cref(std::unique_ptr)

### DIFF
--- a/include/powsybl/stdcxx/reference.hpp
+++ b/include/powsybl/stdcxx/reference.hpp
@@ -104,7 +104,7 @@ CReference<T> cref(T& reference) {
 
 template <typename T>
 CReference<T> cref(const std::unique_ptr<T>& pointer) {
-    return CReference<T>(*pointer);
+    return static_cast<bool>(pointer) ? CReference<T>(*pointer) : CReference<T>();
 }
 
 template <typename T>
@@ -129,7 +129,7 @@ Reference<T> ref(T& reference) {
 
 template <typename T>
 Reference<T> ref(const std::unique_ptr<T>& pointer) {
-    return Reference<T>(*pointer);
+    return static_cast<bool>(pointer) ? Reference<T>(*pointer) : Reference<T>();
 }
 
 template <typename T, typename U, typename = typename std::enable_if<std::is_base_of<T, U>::value && !std::is_same<T, U>::value>::type>

--- a/include/powsybl/stdcxx/reference.hpp
+++ b/include/powsybl/stdcxx/reference.hpp
@@ -138,6 +138,11 @@ Reference<T> ref(U& reference) {
 }
 
 template <typename T>
+Reference<T> ref(const Reference<T>& reference) {
+    return Reference<T>(reference);
+}
+
+template <typename T>
 Reference<T> ref(const CReference<T>& reference) {
     return static_cast<bool>(reference) ? Reference<T>(const_cast<T&>(reference.get())) : Reference<T>();
 }

--- a/test/stdcxx/CMakeLists.txt
+++ b/test/stdcxx/CMakeLists.txt
@@ -12,6 +12,7 @@ set(UNIT_TEST_SOURCES
     MathTest.cpp
     MessageFormatTest.cpp
     PropertiesTest.cpp
+    ReferenceTest.cpp
 )
 
 add_executable(unit-tests-stdcxx ${UNIT_TEST_SOURCES})

--- a/test/stdcxx/ReferenceTest.cpp
+++ b/test/stdcxx/ReferenceTest.cpp
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <powsybl/stdcxx/make_unique.hpp>
+#include <powsybl/stdcxx/reference.hpp>
+
+#include <powsybl/test/AssertionUtils.hpp>
+
+namespace stdcxx {
+
+BOOST_AUTO_TEST_SUITE(ReferenceTestSuite)
+
+BOOST_AUTO_TEST_CASE(refFromStandardRef) {
+    int variable = 2;
+    int& variableRef = variable;
+    const int& cVariableRef = variable;
+
+    auto refFromRef = ref(variableRef);
+    BOOST_CHECK_EQUAL(2, refFromRef.get());
+
+    auto cRefFromRef = cref(variableRef);
+    BOOST_CHECK_EQUAL(2, cRefFromRef.get());
+
+    auto refFromCRef = ref(cVariableRef);
+    BOOST_CHECK_EQUAL(2, refFromCRef.get());
+
+    auto cRefFromCRef = cref(cVariableRef);
+    BOOST_CHECK_EQUAL(2, cRefFromCRef.get());
+}
+
+BOOST_AUTO_TEST_CASE(emptyRef) {
+    BOOST_CHECK(!ref<int>());
+    BOOST_CHECK(!cref<int>());
+}
+
+BOOST_AUTO_TEST_CASE(refFromStdcxxRef) {
+    // invalid reference case
+    Reference<int> myRef;
+    CReference<int> myCRef;
+
+    Reference<int> refFromInvalidRef = ref<int>(myRef);
+    BOOST_CHECK(!refFromInvalidRef);
+
+    Reference<int> refFromInvalidCRef = ref<int>(myCRef);
+    BOOST_CHECK(!refFromInvalidCRef);
+
+    CReference<int> cRefFromInvalidRef = cref<int>(myRef);
+    BOOST_CHECK(!cRefFromInvalidRef);
+
+    // valid reference case
+    int myVar = 2;
+    myRef = ref(myVar);
+    myCRef = cref(myVar);
+
+    Reference<int> refFromValidRef = ref<int>(myRef);
+    BOOST_CHECK_EQUAL(2, refFromValidRef.get());
+
+    CReference<int> cRefFromValidRef = cref<int>(myRef);
+    BOOST_CHECK_EQUAL(2, cRefFromValidRef.get());
+
+    Reference<int> refFromValidCRef = ref<int>(myCRef);
+    BOOST_CHECK_EQUAL(2, refFromValidCRef.get());
+}
+
+BOOST_AUTO_TEST_CASE(refFromPtr) {
+    // invalid pointer case
+    std::unique_ptr<int> ptr;
+
+    auto ptrRef = ref<int>(ptr);
+    BOOST_CHECK(!ptrRef);
+
+    auto cPtrRef = cref<int>(ptr);
+    BOOST_CHECK(!cPtrRef);
+
+    // valid pointer case
+    ptr.reset(new int(2));
+
+    ptrRef = ref<int>(ptr);
+    BOOST_CHECK(ptrRef);
+    BOOST_CHECK_EQUAL(2, ptrRef.get());
+
+    cPtrRef = cref<int>(ptr);
+    BOOST_CHECK(cPtrRef);
+    BOOST_CHECK_EQUAL(2, cPtrRef.get());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace stdcxx


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The library crashes by writing such code:

```
std::unique_ptr<int> ptr;
auto ref = stdcxx::ref<int>(ptr);  // crash here
```

**What is the new behavior (if this is a feature change)?**
The library does not crashes, the code snippet returns an invalid `stdcxx::Reference`


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
