### PR TITLE
Udpate clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,7 @@ Checks: '-*,
   -readability-magic-numbers,
   -readability-redundant-declaration,
   -readability-redundant-access-specifiers,
+  -readability-identifier-length
 '
 
 WarningsAsErrors: '*'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install clang-tidy
         run: |
-          sudo apt-get install -y clang-tidy-9
-          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 100
+          sudo apt-get install -y clang-tidy-14
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 100
 
       - name: Checkout sources
         uses: actions/checkout@v1


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
CI fix


**What is the current behavior?** *(You can also link to an open issue here)*
Clang-tidy 9 is not available anymore on ubuntu 22.04 => CI is broken


**What is the new behavior (if this is a feature change)?**
Use clang-tidy-14, so that CI is ok


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
