### PR TITLE
Add iidm test directory in include path 

### DIFF
--- a/test/iidm/CMakeLists.txt
+++ b/test/iidm/CMakeLists.txt
@@ -64,6 +64,7 @@ set(UNIT_TEST_SOURCES
 
 add_executable(unit-tests-iidm ${UNIT_TEST_SOURCES})
 target_compile_definitions(unit-tests-iidm PRIVATE BOOST_TEST_DYN_LINK)
+target_include_directories(unit-tests-iidm PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(unit-tests-iidm PRIVATE iidm-tests)
 
 add_test(NAME iidm COMMAND unit-tests-iidm -- --resources=${CMAKE_SOURCE_DIR}/test/resources)

--- a/test/iidm/util/SVTest.cpp
+++ b/test/iidm/util/SVTest.cpp
@@ -22,7 +22,7 @@
 #include <powsybl/network/EurostagFactory.hpp>
 #include <powsybl/network/FourSubstationsNodeBreakerFactory.hpp>
 
-#include "../NetworkFactory.hpp" // TODO(sebalaig) To be discussed...
+#include "NetworkFactory.hpp"
 
 namespace powsybl {
 


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Add tests/iidm in include path, because it contains `NetworkFactory.hpp`, which contains useful network for tests, but the file could not be included simply


**What is the current behavior?** *(You can also link to an open issue here)*
NetworkFactory.hpp can be included by writing
```
#include "../NetworkFactory.hpp"
```


**What is the new behavior (if this is a feature change)?**

NetworkFactory.hpp can be included by writing
```
#include "NetworkFactory.hpp"
```

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
