### PR TITLE
Fix usage of stdcxx::optional with C++-17 compliant compilers

### DIFF
--- a/src/iidm/BusBreakerVoltageLevel.cpp
+++ b/src/iidm/BusBreakerVoltageLevel.cpp
@@ -42,8 +42,8 @@ Bus& BusBreakerVoltageLevel::addBus(std::unique_ptr<ConfiguredBus>&& ptrBus) {
 }
 
 Switch& BusBreakerVoltageLevel::addSwitch(std::unique_ptr<Switch>&& ptrSwitch, const std::string& busId1, const std::string& busId2) {
-    unsigned long v1 = getVertex(busId1, true).get();
-    unsigned long v2 = getVertex(busId2, true).get();
+    unsigned long v1 = *getVertex(busId1, true);
+    unsigned long v2 = *getVertex(busId2, true);
 
     Switch& aSwitch = getNetwork().checkAndAdd(std::move(ptrSwitch));
     unsigned long e = m_graph.addEdge(v1, v2, stdcxx::ref(aSwitch));

--- a/src/iidm/MultipleVariantContext.cpp
+++ b/src/iidm/MultipleVariantContext.cpp
@@ -21,7 +21,7 @@ unsigned long MultipleVariantContext::getVariantIndex() const {
     if (!m_index) {
         throw PowsyblException("Variant index not set");
     }
-    return m_index.get();
+    return *m_index;
 }
 
 bool MultipleVariantContext::isIndexSet() const {


### PR DESCRIPTION
⚠️ Target branch to be defined ⚠️ 

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix (fix compilation with C++-17 compliant compilers)


**What is the current behavior?** *(You can also link to an open issue here)*
With C++-17 and newer versions, `stdcxx::optional` = `std::optional`. With older compilers, `stdcxx::optional` = `boost::optional`.
Sometimes, we called `stdcxx::optional::get()` which is boost-specific => the library does not compile with recents compilers.

**What is the new behavior (if this is a feature change)?**
Compilation is OK with C++-17 and newer compilers


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
