### PR TITLE
Fix XML unparsing under windows

### DIFF
--- a/src/xml/XmlStreamWriter.cpp
+++ b/src/xml/XmlStreamWriter.cpp
@@ -82,10 +82,9 @@ void XmlStreamWriter::writeEmptyElement(const std::string& uri, const std::strin
 }
 
 void XmlStreamWriter::writeEndDocument() {
-    int written = xmlTextWriterEndDocument(m_writer.get());
-    if (written < 0) {
-        throw XmlStreamException("Failed to write end document");
-    }
+    // deleting the xmlTextWriter pointer automatically calls xmlTextWriterFlush() and write to stream
+    // m_writer is instanciated in writeStartElement, so it must be deleted here
+    m_writer.reset();
 }
 
 void XmlStreamWriter::writeEndElement() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
XML unparsing in a file duplicates the network under Windows. It's ok under linux.


**What is the new behavior (if this is a feature change)?**
XML unparsing is ok on Windows (and linux also)


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
