### PR TITLE
Fix write callback of XmlStreamWriter which did not work properly on Windows

### DIFF
--- a/src/xml/XmlStreamWriter.cpp
+++ b/src/xml/XmlStreamWriter.cpp
@@ -149,11 +149,9 @@ void XmlStreamWriter::writeStartDocument(const std::string& encoding, const std:
     auto writeCallback = [](void* context, const char* buffer, int len) {
         XmlStreamWriter& writer = *static_cast<XmlStreamWriter*>(context);
 
-        size_t beforeWrite = writer.m_stream.tellp();
         writer.m_stream.write(buffer, len);
-        size_t afterWrite = writer.m_stream.tellp();
 
-        return static_cast<int>(afterWrite - beforeWrite);
+        return len;
     };
 
     auto closeCallback = [](void* /*context*/) {


### PR DESCRIPTION
Signed-off-by: Sébastien LAIGRE <slaigre@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
Unparsing on a file on Windows does not work properly : <network> tag is duplicated. This can be reproduced by launching 
```
$ iidm-benchmark.exe --input-file  test\resources\V1_4\fourSubstationsNbk.xml --output-file out.txt
```

out.txt is the following :  [out.txt](https://github.com/powsybl/powsybl-iidm4cpp/files/10235850/out.txt)

Notice : it's ok for streams

**What is the new behavior (if this is a feature change)?**
Unparsing in a file is OK under Windows


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
