### PR TITLE
Add casts utilities for std::unique_ptr

### DIFF
--- a/include/powsybl/stdcxx/cast.hpp
+++ b/include/powsybl/stdcxx/cast.hpp
@@ -8,9 +8,20 @@
 #ifndef POWSYBL_STDCXX_UPCAST_HPP
 #define POWSYBL_STDCXX_UPCAST_HPP
 
+#include <memory>
 #include <type_traits>
 
 namespace stdcxx {
+
+template <typename Derived, typename Base, typename = typename std::enable_if<std::is_base_of<Base, Derived>::value>::type>
+std::unique_ptr<Derived> downcast(std::unique_ptr<Base>& ptr) {
+    return std::unique_ptr<Derived>(dynamic_cast<Derived*>(ptr.release()));
+}
+
+template <typename Base, typename Derived, typename = typename std::enable_if<std::is_base_of<Base, Derived>::value>::type>
+std::unique_ptr<Base> upcast(std::unique_ptr<Derived>& ptr) {
+    return std::unique_ptr<Base>(ptr.release());
+}
 
 template <typename Derived, typename Base, typename = typename std::enable_if<std::is_base_of<Base, Derived>::value>::type>
 const Base& upcast(const Derived& value) {

--- a/src/iidm/BusBreakerVoltageLevelViews.cpp
+++ b/src/iidm/BusBreakerVoltageLevelViews.cpp
@@ -8,7 +8,7 @@
 #include "BusBreakerVoltageLevelViews.hpp"
 
 #include <powsybl/iidm/Switch.hpp>
-#include <powsybl/stdcxx/upcast.hpp>
+#include <powsybl/stdcxx/cast.hpp>
 
 #include "BusBreakerVoltageLevel.hpp"
 #include "BusBreakerVoltageLevelTopology.hpp"

--- a/src/iidm/CalculatedBus.cpp
+++ b/src/iidm/CalculatedBus.cpp
@@ -11,8 +11,8 @@
 #include <powsybl/iidm/Switch.hpp>
 #include <powsybl/iidm/SynchronousComponentsManager.hpp>
 #include <powsybl/iidm/TopologyVisitor.hpp>
+#include <powsybl/stdcxx/cast.hpp>
 #include <powsybl/stdcxx/math.hpp>
-#include <powsybl/stdcxx/upcast.hpp>
 
 #include "NodeBreakerVoltageLevel.hpp"
 #include "NodeTerminal.hpp"

--- a/src/iidm/ConfiguredBus.cpp
+++ b/src/iidm/ConfiguredBus.cpp
@@ -16,10 +16,10 @@
 #include <powsybl/iidm/SynchronousComponentsManager.hpp>
 #include <powsybl/iidm/TopologyVisitor.hpp>
 #include <powsybl/iidm/ValidationUtils.hpp>
+#include <powsybl/stdcxx/cast.hpp>
 #include <powsybl/stdcxx/format.hpp>
 #include <powsybl/stdcxx/math.hpp>
 #include <powsybl/stdcxx/memory.hpp>
-#include <powsybl/stdcxx/upcast.hpp>
 
 #include "BusBreakerVoltageLevel.hpp"
 #include "BusTerminal.hpp"

--- a/src/iidm/NodeBreakerVoltageLevelViews.cpp
+++ b/src/iidm/NodeBreakerVoltageLevelViews.cpp
@@ -9,7 +9,7 @@
 
 #include <powsybl/iidm/BusbarSection.hpp>
 #include <powsybl/iidm/Switch.hpp>
-#include <powsybl/stdcxx/upcast.hpp>
+#include <powsybl/stdcxx/cast.hpp>
 
 #include "CalculatedBus.hpp"
 #include "NodeBreakerVoltageLevel.hpp"

--- a/test/stdcxx/CMakeLists.txt
+++ b/test/stdcxx/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 set(UNIT_TEST_SOURCES
     stdcxx.cpp
+    CastTest.cpp
     DateTimeTest.cpp
     DemangleTest.cpp
     MathTest.cpp

--- a/test/stdcxx/CastTest.cpp
+++ b/test/stdcxx/CastTest.cpp
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <memory>
+
+#include <boost/test/unit_test.hpp>
+
+#include <powsybl/stdcxx/cast.hpp>
+#include <powsybl/stdcxx/make_unique.hpp>
+
+namespace stdcxx {
+
+BOOST_AUTO_TEST_SUITE(CaseTestSuite)
+
+class BaseClass {
+public:
+    BaseClass() = default;
+
+    virtual ~BaseClass() = default;
+
+    int getBaseAttr() const;
+
+    void setBaseAttr(int newValue);
+
+private:
+    int m_baseAttr = 1;
+};
+
+int BaseClass::getBaseAttr() const {
+    return m_baseAttr;
+}
+
+void BaseClass::setBaseAttr(int newValue) {
+    m_baseAttr = newValue;
+}
+
+class DerivedClass : public BaseClass {
+public:
+    DerivedClass() = default;
+
+    ~DerivedClass() override = default;
+
+    int getDerivedAttr() const;
+
+    void setDerivedAttr(int newValue);
+
+private:
+    int m_derivedAttr = 2;
+};
+
+int DerivedClass::getDerivedAttr() const {
+    return m_derivedAttr;
+}
+
+void DerivedClass::setDerivedAttr(int newValue) {
+    m_derivedAttr = newValue;
+}
+
+BOOST_AUTO_TEST_CASE(unique_ptrCastTest) {
+    std::unique_ptr<BaseClass> basePtr = stdcxx::make_unique<DerivedClass>();
+    BOOST_CHECK_EQUAL(1, basePtr->getBaseAttr());
+    basePtr->setBaseAttr(11);
+    BOOST_CHECK_EQUAL(11, basePtr->getBaseAttr());
+
+    std::unique_ptr<DerivedClass> derivedPtr = stdcxx::downcast<DerivedClass>(basePtr);
+    BOOST_CHECK(!basePtr);
+    BOOST_CHECK_EQUAL(11, derivedPtr->getBaseAttr());
+    BOOST_CHECK_EQUAL(2, derivedPtr->getDerivedAttr());
+    derivedPtr->setBaseAttr(111);
+    derivedPtr->setDerivedAttr(22);
+    BOOST_CHECK_EQUAL(22, derivedPtr->getDerivedAttr());
+
+    std::unique_ptr<BaseClass> otherBasePtr = stdcxx::upcast<BaseClass>(derivedPtr);
+    BOOST_CHECK(!derivedPtr);
+    BOOST_CHECK_EQUAL(111, otherBasePtr->getBaseAttr());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace stdcxx


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
In order to cast a `std::unique_ptr<Base>` into a `std::unique_ptr<Derived>` the ownership of data has to be updated. I added some user-friendly methods in order to do that more easily.


**What is the new behavior (if this is a feature change)?**
It is possible to downcast/upcast std::unique_ptr simply by writing this: 
```
    std::unique_ptr<DerivedClass> derivedPtr = stdcxx::downcast<DerivedClass>(basePtr);
```
By writing this, `basePtr` loses the ownership of data

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
