### PR TITLE
Fix setFictitousP0 and Q0 for CalculatedBus : reset/set values on eac…

### DIFF
--- a/src/iidm/CalculatedBus.cpp
+++ b/src/iidm/CalculatedBus.cpp
@@ -192,7 +192,7 @@ Bus& CalculatedBus::setFictitiousP0(double p0) {
 
     std::set<unsigned long> nodes = Networks::getNodes(getId(), m_voltageLevel, m_getBusFromTerminalFunc);
     for (const auto& node : nodes) {
-        m_voltageLevel.get().getNodeBreakerView().setFictitiousP0(node, stdcxx::nan());
+        m_voltageLevel.get().getNodeBreakerView().setFictitiousP0(node, 0.0);
     }
 
     if(!nodes.empty()){
@@ -209,7 +209,7 @@ Bus& CalculatedBus::setFictitiousQ0(double q0) {
 
     std::set<unsigned long> nodes = Networks::getNodes(getId(), m_voltageLevel, m_getBusFromTerminalFunc);
     for (const auto& node : nodes) {
-        m_voltageLevel.get().getNodeBreakerView().setFictitiousQ0(node, stdcxx::nan());
+        m_voltageLevel.get().getNodeBreakerView().setFictitiousQ0(node, 0.0);
     }
 
     if(!nodes.empty()){

--- a/src/iidm/converter/xml/BusXml.cpp
+++ b/src/iidm/converter/xml/BusXml.cpp
@@ -57,8 +57,8 @@ void BusXml::writeRootElementAttributes(const Bus& bus, const VoltageLevel& /*vo
     context.getWriter().writeOptionalAttribute(V, bus.getV());
     context.getWriter().writeOptionalAttribute(ANGLE, bus.getAngle());
     IidmXmlUtil::runFromMinimumVersion(IidmXmlVersion::V1_8(), context.getVersion(), [&context, &bus]() {
-        context.getWriter().writeOptionalAttribute(FICTITIOUS_P0, bus.getFictitiousP0());
-        context.getWriter().writeOptionalAttribute(FICTITIOUS_Q0, bus.getFictitiousQ0());
+        context.getWriter().writeOptionalAttribute(FICTITIOUS_P0, bus.getFictitiousP0(), 0.0);
+        context.getWriter().writeOptionalAttribute(FICTITIOUS_Q0, bus.getFictitiousQ0(), 0.0);
     });
 }
 

--- a/src/iidm/converter/xml/NodeBreakerViewFictitiousInjectionXml.cpp
+++ b/src/iidm/converter/xml/NodeBreakerViewFictitiousInjectionXml.cpp
@@ -42,8 +42,8 @@ void NodeBreakerViewFictitiousInjectionXml::read(VoltageLevel& voltageLevel, con
 void NodeBreakerViewFictitiousInjectionXml::write(unsigned long node, double fictP0, double fictQ0, NetworkXmlWriterContext& context) const {
     context.getWriter().writeStartElement(context.getVersion().getPrefix(), FICTITIOUS_INJECTION);
     context.getWriter().writeAttribute(NODE, node);
-    context.getWriter().writeOptionalAttribute(FICTITIOUS_P0, fictP0);
-    context.getWriter().writeOptionalAttribute(FICTITIOUS_Q0, fictQ0);
+    context.getWriter().writeOptionalAttribute(FICTITIOUS_P0, fictP0, 0.0);
+    context.getWriter().writeOptionalAttribute(FICTITIOUS_Q0, fictQ0, 0.0);
     context.getWriter().writeEndElement();
 }
 

--- a/test/iidm/NetworkTest.cpp
+++ b/test/iidm/NetworkTest.cpp
@@ -424,6 +424,13 @@ BOOST_AUTO_TEST_CASE(GetNodesByBus) {
     topology.setFictitiousP0(0, 0.0).setFictitiousQ0(0,0.0);
     BOOST_CHECK_CLOSE(0.0, topology.getFictitiousP0(0), std::numeric_limits<double>::epsilon());
     BOOST_CHECK_CLOSE(0.0, topology.getFictitiousQ0(0), std::numeric_limits<double>::epsilon());
+
+    //Test setter/getter on the bus keep the total fictitious value 
+    //We do not enforce how it is distributed among the nodes to allow different behaviors
+    topology.getTerminal(0).get().getBusView().getBus().get().setFictitiousP0(3.0);
+    topology.getTerminal(0).get().getBusView().getBus().get().setFictitiousQ0(4.0);
+    BOOST_CHECK_CLOSE(3.0, topology.getTerminal(0).get().getBusView().getBus().get().getFictitiousP0(), std::numeric_limits<double>::epsilon());
+    BOOST_CHECK_CLOSE(4.0, topology.getTerminal(0).get().getBusView().getBus().get().getFictitiousQ0(), std::numeric_limits<double>::epsilon());
 }
 
 BOOST_AUTO_TEST_CASE(Validation) {


### PR DESCRIPTION
Before setting a value for ficitious P0/Q0 for a CalculatedBus, values on all nodes of this bus are reset to nan, which is not allowed by the checkP0.
Reset value to 0.0 instead of nan.

additionally fictitious P0 and Q0 of buses are not written in xml if value is 0.0  


**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
Fixes #476


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

